### PR TITLE
Remove appId/keySource, unify key resolution

### DIFF
--- a/drizzle/0002_remove_app_id.sql
+++ b/drizzle/0002_remove_app_id.sql
@@ -1,0 +1,10 @@
+-- Delete duplicate rows per org_id, keeping only the newest account
+DELETE FROM "billing_accounts"
+WHERE "id" NOT IN (
+  SELECT DISTINCT ON ("org_id") "id"
+  FROM "billing_accounts"
+  ORDER BY "org_id", "created_at" DESC
+);--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_billing_accounts_org_app";--> statement-breakpoint
+ALTER TABLE "billing_accounts" DROP COLUMN IF EXISTS "app_id";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_billing_accounts_org_id" ON "billing_accounts" USING btree ("org_id");

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,129 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "prevId": "7f22627a-db00-43db-b6e2-c77b88b5f1d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.billing_accounts": {
+      "name": "billing_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_mode": {
+          "name": "billing_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trial'"
+        },
+        "credit_balance_cents": {
+          "name": "credit_balance_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 200
+        },
+        "reload_amount_cents": {
+          "name": "reload_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reload_threshold_cents": {
+          "name": "reload_threshold_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 200
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_accounts_org_id": {
+          "name": "idx_billing_accounts_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_accounts_stripe_customer": {
+          "name": "idx_billing_accounts_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1772094826171,
       "tag": "0001_slow_dreadnoughts",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772697600000,
+      "tag": "0002_remove_app_id",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -31,9 +31,6 @@
             "type": "string",
             "format": "uuid"
           },
-          "appId": {
-            "type": "string"
-          },
           "billingMode": {
             "$ref": "#/components/schemas/BillingMode"
           },
@@ -61,7 +58,6 @@
         "required": [
           "id",
           "orgId",
-          "appId",
           "billingMode",
           "creditBalanceCents",
           "reloadAmountCents",
@@ -80,14 +76,6 @@
         },
         "required": [
           "error"
-        ]
-      },
-      "KeySource": {
-        "type": "string",
-        "enum": [
-          "app",
-          "byok",
-          "platform"
         ]
       },
       "BalanceResponse": {
@@ -215,21 +203,11 @@
           "description": {
             "type": "string",
             "minLength": 1
-          },
-          "app_id": {
-            "type": "string",
-            "minLength": 1
-          },
-          "user_id": {
-            "type": "string",
-            "format": "uuid"
           }
         },
         "required": [
           "amount_cents",
-          "description",
-          "app_id",
-          "user_id"
+          "description"
         ]
       },
       "CheckoutResponse": {
@@ -326,27 +304,11 @@
           },
           {
             "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "x-app-id",
-            "in": "header"
-          },
-          {
-            "schema": {
               "type": "string",
               "format": "uuid"
             },
-            "required": false,
-            "name": "x-user-id",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "$ref": "#/components/schemas/KeySource"
-            },
             "required": true,
-            "name": "x-key-source",
+            "name": "x-user-id",
             "in": "header"
           }
         ],
@@ -407,27 +369,11 @@
           },
           {
             "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "x-app-id",
-            "in": "header"
-          },
-          {
-            "schema": {
               "type": "string",
               "format": "uuid"
             },
-            "required": false,
-            "name": "x-user-id",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "$ref": "#/components/schemas/KeySource"
-            },
             "required": true,
-            "name": "x-key-source",
+            "name": "x-user-id",
             "in": "header"
           }
         ],
@@ -468,27 +414,11 @@
           },
           {
             "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "x-app-id",
-            "in": "header"
-          },
-          {
-            "schema": {
               "type": "string",
               "format": "uuid"
             },
-            "required": false,
-            "name": "x-user-id",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "$ref": "#/components/schemas/KeySource"
-            },
             "required": true,
-            "name": "x-key-source",
+            "name": "x-user-id",
             "in": "header"
           }
         ],
@@ -539,27 +469,11 @@
           },
           {
             "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "x-app-id",
-            "in": "header"
-          },
-          {
-            "schema": {
               "type": "string",
               "format": "uuid"
             },
-            "required": false,
-            "name": "x-user-id",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "$ref": "#/components/schemas/KeySource"
-            },
             "required": true,
-            "name": "x-key-source",
+            "name": "x-user-id",
             "in": "header"
           }
         ],
@@ -619,27 +533,11 @@
           },
           {
             "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "x-app-id",
-            "in": "header"
-          },
-          {
-            "schema": {
               "type": "string",
               "format": "uuid"
             },
-            "required": false,
-            "name": "x-user-id",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "$ref": "#/components/schemas/KeySource"
-            },
             "required": true,
-            "name": "x-key-source",
+            "name": "x-user-id",
             "in": "header"
           }
         ],
@@ -699,27 +597,11 @@
           },
           {
             "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "x-app-id",
-            "in": "header"
-          },
-          {
-            "schema": {
               "type": "string",
               "format": "uuid"
             },
-            "required": false,
-            "name": "x-user-id",
-            "in": "header"
-          },
-          {
-            "schema": {
-              "$ref": "#/components/schemas/KeySource"
-            },
             "required": true,
-            "name": "x-key-source",
+            "name": "x-user-id",
             "in": "header"
           }
         ],
@@ -756,16 +638,17 @@
         }
       }
     },
-    "/v1/webhooks/stripe/{appId}": {
+    "/v1/webhooks/stripe/{orgId}": {
       "post": {
-        "summary": "Stripe webhook handler (per-app)",
+        "summary": "Stripe webhook handler (per-org)",
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             },
             "required": true,
-            "name": "appId",
+            "name": "orgId",
             "in": "path"
           }
         ],

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -13,7 +13,6 @@ export const billingAccounts = pgTable(
   {
     id: uuid("id").primaryKey().defaultRandom(),
     orgId: uuid("org_id").notNull(),
-    appId: text("app_id").notNull(),
     stripeCustomerId: text("stripe_customer_id"),
     billingMode: text("billing_mode").notNull().default("trial"),
     creditBalanceCents: integer("credit_balance_cents").notNull().default(200),
@@ -28,7 +27,7 @@ export const billingAccounts = pgTable(
       .defaultNow(),
   },
   (table) => [
-    uniqueIndex("idx_billing_accounts_org_app").on(table.orgId, table.appId),
+    uniqueIndex("idx_billing_accounts_org_id").on(table.orgId),
     index("idx_billing_accounts_stripe_customer").on(table.stripeCustomerId),
   ]
 );

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -1,9 +1,12 @@
-export type KeySource = "app" | "byok" | "platform";
-
 export interface CallerContext {
   service: string;
   method: string;
   path: string;
+}
+
+export interface KeyResolution {
+  key: string;
+  keySource: "platform" | "org";
 }
 
 const DEFAULT_CALLER: CallerContext = {
@@ -19,51 +22,21 @@ function getKeyServiceConfig() {
   return { url, apiKey };
 }
 
-/** Resolve an app-level secret from key-service at runtime. */
-export async function resolveAppKey(
-  provider: string,
-  appId: string,
-  caller: CallerContext = DEFAULT_CALLER
-): Promise<string> {
-  const config = getKeyServiceConfig();
-  if (!config) {
-    throw new Error(`KEY_SERVICE not configured — cannot resolve ${provider}`);
-  }
-
-  const res = await fetch(
-    `${config.url}/internal/app-keys/${encodeURIComponent(provider)}/decrypt?appId=${encodeURIComponent(appId)}`,
-    {
-      headers: {
-        "x-api-key": config.apiKey,
-        "x-caller-service": caller.service,
-        "x-caller-method": caller.method,
-        "x-caller-path": caller.path,
-      },
-    }
-  );
-
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Failed to resolve ${provider} key for app ${appId}: ${res.status} ${body}`);
-  }
-
-  const data = (await res.json()) as { key: string };
-  return data.key;
-}
-
-/** Resolve a BYOK secret from key-service (user's own key, resolved by orgId). */
-export async function resolveByokKey(
+/** Resolve a provider key from key-service. Returns the key and its source (platform or org). */
+export async function resolveProviderKey(
   provider: string,
   orgId: string,
+  userId: string,
   caller: CallerContext = DEFAULT_CALLER
-): Promise<string> {
+): Promise<KeyResolution> {
   const config = getKeyServiceConfig();
   if (!config) {
     throw new Error(`KEY_SERVICE not configured — cannot resolve ${provider}`);
   }
 
+  const params = new URLSearchParams({ orgId, userId });
   const res = await fetch(
-    `${config.url}/internal/keys/${encodeURIComponent(provider)}/decrypt?orgId=${encodeURIComponent(orgId)}`,
+    `${config.url}/keys/${encodeURIComponent(provider)}/decrypt?${params}`,
     {
       headers: {
         "x-api-key": config.apiKey,
@@ -76,62 +49,11 @@ export async function resolveByokKey(
 
   if (!res.ok) {
     const body = await res.text();
-    throw new Error(`Failed to resolve ${provider} BYOK key for org ${orgId}: ${res.status} ${body}`);
+    throw new Error(
+      `Failed to resolve ${provider} key for org ${orgId}: ${res.status} ${body}`
+    );
   }
 
-  const data = (await res.json()) as { key: string };
-  return data.key;
-}
-
-/** Resolve a platform-level secret from key-service. */
-export async function resolvePlatformKey(
-  provider: string,
-  caller: CallerContext = DEFAULT_CALLER
-): Promise<string> {
-  const config = getKeyServiceConfig();
-  if (!config) {
-    throw new Error(`KEY_SERVICE not configured — cannot resolve ${provider}`);
-  }
-
-  const res = await fetch(
-    `${config.url}/internal/platform-keys/${encodeURIComponent(provider)}/decrypt`,
-    {
-      headers: {
-        "x-api-key": config.apiKey,
-        "x-caller-service": caller.service,
-        "x-caller-method": caller.method,
-        "x-caller-path": caller.path,
-      },
-    }
-  );
-
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Failed to resolve ${provider} platform key: ${res.status} ${body}`);
-  }
-
-  const data = (await res.json()) as { key: string };
-  return data.key;
-}
-
-/** Unified key resolver — dispatches to the correct key-service path based on keySource. */
-export async function resolveKey(
-  provider: string,
-  keySource: KeySource,
-  opts: { appId?: string; orgId?: string },
-  caller: CallerContext = DEFAULT_CALLER
-): Promise<string> {
-  switch (keySource) {
-    case "app": {
-      if (!opts.appId) throw new Error("appId is required for keySource 'app'");
-      return resolveAppKey(provider, opts.appId, caller);
-    }
-    case "byok": {
-      if (!opts.orgId) throw new Error("orgId is required for keySource 'byok'");
-      return resolveByokKey(provider, opts.orgId, caller);
-    }
-    case "platform": {
-      return resolvePlatformKey(provider, caller);
-    }
-  }
+  const data = (await res.json()) as KeyResolution;
+  return data;
 }

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,30 +1,7 @@
 import Stripe from "stripe";
-import { resolveAppKey, resolveKey, type KeySource } from "./key-client.js";
+import { resolveProviderKey } from "./key-client.js";
 
-// --- Key source info type ---
-
-export type KeySourceInfo =
-  | { keySource: "app"; appId: string }
-  | { keySource: "byok"; orgId: string }
-  | { keySource: "platform" };
-
-function cacheKey(info: KeySourceInfo): string {
-  switch (info.keySource) {
-    case "app": return `app:${info.appId}`;
-    case "byok": return `byok:${info.orgId}`;
-    case "platform": return "platform";
-  }
-}
-
-function resolveOpts(info: KeySourceInfo): { appId?: string; orgId?: string } {
-  switch (info.keySource) {
-    case "app": return { appId: info.appId };
-    case "byok": return { orgId: info.orgId };
-    case "platform": return {};
-  }
-}
-
-// --- Stripe instance cache (keyed by keySource:identifier) ---
+// --- Stripe instance cache (keyed by org) ---
 
 const stripeInstances = new Map<string, Stripe>();
 const webhookSecrets = new Map<string, string>();
@@ -32,13 +9,13 @@ const webhookSecrets = new Map<string, string>();
 // Test override — applies to all key sources
 let testStripeInstance: Stripe | null = null;
 
-async function getStripe(info: KeySourceInfo): Promise<Stripe> {
+async function getStripe(orgId: string, userId: string): Promise<Stripe> {
   if (testStripeInstance) return testStripeInstance;
 
-  const ck = cacheKey(info);
+  const ck = `org:${orgId}`;
   let instance = stripeInstances.get(ck);
   if (!instance) {
-    const key = await resolveKey("stripe", info.keySource, resolveOpts(info));
+    const { key } = await resolveProviderKey("stripe", orgId, userId);
     instance = new Stripe(key, { apiVersion: "2024-12-18.acacia" as Stripe.LatestApiVersion });
     stripeInstances.set(ck, instance);
   }
@@ -50,16 +27,16 @@ async function getStripe(info: KeySourceInfo): Promise<Stripe> {
  * If the Stripe key is expired/invalid, evicts the cached instance and retries
  * once with a freshly resolved key from key-service.
  */
-async function withAuthRetry<T>(info: KeySourceInfo, fn: (stripe: Stripe) => Promise<T>): Promise<T> {
-  const stripe = await getStripe(info);
+async function withAuthRetry<T>(orgId: string, userId: string, fn: (stripe: Stripe) => Promise<T>): Promise<T> {
+  const stripe = await getStripe(orgId, userId);
   try {
     return await fn(stripe);
   } catch (err) {
     if (isStripeAuthError(err)) {
-      const ck = cacheKey(info);
+      const ck = `org:${orgId}`;
       console.warn(`Stripe auth error for ${ck} — evicting cached key and retrying`);
       stripeInstances.delete(ck);
-      const freshStripe = await getStripe(info);
+      const freshStripe = await getStripe(orgId, userId);
       return fn(freshStripe);
     }
     throw err;
@@ -79,22 +56,23 @@ export function setStripeInstance(mock: Stripe): void {
 // --- Customer ---
 
 export async function createCustomer(
-  info: KeySourceInfo,
   orgId: string,
+  userId: string,
   metadata?: Record<string, string>
 ): Promise<Stripe.Customer> {
-  return withAuthRetry(info, (stripe) =>
+  return withAuthRetry(orgId, userId, (stripe) =>
     stripe.customers.create({
-      metadata: { org_id: orgId, key_source: info.keySource, ...metadata },
+      metadata: { org_id: orgId, ...metadata },
     })
   );
 }
 
 export async function getCustomer(
-  info: KeySourceInfo,
+  orgId: string,
+  userId: string,
   stripeCustomerId: string
 ): Promise<Stripe.Customer> {
-  return withAuthRetry(info, (stripe) =>
+  return withAuthRetry(orgId, userId, (stripe) =>
     stripe.customers.retrieve(stripeCustomerId) as Promise<Stripe.Customer>
   );
 }
@@ -110,13 +88,14 @@ export async function getCustomer(
  * and negative `amountCents` for credits (decreases balance towards negative).
  */
 export async function createBalanceTransaction(
-  info: KeySourceInfo,
+  orgId: string,
+  userId: string,
   stripeCustomerId: string,
   amountCents: number,
   description: string,
   metadata?: Record<string, string>
 ): Promise<Stripe.CustomerBalanceTransaction> {
-  return withAuthRetry(info, (stripe) =>
+  return withAuthRetry(orgId, userId, (stripe) =>
     stripe.customers.createBalanceTransaction(stripeCustomerId, {
       amount: amountCents,
       currency: "usd",
@@ -127,11 +106,12 @@ export async function createBalanceTransaction(
 }
 
 export async function listBalanceTransactions(
-  info: KeySourceInfo,
+  orgId: string,
+  userId: string,
   stripeCustomerId: string,
   limit = 50
 ): Promise<Stripe.ApiList<Stripe.CustomerBalanceTransaction>> {
-  return withAuthRetry(info, (stripe) =>
+  return withAuthRetry(orgId, userId, (stripe) =>
     stripe.customers.listBalanceTransactions(stripeCustomerId, {
       limit,
     })
@@ -141,13 +121,14 @@ export async function listBalanceTransactions(
 // --- Checkout ---
 
 export async function createCheckoutSession(
-  info: KeySourceInfo,
+  orgId: string,
+  userId: string,
   stripeCustomerId: string,
   successUrl: string,
   cancelUrl: string,
   reloadAmountCents: number
 ): Promise<Stripe.Checkout.Session> {
-  return withAuthRetry(info, (stripe) =>
+  return withAuthRetry(orgId, userId, (stripe) =>
     stripe.checkout.sessions.create({
       customer: stripeCustomerId,
       mode: "payment",
@@ -176,13 +157,14 @@ export async function createCheckoutSession(
 // --- Payment (auto-reload) ---
 
 export async function chargePaymentMethod(
-  info: KeySourceInfo,
+  orgId: string,
+  userId: string,
   stripeCustomerId: string,
   paymentMethodId: string,
   amountCents: number,
   description: string
 ): Promise<Stripe.PaymentIntent> {
-  return withAuthRetry(info, (stripe) =>
+  return withAuthRetry(orgId, userId, (stripe) =>
     stripe.paymentIntents.create({
       amount: amountCents,
       currency: "usd",
@@ -196,23 +178,23 @@ export async function chargePaymentMethod(
   );
 }
 
-// --- Webhook (always uses app key source) ---
+// --- Webhook ---
 
 export async function constructWebhookEvent(
-  appId: string,
+  orgId: string,
   payload: Buffer,
   signature: string
 ): Promise<Stripe.Event> {
-  let secret = webhookSecrets.get(appId);
+  let secret = webhookSecrets.get(orgId);
   if (!secret) {
-    secret = await resolveAppKey("stripe-webhook", appId, {
+    const result = await resolveProviderKey("stripe-webhook", orgId, "system", {
       service: "billing",
       method: "POST",
       path: "/v1/webhooks/stripe",
     });
-    webhookSecrets.set(appId, secret);
+    secret = result.key;
+    webhookSecrets.set(orgId, secret);
   }
-  const info: KeySourceInfo = { keySource: "app", appId };
-  const stripe = await getStripe(info);
+  const stripe = await getStripe(orgId, "system");
   return stripe.webhooks.constructEvent(payload, signature, secret);
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,8 +1,4 @@
 import { Request, Response, NextFunction } from "express";
-import type { KeySource } from "../lib/key-client.js";
-import type { KeySourceInfo } from "../lib/stripe.js";
-
-const VALID_KEY_SOURCES = new Set<string>(["app", "byok", "platform"]);
 
 export function requireApiKey(
   req: Request,
@@ -27,32 +23,10 @@ export function requireOrgHeaders(
     res.status(400).json({ error: "x-org-id header is required" });
     return;
   }
-  const appId = req.headers["x-app-id"] as string;
-  if (!appId) {
-    res.status(400).json({ error: "x-app-id header is required" });
-    return;
-  }
-  const keySource = req.headers["x-key-source"] as string;
-  if (!keySource) {
-    res.status(400).json({ error: "x-key-source header is required" });
-    return;
-  }
-  if (!VALID_KEY_SOURCES.has(keySource)) {
-    res.status(400).json({ error: `Invalid x-key-source: ${keySource}. Must be one of: app, byok, platform` });
+  const userId = req.headers["x-user-id"] as string;
+  if (!userId) {
+    res.status(400).json({ error: "x-user-id header is required" });
     return;
   }
   next();
-}
-
-/** Extract KeySourceInfo from request headers. Call after requireOrgHeaders. */
-export function getKeySourceInfo(req: Request): KeySourceInfo {
-  const keySource = req.headers["x-key-source"] as KeySource;
-  const appId = req.headers["x-app-id"] as string;
-  const orgId = req.headers["x-org-id"] as string;
-
-  switch (keySource) {
-    case "app": return { keySource: "app", appId };
-    case "byok": return { keySource: "byok", orgId };
-    case "platform": return { keySource: "platform" };
-  }
 }

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { billingAccounts } from "../db/schema.js";
-import { requireOrgHeaders, getKeySourceInfo } from "../middleware/auth.js";
+import { requireOrgHeaders } from "../middleware/auth.js";
 import {
   UpdateModeRequestSchema,
   BillingModeSchema,
@@ -20,7 +20,6 @@ function formatAccount(account: typeof billingAccounts.$inferSelect) {
   return {
     id: account.id,
     orgId: account.orgId,
-    appId: account.appId,
     billingMode: account.billingMode,
     creditBalanceCents: account.creditBalanceCents,
     reloadAmountCents: account.reloadAmountCents,
@@ -31,22 +30,17 @@ function formatAccount(account: typeof billingAccounts.$inferSelect) {
   };
 }
 
-function accountFilter(orgId: string, appId: string) {
-  return and(eq(billingAccounts.orgId, orgId), eq(billingAccounts.appId, appId));
-}
-
 // GET /v1/accounts — get or auto-create billing account
 router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
-    const appId = req.headers["x-app-id"] as string;
-    const keySourceInfo = getKeySourceInfo(req);
+    const userId = req.headers["x-user-id"] as string;
 
     // Try to find existing account
     const existing = await db
       .select()
       .from(billingAccounts)
-      .where(accountFilter(orgId, appId))
+      .where(eq(billingAccounts.orgId, orgId))
       .limit(1);
 
     if (existing.length > 0) {
@@ -55,11 +49,12 @@ router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
     }
 
     // Auto-create: Stripe customer + $2 trial credit
-    const stripeCustomer = await createCustomer(keySourceInfo, orgId);
+    const stripeCustomer = await createCustomer(orgId, userId);
 
     // Credit $2 (negative amount = credit in Stripe)
     await createBalanceTransaction(
-      keySourceInfo,
+      orgId,
+      userId,
       stripeCustomer.id,
       -200,
       "Trial credit: $2.00"
@@ -70,7 +65,6 @@ router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
       .insert(billingAccounts)
       .values({
         orgId,
-        appId,
         stripeCustomerId: stripeCustomer.id,
         billingMode: "trial",
         creditBalanceCents: 200,
@@ -83,7 +77,7 @@ router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
       const [refetched] = await db
         .select()
         .from(billingAccounts)
-        .where(accountFilter(orgId, appId))
+        .where(eq(billingAccounts.orgId, orgId))
         .limit(1);
       res.json(formatAccount(refetched));
       return;
@@ -104,12 +98,11 @@ router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
 router.get("/v1/accounts/balance", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
-    const appId = req.headers["x-app-id"] as string;
 
     const [account] = await db
       .select()
       .from(billingAccounts)
-      .where(accountFilter(orgId, appId))
+      .where(eq(billingAccounts.orgId, orgId))
       .limit(1);
 
     if (!account) {
@@ -135,13 +128,12 @@ router.get(
   async (req, res) => {
     try {
       const orgId = req.headers["x-org-id"] as string;
-      const appId = req.headers["x-app-id"] as string;
-      const keySourceInfo = getKeySourceInfo(req);
+      const userId = req.headers["x-user-id"] as string;
 
       const [account] = await db
         .select()
         .from(billingAccounts)
-        .where(accountFilter(orgId, appId))
+        .where(eq(billingAccounts.orgId, orgId))
         .limit(1);
 
       if (!account) {
@@ -154,7 +146,7 @@ router.get(
         return;
       }
 
-      const result = await listBalanceTransactions(keySourceInfo, account.stripeCustomerId);
+      const result = await listBalanceTransactions(orgId, userId, account.stripeCustomerId);
 
       const transactions = result.data.map((txn) => ({
         id: txn.id,
@@ -192,7 +184,6 @@ function classifyTransaction(
 router.patch("/v1/accounts/mode", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
-    const appId = req.headers["x-app-id"] as string;
     const parsed = UpdateModeRequestSchema.safeParse(req.body);
 
     if (!parsed.success) {
@@ -205,7 +196,7 @@ router.patch("/v1/accounts/mode", requireOrgHeaders, async (req, res) => {
     const [account] = await db
       .select()
       .from(billingAccounts)
-      .where(accountFilter(orgId, appId))
+      .where(eq(billingAccounts.orgId, orgId))
       .limit(1);
 
     if (!account) {
@@ -245,7 +236,7 @@ router.patch("/v1/accounts/mode", requireOrgHeaders, async (req, res) => {
     const [updated] = await db
       .update(billingAccounts)
       .set(updateData)
-      .where(accountFilter(orgId, appId))
+      .where(eq(billingAccounts.orgId, orgId))
       .returning();
 
     res.json(formatAccount(updated));

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { billingAccounts } from "../db/schema.js";
-import { requireOrgHeaders, getKeySourceInfo } from "../middleware/auth.js";
+import { requireOrgHeaders } from "../middleware/auth.js";
 import { CreateCheckoutRequestSchema } from "../schemas.js";
 import { createCustomer, createCheckoutSession, isStripeAuthError } from "../lib/stripe.js";
 
@@ -12,8 +12,7 @@ const router = Router();
 router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
-    const appId = req.headers["x-app-id"] as string;
-    const keySourceInfo = getKeySourceInfo(req);
+    const userId = req.headers["x-user-id"] as string;
     const parsed = CreateCheckoutRequestSchema.safeParse(req.body);
 
     if (!parsed.success) {
@@ -22,7 +21,7 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
     }
 
     const { success_url, cancel_url, reload_amount_cents } = parsed.data;
-    const filter = and(eq(billingAccounts.orgId, orgId), eq(billingAccounts.appId, appId));
+    const filter = eq(billingAccounts.orgId, orgId);
 
     // Get or create billing account
     let [account] = await db
@@ -33,13 +32,12 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
 
     if (!account) {
       // Auto-create account with Stripe customer
-      const stripeCustomer = await createCustomer(keySourceInfo, orgId);
+      const stripeCustomer = await createCustomer(orgId, userId);
 
       const [created] = await db
         .insert(billingAccounts)
         .values({
           orgId,
-          appId,
           stripeCustomerId: stripeCustomer.id,
           billingMode: "trial",
           creditBalanceCents: 200,
@@ -57,7 +55,7 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
 
     if (!account.stripeCustomerId) {
       // Account exists but no Stripe customer — create one
-      const stripeCustomer = await createCustomer(keySourceInfo, orgId);
+      const stripeCustomer = await createCustomer(orgId, userId);
       [account] = await db
         .update(billingAccounts)
         .set({
@@ -69,7 +67,8 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
     }
 
     const session = await createCheckoutSession(
-      keySourceInfo,
+      orgId,
+      userId,
       account.stripeCustomerId!,
       success_url,
       cancel_url,

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -1,14 +1,13 @@
 import { Router } from "express";
-import { eq, and, sql as rawSql } from "drizzle-orm";
+import { eq, sql as rawSql } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { billingAccounts, type BillingAccount } from "../db/schema.js";
-import { requireOrgHeaders, getKeySourceInfo } from "../middleware/auth.js";
+import { billingAccounts } from "../db/schema.js";
+import { requireOrgHeaders } from "../middleware/auth.js";
 import { DeductRequestSchema } from "../schemas.js";
 import {
   createBalanceTransaction,
   chargePaymentMethod,
   isStripeAuthError,
-  type KeySourceInfo,
 } from "../lib/stripe.js";
 
 const router = Router();
@@ -17,8 +16,7 @@ const router = Router();
 router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
-    const appId = req.headers["x-app-id"] as string;
-    const keySourceInfo = getKeySourceInfo(req);
+    const userId = req.headers["x-user-id"] as string;
     const parsed = DeductRequestSchema.safeParse(req.body);
 
     if (!parsed.success) {
@@ -26,7 +24,7 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    const { amount_cents, description, app_id, user_id } = parsed.data;
+    const { amount_cents, description } = parsed.data;
 
     // Use Drizzle transaction with FOR UPDATE lock to prevent double-spend
     const result = await db.transaction(async (tx) => {
@@ -34,7 +32,6 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
       const rows = await tx.execute<{
         id: string;
         org_id: string;
-        app_id: string;
         stripe_customer_id: string | null;
         billing_mode: string;
         credit_balance_cents: number;
@@ -42,13 +39,12 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
         reload_threshold_cents: number | null;
         stripe_payment_method_id: string | null;
       }>(
-        rawSql`SELECT * FROM billing_accounts WHERE org_id = ${orgId} AND app_id = ${appId} FOR UPDATE`
+        rawSql`SELECT * FROM billing_accounts WHERE org_id = ${orgId} FOR UPDATE`
       );
 
       const account = (rows as unknown as Array<{
         id: string;
         org_id: string;
-        app_id: string;
         stripe_customer_id: string | null;
         billing_mode: string;
         credit_balance_cents: number;
@@ -71,7 +67,7 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
       }
 
       let currentBalance = account.credit_balance_cents;
-      const filter = and(eq(billingAccounts.orgId, orgId), eq(billingAccounts.appId, appId));
+      const filter = eq(billingAccounts.orgId, orgId);
 
       // If insufficient balance, try auto-reload for PAYG
       if (currentBalance < amount_cents) {
@@ -84,7 +80,8 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
           try {
             // Charge the saved payment method
             await chargePaymentMethod(
-              keySourceInfo,
+              orgId,
+              userId,
               account.stripe_customer_id,
               account.stripe_payment_method_id,
               account.reload_amount_cents,
@@ -93,7 +90,8 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
 
             // Credit the Stripe balance
             await createBalanceTransaction(
-              keySourceInfo,
+              orgId,
+              userId,
               account.stripe_customer_id,
               -account.reload_amount_cents,
               "Auto-reload credit"
@@ -143,11 +141,12 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
       // Fire Stripe balance transaction async (non-blocking)
       if (account.stripe_customer_id) {
         createBalanceTransaction(
-          keySourceInfo,
+          orgId,
+          userId,
           account.stripe_customer_id,
           amount_cents, // positive = deduction in Stripe
           description,
-          { app_id, user_id }
+          { user_id: userId }
         ).catch((err) => {
           console.error("Stripe balance transaction failed (async):", err);
         });
@@ -169,15 +168,15 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
         // Fire auto-reload async (non-blocking)
         (async () => {
           try {
-            await chargePaymentMethod(keySourceInfo, customerId, pmId, reloadAmount, "Auto-reload");
-            await createBalanceTransaction(keySourceInfo, customerId, -reloadAmount, "Auto-reload credit");
+            await chargePaymentMethod(orgId, userId, customerId, pmId, reloadAmount, "Auto-reload");
+            await createBalanceTransaction(orgId, userId, customerId, -reloadAmount, "Auto-reload credit");
             await db
               .update(billingAccounts)
               .set({
                 creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${reloadAmount}`,
                 updatedAt: new Date(),
               })
-              .where(and(eq(billingAccounts.orgId, orgId), eq(billingAccounts.appId, appId)));
+              .where(eq(billingAccounts.orgId, orgId));
           } catch (err) {
             console.error("Async auto-reload failed:", err);
           }

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -5,17 +5,16 @@ import { billingAccounts } from "../db/schema.js";
 import {
   constructWebhookEvent,
   createBalanceTransaction,
-  type KeySourceInfo,
 } from "../lib/stripe.js";
 import type Stripe from "stripe";
 
 const router = Router();
 
-// POST /v1/webhooks/stripe/:appId — Stripe webhook handler (per-app)
+// POST /v1/webhooks/stripe/:orgId — Stripe webhook handler (per-org)
 // NOTE: This route uses express.raw() body parser (mounted before express.json() in index.ts)
-router.post("/v1/webhooks/stripe/:appId", async (req, res) => {
+router.post("/v1/webhooks/stripe/:orgId", async (req, res) => {
   try {
-    const appId = req.params.appId;
+    const orgId = req.params.orgId;
     const signature = req.headers["stripe-signature"] as string;
     if (!signature) {
       res.status(400).json({ error: "Missing stripe-signature header" });
@@ -24,7 +23,7 @@ router.post("/v1/webhooks/stripe/:appId", async (req, res) => {
 
     let event: Stripe.Event;
     try {
-      event = await constructWebhookEvent(appId, req.body as Buffer, signature);
+      event = await constructWebhookEvent(orgId, req.body as Buffer, signature);
     } catch (err) {
       console.error("Webhook signature verification failed:", err);
       res.status(400).json({ error: "Invalid signature" });
@@ -34,7 +33,7 @@ router.post("/v1/webhooks/stripe/:appId", async (req, res) => {
     switch (event.type) {
       case "checkout.session.completed": {
         await handleCheckoutCompleted(
-          appId,
+          orgId,
           event.data.object as Stripe.Checkout.Session
         );
         break;
@@ -64,7 +63,7 @@ router.post("/v1/webhooks/stripe/:appId", async (req, res) => {
   }
 });
 
-async function handleCheckoutCompleted(appId: string, session: Stripe.Checkout.Session) {
+async function handleCheckoutCompleted(orgId: string, session: Stripe.Checkout.Session) {
   const customerId = session.customer as string;
   if (!customerId) return;
 
@@ -90,11 +89,11 @@ async function handleCheckoutCompleted(appId: string, session: Stripe.Checkout.S
     ? parseInt(session.metadata.reload_amount_cents, 10)
     : account.reloadAmountCents;
 
-  // Credit the balance with the reload amount (webhooks always use app key source)
-  const keySourceInfo: KeySourceInfo = { keySource: "app", appId };
+  // Credit the balance with the reload amount
   if (reloadAmountCents && account.stripeCustomerId) {
     await createBalanceTransaction(
-      keySourceInfo,
+      orgId,
+      "system",
       account.stripeCustomerId,
       -reloadAmountCents,
       "Initial reload credit"

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -17,17 +17,12 @@ export const BillingModeSchema = z
   .enum(["trial", "byok", "payg"])
   .openapi("BillingMode");
 
-export const KeySourceSchema = z
-  .enum(["app", "byok", "platform"])
-  .openapi("KeySource");
-
 // --- Account ---
 
 export const BillingAccountSchema = z
   .object({
     id: z.string().uuid(),
     orgId: z.string().uuid(),
-    appId: z.string(),
     billingMode: BillingModeSchema,
     creditBalanceCents: z.number().int(),
     reloadAmountCents: z.number().int().nullable(),
@@ -44,8 +39,6 @@ export const DeductRequestSchema = z
   .object({
     amount_cents: z.number().int().positive(),
     description: z.string().min(1),
-    app_id: z.string().min(1),
-    user_id: z.string().uuid(),
   })
   .openapi("DeductRequest");
 
@@ -118,9 +111,7 @@ export const TransactionsResponseSchema = z
 const protectedHeaders = z.object({
   "x-api-key": z.string(),
   "x-org-id": z.string().uuid(),
-  "x-app-id": z.string(),
-  "x-user-id": z.string().uuid().optional(),
-  "x-key-source": KeySourceSchema,
+  "x-user-id": z.string().uuid(),
 });
 
 registry.registerPath({
@@ -269,11 +260,11 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/webhooks/stripe/{appId}",
-  summary: "Stripe webhook handler (per-app)",
+  path: "/v1/webhooks/stripe/{orgId}",
+  summary: "Stripe webhook handler (per-org)",
   request: {
     params: z.object({
-      appId: z.string(),
+      orgId: z.string().uuid(),
     }),
   },
   responses: {

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -38,20 +38,17 @@ export function setupStripeMocks() {
       amount: 2000,
     }),
     constructWebhookEvent: vi.fn(),
-    resolveAppKey: vi.fn().mockResolvedValue("sk_test_mock_key"),
-    resolveByokKey: vi.fn().mockResolvedValue("sk_test_byok_key"),
-    resolvePlatformKey: vi.fn().mockResolvedValue("sk_test_platform_key"),
-    resolveKey: vi.fn().mockResolvedValue("sk_test_mock_key"),
+    resolveProviderKey: vi.fn().mockResolvedValue({
+      key: "sk_test_mock_key",
+      keySource: "platform",
+    }),
     isStripeAuthError: vi.fn().mockImplementation(
       (err: unknown) => err instanceof Stripe.errors.StripeAuthenticationError
     ),
   };
 
   // Mock key-service so Stripe never actually calls it
-  vi.spyOn(keyClient, "resolveAppKey").mockImplementation(mocks.resolveAppKey);
-  vi.spyOn(keyClient, "resolveByokKey").mockImplementation(mocks.resolveByokKey);
-  vi.spyOn(keyClient, "resolvePlatformKey").mockImplementation(mocks.resolvePlatformKey);
-  vi.spyOn(keyClient, "resolveKey").mockImplementation(mocks.resolveKey);
+  vi.spyOn(keyClient, "resolveProviderKey").mockImplementation(mocks.resolveProviderKey);
 
   vi.spyOn(stripeLib, "createCustomer").mockImplementation(mocks.createCustomer);
   vi.spyOn(stripeLib, "createBalanceTransaction").mockImplementation(

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -36,14 +36,12 @@ export function createTestApp() {
 
 export function getAuthHeaders(
   orgId = "00000000-0000-0000-0000-000000000001",
-  appId = "testapp",
-  keySource: "app" | "byok" | "platform" = "app"
+  userId = "00000000-0000-0000-0000-000000000099"
 ) {
   return {
     "X-API-Key": "test-api-key",
     "x-org-id": orgId,
-    "x-app-id": appId,
-    "x-key-source": keySource,
+    "x-user-id": userId,
     "Content-Type": "application/json",
   };
 }

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -7,7 +7,6 @@ export async function cleanTestData() {
 
 export async function insertTestAccount(data: {
   orgId: string;
-  appId?: string;
   stripeCustomerId?: string;
   billingMode?: string;
   creditBalanceCents?: number;
@@ -19,7 +18,6 @@ export async function insertTestAccount(data: {
     .insert(billingAccounts)
     .values({
       orgId: data.orgId,
-      appId: data.appId ?? "testapp",
       stripeCustomerId: data.stripeCustomerId ?? null,
       billingMode: data.billingMode ?? "trial",
       creditBalanceCents: data.creditBalanceCents ?? 200,

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -7,7 +7,7 @@ import { setupStripeMocks, createStripeAuthError } from "../helpers/mock-stripe.
 describe("Accounts endpoints", () => {
   const app = createTestApp();
   const orgId = "00000000-0000-0000-0000-000000000001";
-  const appId = "testapp";
+  const userId = "00000000-0000-0000-0000-000000000099";
   let stripeMocks: ReturnType<typeof setupStripeMocks>;
 
   beforeEach(async () => {
@@ -29,16 +29,17 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.orgId).toBe(orgId);
-      expect(res.body.appId).toBe(appId);
       expect(res.body.billingMode).toBe("trial");
       expect(res.body.creditBalanceCents).toBe(200);
       expect(res.body.hasPaymentMethod).toBe(false);
+      expect(res.body).not.toHaveProperty("appId");
       expect(stripeMocks.createCustomer).toHaveBeenCalledWith(
-        { keySource: "app", appId },
-        orgId
+        orgId,
+        userId
       );
       expect(stripeMocks.createBalanceTransaction).toHaveBeenCalledWith(
-        { keySource: "app", appId },
+        orgId,
+        userId,
         "cus_mock123",
         -200,
         "Trial credit: $2.00"
@@ -64,7 +65,7 @@ describe("Accounts endpoints", () => {
     it("returns 401 without API key", async () => {
       const res = await request(app)
         .get("/v1/accounts")
-        .set({ "x-org-id": orgId, "x-app-id": appId });
+        .set({ "x-org-id": orgId, "x-user-id": userId });
 
       expect(res.status).toBe(401);
     });
@@ -72,28 +73,19 @@ describe("Accounts endpoints", () => {
     it("returns 400 without x-org-id header", async () => {
       const res = await request(app)
         .get("/v1/accounts")
-        .set({ "X-API-Key": "test-api-key", "x-app-id": appId });
+        .set({ "X-API-Key": "test-api-key", "x-user-id": userId });
 
       expect(res.status).toBe(400);
+      expect(res.body.error).toBe("x-org-id header is required");
     });
 
-    it("returns 400 without x-app-id header", async () => {
+    it("returns 400 without x-user-id header", async () => {
       const res = await request(app)
         .get("/v1/accounts")
         .set({ "X-API-Key": "test-api-key", "x-org-id": orgId });
 
       expect(res.status).toBe(400);
-    });
-
-    it("auto-creates account for any appId (not just billing-service)", async () => {
-      const res = await request(app)
-        .get("/v1/accounts")
-        .set(getAuthHeaders(orgId, "sales-cold-emails"));
-
-      expect(res.status).toBe(200);
-      expect(res.body.appId).toBe("sales-cold-emails");
-      expect(res.body.billingMode).toBe("trial");
-      expect(res.body.creditBalanceCents).toBe(200);
+      expect(res.body.error).toBe("x-user-id header is required");
     });
 
     it("returns 502 when Stripe key is expired", async () => {
@@ -107,55 +99,6 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(502);
       expect(res.body.error).toBe("Payment provider authentication failed");
-    });
-
-    it("passes byok KeySourceInfo when x-key-source is byok", async () => {
-      const res = await request(app)
-        .get("/v1/accounts")
-        .set(getAuthHeaders(orgId, appId, "byok"));
-
-      expect(res.status).toBe(200);
-      expect(stripeMocks.createCustomer).toHaveBeenCalledWith(
-        { keySource: "byok", orgId },
-        orgId
-      );
-    });
-
-    it("passes platform KeySourceInfo when x-key-source is platform", async () => {
-      const res = await request(app)
-        .get("/v1/accounts")
-        .set(getAuthHeaders(orgId, appId, "platform"));
-
-      expect(res.status).toBe(200);
-      expect(stripeMocks.createCustomer).toHaveBeenCalledWith(
-        { keySource: "platform" },
-        orgId
-      );
-    });
-
-    it("returns 400 when x-key-source is missing", async () => {
-      const res = await request(app)
-        .get("/v1/accounts")
-        .set({
-          "X-API-Key": "test-api-key",
-          "x-org-id": orgId,
-          "x-app-id": appId,
-        });
-
-      expect(res.status).toBe(400);
-      expect(res.body.error).toBe("x-key-source header is required");
-    });
-
-    it("returns 400 for invalid x-key-source", async () => {
-      const res = await request(app)
-        .get("/v1/accounts")
-        .set({
-          ...getAuthHeaders(orgId),
-          "x-key-source": "invalid",
-        });
-
-      expect(res.status).toBe(400);
-      expect(res.body.error).toContain("Invalid x-key-source");
     });
   });
 

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -7,7 +7,7 @@ import { setupStripeMocks } from "../helpers/mock-stripe.js";
 describe("Checkout endpoint", () => {
   const app = createTestApp();
   const orgId = "00000000-0000-0000-0000-000000000001";
-  const appId = "testapp";
+  const userId = "00000000-0000-0000-0000-000000000099";
   let stripeMocks: ReturnType<typeof setupStripeMocks>;
 
   beforeEach(async () => {
@@ -40,7 +40,8 @@ describe("Checkout endpoint", () => {
     expect(res.body.url).toContain("checkout.stripe.com");
     expect(res.body.session_id).toBe("cs_mock_session");
     expect(stripeMocks.createCheckoutSession).toHaveBeenCalledWith(
-      { keySource: "app", appId },
+      orgId,
+      userId,
       "cus_123",
       "https://app.example.com/success",
       "https://app.example.com/cancel",
@@ -61,31 +62,6 @@ describe("Checkout endpoint", () => {
     expect(res.status).toBe(200);
     expect(stripeMocks.createCustomer).toHaveBeenCalled();
     expect(stripeMocks.createCheckoutSession).toHaveBeenCalled();
-  });
-
-  it("uses platform KeySourceInfo when x-key-source is platform", async () => {
-    await insertTestAccount({
-      orgId,
-      stripeCustomerId: "cus_123",
-    });
-
-    const res = await request(app)
-      .post("/v1/checkout-sessions")
-      .set(getAuthHeaders(orgId, appId, "platform"))
-      .send({
-        success_url: "https://app.example.com/success",
-        cancel_url: "https://app.example.com/cancel",
-        reload_amount_cents: 2000,
-      });
-
-    expect(res.status).toBe(200);
-    expect(stripeMocks.createCheckoutSession).toHaveBeenCalledWith(
-      { keySource: "platform" },
-      "cus_123",
-      "https://app.example.com/success",
-      "https://app.example.com/cancel",
-      2000
-    );
   });
 
   it("validates request body", async () => {

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -7,8 +7,7 @@ import { setupStripeMocks } from "../helpers/mock-stripe.js";
 describe("Credits deduction endpoint", () => {
   const app = createTestApp();
   const orgId = "00000000-0000-0000-0000-000000000001";
-  const appId = "testapp";
-  const userId = "00000000-0000-0000-0000-000000000002";
+  const userId = "00000000-0000-0000-0000-000000000099";
   let stripeMocks: ReturnType<typeof setupStripeMocks>;
 
   beforeEach(async () => {
@@ -35,8 +34,6 @@ describe("Credits deduction endpoint", () => {
       .send({
         amount_cents: 5,
         description: "anthropic-sonnet-4.5 tokens",
-        app_id: "mcpfactory",
-        user_id: userId,
       });
 
     expect(res.status).toBe(200);
@@ -62,8 +59,6 @@ describe("Credits deduction endpoint", () => {
       .send({
         amount_cents: 5,
         description: "test deduction",
-        app_id: "testapp",
-        user_id: userId,
       });
 
     expect(res.status).toBe(200);
@@ -85,8 +80,6 @@ describe("Credits deduction endpoint", () => {
       .send({
         amount_cents: 100,
         description: "should not deduct",
-        app_id: "testapp",
-        user_id: userId,
       });
 
     expect(res.status).toBe(200);
@@ -115,8 +108,6 @@ describe("Credits deduction endpoint", () => {
       .send({
         amount_cents: 5,
         description: "test deduction with reload",
-        app_id: "testapp",
-        user_id: userId,
       });
 
     expect(res.status).toBe(200);
@@ -124,7 +115,8 @@ describe("Credits deduction endpoint", () => {
     // Balance should be: 3 (original) + 2000 (reload) - 5 (deduction) = 1998
     expect(res.body.balance_cents).toBe(1998);
     expect(stripeMocks.chargePaymentMethod).toHaveBeenCalledWith(
-      { keySource: "app", appId },
+      orgId,
+      userId,
       "cus_123",
       "pm_123",
       2000,
@@ -153,8 +145,6 @@ describe("Credits deduction endpoint", () => {
       .send({
         amount_cents: 5,
         description: "test deduction",
-        app_id: "testapp",
-        user_id: userId,
       });
 
     expect(res.status).toBe(200);
@@ -169,8 +159,6 @@ describe("Credits deduction endpoint", () => {
       .send({
         amount_cents: 5,
         description: "test",
-        app_id: "testapp",
-        user_id: userId,
       });
 
     expect(res.status).toBe(404);
@@ -185,7 +173,7 @@ describe("Credits deduction endpoint", () => {
     expect(res.status).toBe(400);
   });
 
-  it("uses byok KeySourceInfo when x-key-source is byok", async () => {
+  it("passes userId from header to Stripe metadata", async () => {
     await insertTestAccount({
       orgId,
       stripeCustomerId: "cus_123",
@@ -194,23 +182,22 @@ describe("Credits deduction endpoint", () => {
 
     const res = await request(app)
       .post("/v1/credits/deduct")
-      .set(getAuthHeaders(orgId, appId, "byok"))
+      .set(getAuthHeaders(orgId))
       .send({
         amount_cents: 5,
         description: "test deduction",
-        app_id: "testapp",
-        user_id: userId,
       });
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-    // Async Stripe balance transaction should use byok key source
+    // Async Stripe balance transaction should include userId in metadata
     expect(stripeMocks.createBalanceTransaction).toHaveBeenCalledWith(
-      { keySource: "byok", orgId },
+      orgId,
+      userId,
       "cus_123",
       5,
       "test deduction",
-      { app_id: "testapp", user_id: userId }
+      { user_id: userId }
     );
   });
 
@@ -225,8 +212,6 @@ describe("Credits deduction endpoint", () => {
     const body = {
       amount_cents: 10,
       description: "test",
-      app_id: "testapp",
-      user_id: userId,
     };
 
     const res1 = await request(app).post("/v1/credits/deduct").set(headers).send(body);

--- a/tests/integration/webhooks.test.ts
+++ b/tests/integration/webhooks.test.ts
@@ -10,7 +10,6 @@ import { eq } from "drizzle-orm";
 describe("Stripe webhooks", () => {
   const app = createTestApp();
   const orgId = "00000000-0000-0000-0000-000000000001";
-  const webhookAppId = "testapp";
   let stripeMocks: ReturnType<typeof setupStripeMocks>;
 
   beforeEach(async () => {
@@ -26,7 +25,7 @@ describe("Stripe webhooks", () => {
 
   it("rejects requests without stripe-signature", async () => {
     const res = await request(app)
-      .post(`/v1/webhooks/stripe/${webhookAppId}`)
+      .post(`/v1/webhooks/stripe/${orgId}`)
       .set("Content-Type", "application/json")
       .send(JSON.stringify({ type: "test" }));
 
@@ -40,7 +39,7 @@ describe("Stripe webhooks", () => {
     });
 
     const res = await request(app)
-      .post(`/v1/webhooks/stripe/${webhookAppId}`)
+      .post(`/v1/webhooks/stripe/${orgId}`)
       .set("Content-Type", "application/json")
       .set("stripe-signature", "invalid_sig")
       .send(JSON.stringify({ type: "test" }));
@@ -71,7 +70,7 @@ describe("Stripe webhooks", () => {
     });
 
     const res = await request(app)
-      .post(`/v1/webhooks/stripe/${webhookAppId}`)
+      .post(`/v1/webhooks/stripe/${orgId}`)
       .set("Content-Type", "application/json")
       .set("stripe-signature", "valid_sig")
       .send(JSON.stringify({ type: "checkout.session.completed" }));
@@ -111,7 +110,7 @@ describe("Stripe webhooks", () => {
     });
 
     const res = await request(app)
-      .post(`/v1/webhooks/stripe/${webhookAppId}`)
+      .post(`/v1/webhooks/stripe/${orgId}`)
       .set("Content-Type", "application/json")
       .set("stripe-signature", "valid_sig")
       .send(JSON.stringify({ type: "payment_intent.succeeded" }));
@@ -135,7 +134,7 @@ describe("Stripe webhooks", () => {
     });
 
     const res = await request(app)
-      .post(`/v1/webhooks/stripe/${webhookAppId}`)
+      .post(`/v1/webhooks/stripe/${orgId}`)
       .set("Content-Type", "application/json")
       .set("stripe-signature", "valid_sig")
       .send(JSON.stringify({ type: "some.unknown.event" }));

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -5,90 +5,46 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 // Now import the module — it will pick up the stubbed fetch
-import { resolveAppKey, resolveByokKey, resolvePlatformKey, resolveKey } from "../../src/lib/key-client.js";
+import { resolveProviderKey } from "../../src/lib/key-client.js";
 
-describe("resolveAppKey", () => {
+describe("resolveProviderKey", () => {
   beforeEach(() => {
     mockFetch.mockReset();
   });
 
-  it("sends x-caller-service, x-caller-method, x-caller-path headers", async () => {
+  it("sends correct URL with orgId and userId query params", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ key: "sk_test_123" }),
+      json: () => Promise.resolve({ key: "sk_test_123", keySource: "platform" }),
     });
 
-    await resolveAppKey("stripe", "sales-cold-emails", {
+    const result = await resolveProviderKey("stripe", "org-uuid-abc", "user-uuid-123", {
       service: "billing",
       method: "GET",
       path: "/v1/accounts",
     });
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/internal/app-keys/stripe/decrypt?appId=sales-cold-emails"),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          "x-caller-service": "billing",
-          "x-caller-method": "GET",
-          "x-caller-path": "/v1/accounts",
-        }),
-      })
-    );
+    expect(result).toEqual({ key: "sk_test_123", keySource: "platform" });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/keys/stripe/decrypt?");
+    expect(url).toContain("orgId=org-uuid-abc");
+    expect(url).toContain("userId=user-uuid-123");
   });
 
-  it("uses default caller context when none provided", async () => {
+  it("sends x-caller-service, x-caller-method, x-caller-path headers", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ key: "sk_test_456" }),
+      json: () => Promise.resolve({ key: "sk_test_123", keySource: "org" }),
     });
 
-    await resolveAppKey("stripe", "my-app");
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("appId=my-app"),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          "x-caller-service": "billing",
-          "x-caller-method": "GET",
-          "x-caller-path": "/v1/accounts",
-        }),
-      })
-    );
-  });
-
-  it("throws when key-service returns error", async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 404,
-      text: () => Promise.resolve("Key not found"),
-    });
-
-    await expect(resolveAppKey("stripe", "unknown-app")).rejects.toThrow(
-      "Failed to resolve stripe key for app unknown-app: 404"
-    );
-  });
-});
-
-describe("resolveByokKey", () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-  });
-
-  it("sends correct URL with orgId and caller headers", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ key: "sk_byok_123" }),
-    });
-
-    const key = await resolveByokKey("stripe", "org-uuid-abc", {
+    await resolveProviderKey("stripe", "org-123", "user-456", {
       service: "billing",
       method: "POST",
       path: "/v1/credits/deduct",
     });
 
-    expect(key).toBe("sk_byok_123");
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/internal/keys/stripe/decrypt?orgId=org-uuid-abc"),
+      expect.any(String),
       expect.objectContaining({
         headers: expect.objectContaining({
           "x-caller-service": "billing",
@@ -99,49 +55,24 @@ describe("resolveByokKey", () => {
     );
   });
 
-  it("throws when key-service returns error", async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 404,
-      text: () => Promise.resolve("Key not found"),
-    });
-
-    await expect(resolveByokKey("stripe", "org-unknown")).rejects.toThrow(
-      "Failed to resolve stripe BYOK key for org org-unknown: 404"
-    );
-  });
-});
-
-describe("resolvePlatformKey", () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
-  });
-
-  it("sends correct URL with no appId/orgId query param", async () => {
+  it("uses default caller context when none provided", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ key: "sk_platform_123" }),
+      json: () => Promise.resolve({ key: "sk_test_456", keySource: "platform" }),
     });
 
-    const key = await resolvePlatformKey("stripe", {
-      service: "billing",
-      method: "GET",
-      path: "/v1/accounts",
-    });
+    await resolveProviderKey("stripe", "org-123", "user-456");
 
-    expect(key).toBe("sk_platform_123");
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/internal/platform-keys/stripe/decrypt"),
+      expect.any(String),
       expect.objectContaining({
         headers: expect.objectContaining({
           "x-caller-service": "billing",
+          "x-caller-method": "GET",
+          "x-caller-path": "/v1/accounts",
         }),
       })
     );
-    // No query params
-    const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).not.toContain("appId=");
-    expect(url).not.toContain("orgId=");
   });
 
   it("throws when key-service returns error", async () => {
@@ -151,48 +82,48 @@ describe("resolvePlatformKey", () => {
       text: () => Promise.resolve("Key not found"),
     });
 
-    await expect(resolvePlatformKey("stripe")).rejects.toThrow(
-      "Failed to resolve stripe platform key: 404"
+    await expect(resolveProviderKey("stripe", "org-unknown", "user-123")).rejects.toThrow(
+      "Failed to resolve stripe key for org org-unknown: 404"
     );
   });
-});
 
-describe("resolveKey (dispatcher)", () => {
-  beforeEach(() => {
-    mockFetch.mockReset();
+  it("returns keySource 'org' when org key is used", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ key: "sk_resolved" }),
+      json: () => Promise.resolve({ key: "sk_org_key", keySource: "org" }),
     });
+
+    const result = await resolveProviderKey("stripe", "org-123", "user-456");
+    expect(result.keySource).toBe("org");
   });
 
-  it("dispatches to app-keys path for keySource 'app'", async () => {
-    await resolveKey("stripe", "app", { appId: "my-app" });
+  it("encodes provider name in URL", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ key: "whsec_123", keySource: "platform" }),
+    });
+
+    await resolveProviderKey("stripe-webhook", "org-123", "user-456");
+
     const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("/internal/app-keys/stripe/decrypt?appId=my-app");
+    expect(url).toContain("/keys/stripe-webhook/decrypt?");
   });
 
-  it("dispatches to byok path for keySource 'byok'", async () => {
-    await resolveKey("stripe", "byok", { orgId: "org-123" });
-    const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("/internal/keys/stripe/decrypt?orgId=org-123");
-  });
+  it("sends x-api-key header", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ key: "sk_test", keySource: "platform" }),
+    });
 
-  it("dispatches to platform path for keySource 'platform'", async () => {
-    await resolveKey("stripe", "platform", {});
-    const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("/internal/platform-keys/stripe/decrypt");
-  });
+    await resolveProviderKey("stripe", "org-123", "user-456");
 
-  it("throws when keySource is 'app' but appId is missing", async () => {
-    await expect(resolveKey("stripe", "app", {})).rejects.toThrow(
-      "appId is required for keySource 'app'"
-    );
-  });
-
-  it("throws when keySource is 'byok' but orgId is missing", async () => {
-    await expect(resolveKey("stripe", "byok", {})).rejects.toThrow(
-      "orgId is required for keySource 'byok'"
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-api-key": "test-key-service-key",
+        }),
+      })
     );
   });
 });

--- a/tests/unit/stripe.test.ts
+++ b/tests/unit/stripe.test.ts
@@ -7,85 +7,74 @@ describe("Stripe key resolution", () => {
     vi.resetModules();
   });
 
-  it("resolves Stripe key via resolveKey with KeySourceInfo (app)", async () => {
-    const mockResolveKey = vi.fn().mockResolvedValue("sk_test_mock");
+  it("resolves Stripe key via resolveProviderKey with orgId and userId", async () => {
+    const mockResolveProviderKey = vi.fn().mockResolvedValue({
+      key: "sk_test_mock",
+      keySource: "platform",
+    });
     vi.doMock("../../src/lib/key-client.js", () => ({
-      resolveAppKey: vi.fn(),
-      resolveKey: mockResolveKey,
+      resolveProviderKey: mockResolveProviderKey,
     }));
 
     const { createCustomer } = await import("../../src/lib/stripe.js");
 
     try {
-      await createCustomer({ keySource: "app", appId: "sales-cold-emails" }, "org-123");
+      await createCustomer("org-123", "user-456");
     } catch {
       // Stripe constructor may throw with mock key — that's fine
     }
 
-    expect(mockResolveKey).toHaveBeenCalledWith(
-      "stripe", "app", { appId: "sales-cold-emails" }
+    expect(mockResolveProviderKey).toHaveBeenCalledWith(
+      "stripe", "org-123", "user-456"
     );
   });
 
-  it("resolves Stripe key via resolveKey with KeySourceInfo (byok)", async () => {
-    const mockResolveKey = vi.fn().mockResolvedValue("sk_byok_mock");
+  it("caches Stripe instance by orgId", async () => {
+    const mockResolveProviderKey = vi.fn().mockResolvedValue({
+      key: "sk_test_cached",
+      keySource: "platform",
+    });
     vi.doMock("../../src/lib/key-client.js", () => ({
-      resolveAppKey: vi.fn(),
-      resolveKey: mockResolveKey,
+      resolveProviderKey: mockResolveProviderKey,
     }));
+
+    // Mock Stripe constructor to avoid real API calls that trigger auth errors
+    const mockCreate = vi.fn().mockResolvedValue({ id: "cus_mock", object: "customer" });
+    vi.doMock("stripe", () => {
+      const MockStripe = function () {
+        return { customers: { create: mockCreate } };
+      };
+      MockStripe.errors = Stripe.errors;
+      return { default: MockStripe };
+    });
 
     const { createCustomer } = await import("../../src/lib/stripe.js");
 
-    try {
-      await createCustomer({ keySource: "byok", orgId: "org-uuid" }, "org-uuid");
-    } catch {
-      // Expected
-    }
+    await createCustomer("org-123", "user-456");
+    await createCustomer("org-123", "user-456");
 
-    expect(mockResolveKey).toHaveBeenCalledWith(
-      "stripe", "byok", { orgId: "org-uuid" }
-    );
-  });
-
-  it("resolves Stripe key via resolveKey with KeySourceInfo (platform)", async () => {
-    const mockResolveKey = vi.fn().mockResolvedValue("sk_platform_mock");
-    vi.doMock("../../src/lib/key-client.js", () => ({
-      resolveAppKey: vi.fn(),
-      resolveKey: mockResolveKey,
-    }));
-
-    const { createCustomer } = await import("../../src/lib/stripe.js");
-
-    try {
-      await createCustomer({ keySource: "platform" }, "org-123");
-    } catch {
-      // Expected
-    }
-
-    expect(mockResolveKey).toHaveBeenCalledWith(
-      "stripe", "platform", {}
-    );
+    // Key should be resolved only once (cached)
+    expect(mockResolveProviderKey).toHaveBeenCalledTimes(1);
   });
 
   it("evicts cached Stripe instance on auth error and retries with fresh key", async () => {
-    const mockResolveKey = vi.fn()
-      .mockResolvedValueOnce("sk_expired_key")
-      .mockResolvedValueOnce("sk_fresh_key");
+    const mockResolveProviderKey = vi.fn()
+      .mockResolvedValueOnce({ key: "sk_expired_key", keySource: "platform" })
+      .mockResolvedValueOnce({ key: "sk_fresh_key", keySource: "platform" });
     vi.doMock("../../src/lib/key-client.js", () => ({
-      resolveAppKey: vi.fn(),
-      resolveKey: mockResolveKey,
+      resolveProviderKey: mockResolveProviderKey,
     }));
 
     const { createCustomer } = await import("../../src/lib/stripe.js");
 
     try {
-      await createCustomer({ keySource: "app", appId: "test-app" }, "org-123");
+      await createCustomer("org-123", "user-456");
     } catch {
       // Expected — mock key can't actually reach Stripe
     }
 
-    // Key was resolved at least once (may be twice if the error triggers a retry)
-    expect(mockResolveKey).toHaveBeenCalledWith("stripe", "app", { appId: "test-app" });
+    // Key was resolved at least once
+    expect(mockResolveProviderKey).toHaveBeenCalledWith("stripe", "org-123", "user-456");
   });
 });
 


### PR DESCRIPTION
## Summary
- **Drop `app_id` column** from `billing_accounts` with safe dedup migration (keeps newest row per `org_id`)
- **Remove `x-app-id` and `x-key-source` headers** from the API contract; make `x-user-id` mandatory
- **Replace multi-path key resolution** (`resolveAppKey`/`resolveByokKey`/`resolvePlatformKey`) with single `resolveProviderKey()` calling `GET /keys/:provider/decrypt?orgId=&userId=`
- **Simplify Stripe client** — all functions take `(orgId, userId)` instead of `KeySourceInfo`
- **Change webhook route** from `/v1/webhooks/stripe/:appId` to `/v1/webhooks/stripe/:orgId`
- **Net -299 lines** (381 added, 680 removed)

## Test plan
- [x] All 72 tests pass (9 test files: 3 unit + 4 integration + health + key-client)
- [x] TypeScript strict mode compiles cleanly
- [x] OpenAPI spec regenerated — confirms appId/keySource removed, x-user-id required
- [x] DB migration tested against local and Neon databases
- [ ] Deploy to staging and verify key resolution with key-service v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)