### PR TITLE
Add x-run-id as required header on all protected endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -310,6 +310,15 @@
             "required": true,
             "name": "x-user-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -375,6 +384,15 @@
             "required": true,
             "name": "x-user-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "responses": {
@@ -419,6 +437,15 @@
             },
             "required": true,
             "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
             "in": "header"
           }
         ],
@@ -474,6 +501,15 @@
             },
             "required": true,
             "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
             "in": "header"
           }
         ],
@@ -539,6 +575,15 @@
             "required": true,
             "name": "x-user-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -602,6 +647,15 @@
             },
             "required": true,
             "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
             "in": "header"
           }
         ],

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -28,5 +28,10 @@ export function requireOrgHeaders(
     res.status(400).json({ error: "x-user-id header is required" });
     return;
   }
+  const runId = req.headers["x-run-id"] as string;
+  if (!runId) {
+    res.status(400).json({ error: "x-run-id header is required" });
+    return;
+  }
   next();
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -112,6 +112,7 @@ const protectedHeaders = z.object({
   "x-api-key": z.string(),
   "x-org-id": z.string().uuid(),
   "x-user-id": z.string().uuid(),
+  "x-run-id": z.string().uuid(),
 });
 
 registry.registerPath({

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -36,12 +36,14 @@ export function createTestApp() {
 
 export function getAuthHeaders(
   orgId = "00000000-0000-0000-0000-000000000001",
-  userId = "00000000-0000-0000-0000-000000000099"
+  userId = "00000000-0000-0000-0000-000000000099",
+  runId = "00000000-0000-0000-0000-000000000aaa"
 ) {
   return {
     "X-API-Key": "test-api-key",
     "x-org-id": orgId,
     "x-user-id": userId,
+    "x-run-id": runId,
     "Content-Type": "application/json",
   };
 }

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -88,6 +88,19 @@ describe("Accounts endpoints", () => {
       expect(res.body.error).toBe("x-user-id header is required");
     });
 
+    it("returns 400 without x-run-id header", async () => {
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set({
+          "X-API-Key": "test-api-key",
+          "x-org-id": orgId,
+          "x-user-id": userId,
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("x-run-id header is required");
+    });
+
     it("returns 502 when Stripe key is expired", async () => {
       stripeMocks.createCustomer.mockRejectedValue(
         createStripeAuthError("Expired API Key provided")


### PR DESCRIPTION
## Summary
- Added `x-run-id` as a mandatory header on all protected endpoints (alongside `x-org-id` and `x-user-id`)
- Middleware returns 400 if `x-run-id` is missing
- Updated OpenAPI spec with the new header requirement
- Added regression test for missing `x-run-id` → 400

## Test plan
- [x] All 73 existing tests pass
- [x] New test: `returns 400 without x-run-id header`
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)