### PR TITLE
Make x-key-source header mandatory

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -88,8 +88,7 @@
           "app",
           "byok",
           "platform"
-        ],
-        "default": "app"
+        ]
       },
       "BalanceResponse": {
         "type": "object",
@@ -346,7 +345,7 @@
             "schema": {
               "$ref": "#/components/schemas/KeySource"
             },
-            "required": false,
+            "required": true,
             "name": "x-key-source",
             "in": "header"
           }
@@ -427,7 +426,7 @@
             "schema": {
               "$ref": "#/components/schemas/KeySource"
             },
-            "required": false,
+            "required": true,
             "name": "x-key-source",
             "in": "header"
           }
@@ -488,7 +487,7 @@
             "schema": {
               "$ref": "#/components/schemas/KeySource"
             },
-            "required": false,
+            "required": true,
             "name": "x-key-source",
             "in": "header"
           }
@@ -559,7 +558,7 @@
             "schema": {
               "$ref": "#/components/schemas/KeySource"
             },
-            "required": false,
+            "required": true,
             "name": "x-key-source",
             "in": "header"
           }
@@ -639,7 +638,7 @@
             "schema": {
               "$ref": "#/components/schemas/KeySource"
             },
-            "required": false,
+            "required": true,
             "name": "x-key-source",
             "in": "header"
           }
@@ -719,7 +718,7 @@
             "schema": {
               "$ref": "#/components/schemas/KeySource"
             },
-            "required": false,
+            "required": true,
             "name": "x-key-source",
             "in": "header"
           }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -32,7 +32,11 @@ export function requireOrgHeaders(
     res.status(400).json({ error: "x-app-id header is required" });
     return;
   }
-  const keySource = (req.headers["x-key-source"] as string) || "app";
+  const keySource = req.headers["x-key-source"] as string;
+  if (!keySource) {
+    res.status(400).json({ error: "x-key-source header is required" });
+    return;
+  }
   if (!VALID_KEY_SOURCES.has(keySource)) {
     res.status(400).json({ error: `Invalid x-key-source: ${keySource}. Must be one of: app, byok, platform` });
     return;
@@ -42,7 +46,7 @@ export function requireOrgHeaders(
 
 /** Extract KeySourceInfo from request headers. Call after requireOrgHeaders. */
 export function getKeySourceInfo(req: Request): KeySourceInfo {
-  const keySource = ((req.headers["x-key-source"] as string) || "app") as KeySource;
+  const keySource = req.headers["x-key-source"] as KeySource;
   const appId = req.headers["x-app-id"] as string;
   const orgId = req.headers["x-org-id"] as string;
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -19,7 +19,6 @@ export const BillingModeSchema = z
 
 export const KeySourceSchema = z
   .enum(["app", "byok", "platform"])
-  .default("app")
   .openapi("KeySource");
 
 // --- Account ---
@@ -121,7 +120,7 @@ const protectedHeaders = z.object({
   "x-org-id": z.string().uuid(),
   "x-app-id": z.string(),
   "x-user-id": z.string().uuid().optional(),
-  "x-key-source": KeySourceSchema.optional(),
+  "x-key-source": KeySourceSchema,
 });
 
 registry.registerPath({

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -37,16 +37,13 @@ export function createTestApp() {
 export function getAuthHeaders(
   orgId = "00000000-0000-0000-0000-000000000001",
   appId = "testapp",
-  keySource?: "app" | "byok" | "platform"
+  keySource: "app" | "byok" | "platform" = "app"
 ) {
-  const headers: Record<string, string> = {
+  return {
     "X-API-Key": "test-api-key",
     "x-org-id": orgId,
     "x-app-id": appId,
+    "x-key-source": keySource,
     "Content-Type": "application/json",
   };
-  if (keySource) {
-    headers["x-key-source"] = keySource;
-  }
-  return headers;
 }

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -133,6 +133,19 @@ describe("Accounts endpoints", () => {
       );
     });
 
+    it("returns 400 when x-key-source is missing", async () => {
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set({
+          "X-API-Key": "test-api-key",
+          "x-org-id": orgId,
+          "x-app-id": appId,
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("x-key-source header is required");
+    });
+
     it("returns 400 for invalid x-key-source", async () => {
       const res = await request(app)
         .get("/v1/accounts")


### PR DESCRIPTION
## Summary
- Changed `x-key-source` from optional (defaulting to `"app"`) to **mandatory** on all protected endpoints
- Returns 400 with `"x-key-source header is required"` when the header is missing
- Removed `.default("app")` from schema and `.optional()` from protectedHeaders
- Updated tests: `getAuthHeaders` always sends `x-key-source`, added test for missing header → 400

## Test plan
- [x] All 84 tests pass (9 test files)
- [x] New test verifies missing `x-key-source` returns 400
- [x] Invalid `x-key-source` still returns 400
- [x] Existing tests updated to always include the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)