### PR TITLE
Add keySource support for app, byok, and platform Stripe key resolution

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -82,6 +82,15 @@
           "error"
         ]
       },
+      "KeySource": {
+        "type": "string",
+        "enum": [
+          "app",
+          "byok",
+          "platform"
+        ],
+        "default": "app"
+      },
       "BalanceResponse": {
         "type": "object",
         "properties": {
@@ -332,6 +341,14 @@
             "required": false,
             "name": "x-user-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/KeySource"
+            },
+            "required": false,
+            "name": "x-key-source",
+            "in": "header"
           }
         ],
         "responses": {
@@ -405,6 +422,14 @@
             "required": false,
             "name": "x-user-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/KeySource"
+            },
+            "required": false,
+            "name": "x-key-source",
+            "in": "header"
           }
         ],
         "responses": {
@@ -457,6 +482,14 @@
             },
             "required": false,
             "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/KeySource"
+            },
+            "required": false,
+            "name": "x-key-source",
             "in": "header"
           }
         ],
@@ -520,6 +553,14 @@
             },
             "required": false,
             "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/KeySource"
+            },
+            "required": false,
+            "name": "x-key-source",
             "in": "header"
           }
         ],
@@ -593,6 +634,14 @@
             "required": false,
             "name": "x-user-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/KeySource"
+            },
+            "required": false,
+            "name": "x-key-source",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -664,6 +713,14 @@
             },
             "required": false,
             "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/KeySource"
+            },
+            "required": false,
+            "name": "x-key-source",
             "in": "header"
           }
         ],

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -5,6 +5,7 @@ import { billingAccounts } from "../db/schema.js";
 import {
   constructWebhookEvent,
   createBalanceTransaction,
+  type KeySourceInfo,
 } from "../lib/stripe.js";
 import type Stripe from "stripe";
 
@@ -89,10 +90,11 @@ async function handleCheckoutCompleted(appId: string, session: Stripe.Checkout.S
     ? parseInt(session.metadata.reload_amount_cents, 10)
     : account.reloadAmountCents;
 
-  // Credit the balance with the reload amount
+  // Credit the balance with the reload amount (webhooks always use app key source)
+  const keySourceInfo: KeySourceInfo = { keySource: "app", appId };
   if (reloadAmountCents && account.stripeCustomerId) {
     await createBalanceTransaction(
-      appId,
+      keySourceInfo,
       account.stripeCustomerId,
       -reloadAmountCents,
       "Initial reload credit"

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -17,6 +17,11 @@ export const BillingModeSchema = z
   .enum(["trial", "byok", "payg"])
   .openapi("BillingMode");
 
+export const KeySourceSchema = z
+  .enum(["app", "byok", "platform"])
+  .default("app")
+  .openapi("KeySource");
+
 // --- Account ---
 
 export const BillingAccountSchema = z
@@ -116,6 +121,7 @@ const protectedHeaders = z.object({
   "x-org-id": z.string().uuid(),
   "x-app-id": z.string(),
   "x-user-id": z.string().uuid().optional(),
+  "x-key-source": KeySourceSchema.optional(),
 });
 
 registry.registerPath({

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -39,6 +39,9 @@ export function setupStripeMocks() {
     }),
     constructWebhookEvent: vi.fn(),
     resolveAppKey: vi.fn().mockResolvedValue("sk_test_mock_key"),
+    resolveByokKey: vi.fn().mockResolvedValue("sk_test_byok_key"),
+    resolvePlatformKey: vi.fn().mockResolvedValue("sk_test_platform_key"),
+    resolveKey: vi.fn().mockResolvedValue("sk_test_mock_key"),
     isStripeAuthError: vi.fn().mockImplementation(
       (err: unknown) => err instanceof Stripe.errors.StripeAuthenticationError
     ),
@@ -46,6 +49,9 @@ export function setupStripeMocks() {
 
   // Mock key-service so Stripe never actually calls it
   vi.spyOn(keyClient, "resolveAppKey").mockImplementation(mocks.resolveAppKey);
+  vi.spyOn(keyClient, "resolveByokKey").mockImplementation(mocks.resolveByokKey);
+  vi.spyOn(keyClient, "resolvePlatformKey").mockImplementation(mocks.resolvePlatformKey);
+  vi.spyOn(keyClient, "resolveKey").mockImplementation(mocks.resolveKey);
 
   vi.spyOn(stripeLib, "createCustomer").mockImplementation(mocks.createCustomer);
   vi.spyOn(stripeLib, "createBalanceTransaction").mockImplementation(

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -34,11 +34,19 @@ export function createTestApp() {
   return app;
 }
 
-export function getAuthHeaders(orgId = "00000000-0000-0000-0000-000000000001", appId = "testapp") {
-  return {
+export function getAuthHeaders(
+  orgId = "00000000-0000-0000-0000-000000000001",
+  appId = "testapp",
+  keySource?: "app" | "byok" | "platform"
+) {
+  const headers: Record<string, string> = {
     "X-API-Key": "test-api-key",
     "x-org-id": orgId,
     "x-app-id": appId,
     "Content-Type": "application/json",
   };
+  if (keySource) {
+    headers["x-key-source"] = keySource;
+  }
+  return headers;
 }

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -5,7 +5,7 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 // Now import the module — it will pick up the stubbed fetch
-import { resolveAppKey } from "../../src/lib/key-client.js";
+import { resolveAppKey, resolveByokKey, resolvePlatformKey, resolveKey } from "../../src/lib/key-client.js";
 
 describe("resolveAppKey", () => {
   beforeEach(() => {
@@ -65,6 +65,134 @@ describe("resolveAppKey", () => {
 
     await expect(resolveAppKey("stripe", "unknown-app")).rejects.toThrow(
       "Failed to resolve stripe key for app unknown-app: 404"
+    );
+  });
+});
+
+describe("resolveByokKey", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("sends correct URL with orgId and caller headers", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ key: "sk_byok_123" }),
+    });
+
+    const key = await resolveByokKey("stripe", "org-uuid-abc", {
+      service: "billing",
+      method: "POST",
+      path: "/v1/credits/deduct",
+    });
+
+    expect(key).toBe("sk_byok_123");
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/internal/keys/stripe/decrypt?orgId=org-uuid-abc"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-caller-service": "billing",
+          "x-caller-method": "POST",
+          "x-caller-path": "/v1/credits/deduct",
+        }),
+      })
+    );
+  });
+
+  it("throws when key-service returns error", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Key not found"),
+    });
+
+    await expect(resolveByokKey("stripe", "org-unknown")).rejects.toThrow(
+      "Failed to resolve stripe BYOK key for org org-unknown: 404"
+    );
+  });
+});
+
+describe("resolvePlatformKey", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("sends correct URL with no appId/orgId query param", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ key: "sk_platform_123" }),
+    });
+
+    const key = await resolvePlatformKey("stripe", {
+      service: "billing",
+      method: "GET",
+      path: "/v1/accounts",
+    });
+
+    expect(key).toBe("sk_platform_123");
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/internal/platform-keys/stripe/decrypt"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-caller-service": "billing",
+        }),
+      })
+    );
+    // No query params
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).not.toContain("appId=");
+    expect(url).not.toContain("orgId=");
+  });
+
+  it("throws when key-service returns error", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Key not found"),
+    });
+
+    await expect(resolvePlatformKey("stripe")).rejects.toThrow(
+      "Failed to resolve stripe platform key: 404"
+    );
+  });
+});
+
+describe("resolveKey (dispatcher)", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ key: "sk_resolved" }),
+    });
+  });
+
+  it("dispatches to app-keys path for keySource 'app'", async () => {
+    await resolveKey("stripe", "app", { appId: "my-app" });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/internal/app-keys/stripe/decrypt?appId=my-app");
+  });
+
+  it("dispatches to byok path for keySource 'byok'", async () => {
+    await resolveKey("stripe", "byok", { orgId: "org-123" });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/internal/keys/stripe/decrypt?orgId=org-123");
+  });
+
+  it("dispatches to platform path for keySource 'platform'", async () => {
+    await resolveKey("stripe", "platform", {});
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/internal/platform-keys/stripe/decrypt");
+  });
+
+  it("throws when keySource is 'app' but appId is missing", async () => {
+    await expect(resolveKey("stripe", "app", {})).rejects.toThrow(
+      "appId is required for keySource 'app'"
+    );
+  });
+
+  it("throws when keySource is 'byok' but orgId is missing", async () => {
+    await expect(resolveKey("stripe", "byok", {})).rejects.toThrow(
+      "orgId is required for keySource 'byok'"
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add `x-key-source` header (optional, defaults to `app`) to all protected endpoints
- Route Stripe key resolution to correct key-service path based on key source:
  - `app` → `/internal/app-keys/{provider}/decrypt?appId=`
  - `byok` → `/internal/keys/{provider}/decrypt?orgId=`
  - `platform` → `/internal/platform-keys/{provider}/decrypt`
- Stripe instance cache uses composite keys (`app:X`, `byok:Y`, `platform`) to avoid cross-contamination
- Webhooks unchanged — always use `app` key source

## Test plan
- [x] Unit tests for `resolveByokKey`, `resolvePlatformKey`, `resolveKey` dispatcher
- [x] Unit tests for `KeySourceInfo` dispatch (app, byok, platform) and cache eviction
- [x] Integration tests for byok/platform key source on accounts, credits, checkout
- [x] Integration test for invalid `x-key-source` → 400
- [x] All 83 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)