### PR TITLE
Fix GET /v1/accounts 500 for non-billing-service appIds

### DIFF
--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -81,6 +81,17 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(400);
     });
+
+    it("auto-creates account for any appId (not just billing-service)", async () => {
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set(getAuthHeaders(orgId, "sales-cold-emails"));
+
+      expect(res.status).toBe(200);
+      expect(res.body.appId).toBe("sales-cold-emails");
+      expect(res.body.billingMode).toBe("trial");
+      expect(res.body.creditBalanceCents).toBe(200);
+    });
   });
 
   describe("GET /v1/accounts/balance", () => {

--- a/tests/unit/stripe.test.ts
+++ b/tests/unit/stripe.test.ts
@@ -1,4 +1,27 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as keyClient from "../../src/lib/key-client.js";
+
+describe("Stripe key resolution", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves Stripe key using billing-service appId, not the caller appId", async () => {
+    const spy = vi.spyOn(keyClient, "resolveAppKey").mockResolvedValue("sk_test_mock");
+
+    // Use setStripeInstance to bypass real Stripe init
+    const { setStripeInstance, createCustomer } = await import("../../src/lib/stripe.js");
+    const mockStripe = {
+      customers: { create: vi.fn().mockResolvedValue({ id: "cus_new", metadata: {} }) },
+    };
+    setStripeInstance(mockStripe as any);
+
+    await createCustomer("sales-cold-emails", "org-123");
+
+    // resolveAppKey should NOT be called with the caller's appId
+    expect(spy).not.toHaveBeenCalledWith("stripe", "sales-cold-emails");
+  });
+});
 
 describe("Stripe balance semantics", () => {
   it("negative Stripe balance means customer has credit", () => {


### PR DESCRIPTION
## Summary

- **Root cause**: `getStripe(appId)` passed the caller's `appId` (e.g. `"sales-cold-emails"`) to `resolveAppKey("stripe", appId)`, but the Stripe key is only registered under `"billing-service"`. Key-service returned "key not found" → unhandled error → 500.
- **Fix**: `getStripe()` now resolves the Stripe key using billing-service's own appId (the default). The request's `appId` is still passed as Stripe metadata for tenant tracking.
- Same fix applied to webhook secret resolution in `constructWebhookEvent`.

## Test plan

- [x] Unit test: verify `resolveAppKey` is NOT called with the caller's appId
- [x] Integration test: `GET /v1/accounts` with `x-app-id: sales-cold-emails` returns 200
- [x] All existing unit tests pass
- [x] Type check passes (`tsc --noEmit`)
- [ ] CI integration tests (Postgres) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)