### PR TITLE
Fix Dockerfile to use pnpm instead of npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
 FROM node:20-alpine AS builder
+RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
-COPY package*.json ./
-RUN npm ci
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
 COPY . .
-RUN npm run build
+RUN pnpm build
 
 FROM node:20-alpine
+RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/drizzle ./drizzle
-COPY --from=builder /app/package*.json ./
-RUN npm install --production
+COPY --from=builder /app/openapi.json ./
+COPY --from=builder /app/package.json /app/pnpm-lock.yaml ./
+RUN pnpm install --prod --frozen-lockfile
 ENV NODE_OPTIONS="--dns-result-order=ipv4first"
 EXPOSE 3012
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- Switch Dockerfile from `npm ci` to `pnpm install --frozen-lockfile` (we use pnpm, no package-lock.json)
- Enable corepack for pnpm in both builder and runtime stages
- Copy `openapi.json` into production image for the `/openapi.json` endpoint

## Test plan
- [x] Fixes Railway deploy error: `npm ci` failing due to missing package-lock.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)