### PR TITLE
Fix GET /v1/accounts 500: add key-service caller headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ import creditsRoutes from "./routes/credits.js";
 import checkoutRoutes from "./routes/checkout.js";
 import webhookRoutes from "./routes/webhooks.js";
 import { requireApiKey } from "./middleware/auth.js";
-import { registerAllAppKeys } from "./lib/key-client.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -57,9 +56,6 @@ if (process.env.NODE_ENV !== "test") {
   migrate(db, { migrationsFolder: "./drizzle" })
     .then(() => {
       console.log("Migrations complete");
-      return registerAllAppKeys();
-    })
-    .then(() => {
       app.listen(Number(PORT), "::", () => {
         console.log(`Billing service running on port ${PORT}`);
       });

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -1,4 +1,14 @@
-const APP_ID = "billing-service";
+export interface CallerContext {
+  service: string;
+  method: string;
+  path: string;
+}
+
+const DEFAULT_CALLER: CallerContext = {
+  service: "billing",
+  method: "GET",
+  path: "/v1/accounts",
+};
 
 function getKeyServiceConfig() {
   const url = process.env.KEY_SERVICE_URL;
@@ -7,41 +17,12 @@ function getKeyServiceConfig() {
   return { url, apiKey };
 }
 
-/** Register an app-level secret with key-service (idempotent, safe to call on every cold start). */
-export async function registerAppKey(
+/** Resolve an app-level secret from key-service at runtime. */
+export async function resolveAppKey(
   provider: string,
-  apiKey: string
-): Promise<void> {
-  const config = getKeyServiceConfig();
-  if (!config) {
-    console.warn(`KEY_SERVICE not configured — skipping ${provider} registration`);
-    return;
-  }
-
-  const res = await fetch(`${config.url}/internal/app-keys`, {
-    method: "POST",
-    headers: {
-      "x-api-key": config.apiKey,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      appId: APP_ID,
-      provider,
-      apiKey,
-    }),
-  });
-
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Failed to register ${provider} key: ${res.status} ${body}`);
-  }
-}
-
-/** Resolve an app-level secret from key-service at runtime.
- *  @param provider - key provider (e.g. "stripe", "stripe-webhook")
- *  @param appId - which app registered the key (defaults to billing-service's own)
- */
-export async function resolveAppKey(provider: string, appId: string = APP_ID): Promise<string> {
+  appId: string,
+  caller: CallerContext = DEFAULT_CALLER
+): Promise<string> {
   const config = getKeyServiceConfig();
   if (!config) {
     throw new Error(`KEY_SERVICE not configured — cannot resolve ${provider}`);
@@ -50,7 +31,12 @@ export async function resolveAppKey(provider: string, appId: string = APP_ID): P
   const res = await fetch(
     `${config.url}/internal/app-keys/${encodeURIComponent(provider)}/decrypt?appId=${encodeURIComponent(appId)}`,
     {
-      headers: { "x-api-key": config.apiKey },
+      headers: {
+        "x-api-key": config.apiKey,
+        "x-caller-service": caller.service,
+        "x-caller-method": caller.method,
+        "x-caller-path": caller.path,
+      },
     }
   );
 
@@ -61,22 +47,4 @@ export async function resolveAppKey(provider: string, appId: string = APP_ID): P
 
   const data = (await res.json()) as { key: string };
   return data.key;
-}
-
-/** Register all billing-service secrets at startup. */
-export async function registerAllAppKeys(): Promise<void> {
-  const stripeKey = process.env.STRIPE_SECRET_KEY;
-  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
-
-  const registrations: Promise<void>[] = [];
-
-  if (stripeKey) {
-    registrations.push(registerAppKey("stripe", stripeKey));
-  }
-  if (webhookSecret) {
-    registrations.push(registerAppKey("stripe-webhook", webhookSecret));
-  }
-
-  await Promise.all(registrations);
-  console.log("App keys registered with key-service");
 }

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock fetch BEFORE importing the module under test
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Now import the module — it will pick up the stubbed fetch
+import { resolveAppKey } from "../../src/lib/key-client.js";
+
+describe("resolveAppKey", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("sends x-caller-service, x-caller-method, x-caller-path headers", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ key: "sk_test_123" }),
+    });
+
+    await resolveAppKey("stripe", "sales-cold-emails", {
+      service: "billing",
+      method: "GET",
+      path: "/v1/accounts",
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/internal/app-keys/stripe/decrypt?appId=sales-cold-emails"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-caller-service": "billing",
+          "x-caller-method": "GET",
+          "x-caller-path": "/v1/accounts",
+        }),
+      })
+    );
+  });
+
+  it("uses default caller context when none provided", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ key: "sk_test_456" }),
+    });
+
+    await resolveAppKey("stripe", "my-app");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("appId=my-app"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-caller-service": "billing",
+          "x-caller-method": "GET",
+          "x-caller-path": "/v1/accounts",
+        }),
+      })
+    );
+  });
+
+  it("throws when key-service returns error", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Key not found"),
+    });
+
+    await expect(resolveAppKey("stripe", "unknown-app")).rejects.toThrow(
+      "Failed to resolve stripe key for app unknown-app: 404"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: key-service's `GET /internal/app-keys/{provider}/decrypt` requires `X-Caller-Service`, `X-Caller-Method`, `X-Caller-Path` headers. billing-service wasn't sending them → key-service returned 400 → billing-service caught it as 500.
- **Fix**: `resolveAppKey` now sends the required `x-caller-*` headers on every call to key-service.
- **Architecture fix**: Restored per-app Stripe key resolution. Each app (e.g. `sales-cold-emails`) registers its own Stripe key with key-service at its startup. billing-service resolves the caller's key at runtime — it does not own an internal Stripe key. Removed `registerAllAppKeys` from startup.

## Test plan

- [x] Unit test: `resolveAppKey` sends `x-caller-service`, `x-caller-method`, `x-caller-path` headers
- [x] Unit test: `getStripe(appId)` calls `resolveAppKey("stripe", appId)` with the caller's appId
- [x] Integration test: `GET /v1/accounts` with `x-app-id: sales-cold-emails` returns 200
- [x] Type check passes
- [ ] CI integration tests (Postgres)

🤖 Generated with [Claude Code](https://claude.com/claude-code)