### PR TITLE
Add optional x-user-id header to all protected endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -323,6 +323,15 @@
             "required": true,
             "name": "x-app-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "x-user-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -377,6 +386,15 @@
             "required": true,
             "name": "x-app-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "x-user-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -421,6 +439,15 @@
             "required": true,
             "name": "x-app-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "x-user-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -464,6 +491,15 @@
             },
             "required": true,
             "name": "x-app-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "x-user-id",
             "in": "header"
           }
         ],
@@ -528,6 +564,15 @@
             "required": true,
             "name": "x-app-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "x-user-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -580,6 +625,15 @@
             },
             "required": true,
             "name": "x-app-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": false,
+            "name": "x-user-id",
             "in": "header"
           }
         ],

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -115,6 +115,7 @@ const protectedHeaders = z.object({
   "x-api-key": z.string(),
   "x-org-id": z.string().uuid(),
   "x-app-id": z.string(),
+  "x-user-id": z.string().uuid().optional(),
 });
 
 registry.registerPath({


### PR DESCRIPTION
## Summary
- Adds optional `x-user-id` header to all protected endpoint OpenAPI definitions
- Regenerates `openapi.json` with the updated schema

## Test plan
- [x] All 56 tests pass
- [x] OpenAPI spec includes x-user-id in protectedHeaders

🤖 Generated with [Claude Code](https://claude.com/claude-code)