### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Run migrations
+        run: npx tsx scripts/migrate.ts
+        env:
+          BILLING_SERVICE_DATABASE_URL: postgresql://test:test@localhost:5432/test
+
+      - name: Run tests
+        run: pnpm test -- --run
+        env:
+          BILLING_SERVICE_DATABASE_URL: postgresql://test:test@localhost:5432/test
+
+      - name: Build
+        run: pnpm build

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,12 @@
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { db, sql } from "../src/db/index.js";
+
+migrate(db, { migrationsFolder: "./drizzle" })
+  .then(() => {
+    console.log("Migrations complete");
+    return sql.end();
+  })
+  .catch((err) => {
+    console.error("Migration failed:", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow running on PRs and pushes to main
- Postgres 16 service container for integration tests
- Pipeline: type check → migrations → tests (56) → build
- Add `scripts/migrate.ts` for running Drizzle migrations in CI

## Test plan
- [x] CI runs on this PR itself — check the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)