### PR TITLE
Use dedicated platform key endpoint for Stripe

### DIFF
--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -4,9 +4,9 @@ export interface CallerContext {
   path: string;
 }
 
-export interface KeyResolution {
+export interface PlatformKeyResponse {
+  provider: string;
   key: string;
-  keySource: "platform" | "org";
 }
 
 const DEFAULT_CALLER: CallerContext = {
@@ -22,21 +22,18 @@ function getKeyServiceConfig() {
   return { url, apiKey };
 }
 
-/** Resolve a provider key from key-service. Returns the key and its source (platform or org). */
-export async function resolveProviderKey(
+/** Resolve a platform key from key-service. Platform keys are global — no orgId/userId needed. */
+export async function resolvePlatformKey(
   provider: string,
-  orgId: string,
-  userId: string,
   caller: CallerContext = DEFAULT_CALLER
-): Promise<KeyResolution> {
+): Promise<PlatformKeyResponse> {
   const config = getKeyServiceConfig();
   if (!config) {
     throw new Error(`KEY_SERVICE not configured — cannot resolve ${provider}`);
   }
 
-  const params = new URLSearchParams({ orgId, userId });
   const res = await fetch(
-    `${config.url}/keys/${encodeURIComponent(provider)}/decrypt?${params}`,
+    `${config.url}/keys/platform/${encodeURIComponent(provider)}/decrypt`,
     {
       headers: {
         "x-api-key": config.apiKey,
@@ -50,10 +47,9 @@ export async function resolveProviderKey(
   if (!res.ok) {
     const body = await res.text();
     throw new Error(
-      `Failed to resolve ${provider} key for org ${orgId}: ${res.status} ${body}`
+      `Failed to resolve platform key for ${provider}: ${res.status} ${body}`
     );
   }
 
-  const data = (await res.json()) as KeyResolution;
-  return data;
+  return (await res.json()) as PlatformKeyResponse;
 }

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,25 +1,22 @@
 import Stripe from "stripe";
-import { resolveProviderKey } from "./key-client.js";
+import { resolvePlatformKey } from "./key-client.js";
 
-// --- Stripe instance cache (keyed by org) ---
+// --- Single Stripe instance (platform key is global) ---
 
-const stripeInstances = new Map<string, Stripe>();
-const webhookSecrets = new Map<string, string>();
+let cachedStripe: Stripe | null = null;
+let cachedWebhookSecret: string | null = null;
 
-// Test override — applies to all key sources
+// Test override
 let testStripeInstance: Stripe | null = null;
 
-async function getStripe(orgId: string, userId: string): Promise<Stripe> {
+async function getStripe(): Promise<Stripe> {
   if (testStripeInstance) return testStripeInstance;
 
-  const ck = `org:${orgId}`;
-  let instance = stripeInstances.get(ck);
-  if (!instance) {
-    const { key } = await resolveProviderKey("stripe", orgId, userId);
-    instance = new Stripe(key, { apiVersion: "2024-12-18.acacia" as Stripe.LatestApiVersion });
-    stripeInstances.set(ck, instance);
+  if (!cachedStripe) {
+    const { key } = await resolvePlatformKey("stripe");
+    cachedStripe = new Stripe(key, { apiVersion: "2024-12-18.acacia" as Stripe.LatestApiVersion });
   }
-  return instance;
+  return cachedStripe;
 }
 
 /**
@@ -27,16 +24,15 @@ async function getStripe(orgId: string, userId: string): Promise<Stripe> {
  * If the Stripe key is expired/invalid, evicts the cached instance and retries
  * once with a freshly resolved key from key-service.
  */
-async function withAuthRetry<T>(orgId: string, userId: string, fn: (stripe: Stripe) => Promise<T>): Promise<T> {
-  const stripe = await getStripe(orgId, userId);
+async function withAuthRetry<T>(fn: (stripe: Stripe) => Promise<T>): Promise<T> {
+  const stripe = await getStripe();
   try {
     return await fn(stripe);
   } catch (err) {
     if (isStripeAuthError(err)) {
-      const ck = `org:${orgId}`;
-      console.warn(`Stripe auth error for ${ck} — evicting cached key and retrying`);
-      stripeInstances.delete(ck);
-      const freshStripe = await getStripe(orgId, userId);
+      console.warn("Stripe auth error — evicting cached platform key and retrying");
+      cachedStripe = null;
+      const freshStripe = await getStripe();
       return fn(freshStripe);
     }
     throw err;
@@ -48,7 +44,7 @@ export function isStripeAuthError(err: unknown): boolean {
   return err instanceof Stripe.errors.StripeAuthenticationError;
 }
 
-/** Override Stripe instance for all key sources (tests only). */
+/** Override Stripe instance for tests. */
 export function setStripeInstance(mock: Stripe): void {
   testStripeInstance = mock;
 }
@@ -60,7 +56,7 @@ export async function createCustomer(
   userId: string,
   metadata?: Record<string, string>
 ): Promise<Stripe.Customer> {
-  return withAuthRetry(orgId, userId, (stripe) =>
+  return withAuthRetry((stripe) =>
     stripe.customers.create({
       metadata: { org_id: orgId, ...metadata },
     })
@@ -72,7 +68,7 @@ export async function getCustomer(
   userId: string,
   stripeCustomerId: string
 ): Promise<Stripe.Customer> {
-  return withAuthRetry(orgId, userId, (stripe) =>
+  return withAuthRetry((stripe) =>
     stripe.customers.retrieve(stripeCustomerId) as Promise<Stripe.Customer>
   );
 }
@@ -95,7 +91,7 @@ export async function createBalanceTransaction(
   description: string,
   metadata?: Record<string, string>
 ): Promise<Stripe.CustomerBalanceTransaction> {
-  return withAuthRetry(orgId, userId, (stripe) =>
+  return withAuthRetry((stripe) =>
     stripe.customers.createBalanceTransaction(stripeCustomerId, {
       amount: amountCents,
       currency: "usd",
@@ -111,7 +107,7 @@ export async function listBalanceTransactions(
   stripeCustomerId: string,
   limit = 50
 ): Promise<Stripe.ApiList<Stripe.CustomerBalanceTransaction>> {
-  return withAuthRetry(orgId, userId, (stripe) =>
+  return withAuthRetry((stripe) =>
     stripe.customers.listBalanceTransactions(stripeCustomerId, {
       limit,
     })
@@ -128,7 +124,7 @@ export async function createCheckoutSession(
   cancelUrl: string,
   reloadAmountCents: number
 ): Promise<Stripe.Checkout.Session> {
-  return withAuthRetry(orgId, userId, (stripe) =>
+  return withAuthRetry((stripe) =>
     stripe.checkout.sessions.create({
       customer: stripeCustomerId,
       mode: "payment",
@@ -164,7 +160,7 @@ export async function chargePaymentMethod(
   amountCents: number,
   description: string
 ): Promise<Stripe.PaymentIntent> {
-  return withAuthRetry(orgId, userId, (stripe) =>
+  return withAuthRetry((stripe) =>
     stripe.paymentIntents.create({
       amount: amountCents,
       currency: "usd",
@@ -185,16 +181,14 @@ export async function constructWebhookEvent(
   payload: Buffer,
   signature: string
 ): Promise<Stripe.Event> {
-  let secret = webhookSecrets.get(orgId);
-  if (!secret) {
-    const result = await resolveProviderKey("stripe-webhook", orgId, "system", {
+  if (!cachedWebhookSecret) {
+    const result = await resolvePlatformKey("stripe-webhook", {
       service: "billing",
       method: "POST",
       path: "/v1/webhooks/stripe",
     });
-    secret = result.key;
-    webhookSecrets.set(orgId, secret);
+    cachedWebhookSecret = result.key;
   }
-  const stripe = await getStripe(orgId, "system");
-  return stripe.webhooks.constructEvent(payload, signature, secret);
+  const stripe = await getStripe();
+  return stripe.webhooks.constructEvent(payload, signature, cachedWebhookSecret);
 }

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -38,9 +38,9 @@ export function setupStripeMocks() {
       amount: 2000,
     }),
     constructWebhookEvent: vi.fn(),
-    resolveProviderKey: vi.fn().mockResolvedValue({
+    resolvePlatformKey: vi.fn().mockResolvedValue({
+      provider: "stripe",
       key: "sk_test_mock_key",
-      keySource: "platform",
     }),
     isStripeAuthError: vi.fn().mockImplementation(
       (err: unknown) => err instanceof Stripe.errors.StripeAuthenticationError
@@ -48,7 +48,7 @@ export function setupStripeMocks() {
   };
 
   // Mock key-service so Stripe never actually calls it
-  vi.spyOn(keyClient, "resolveProviderKey").mockImplementation(mocks.resolveProviderKey);
+  vi.spyOn(keyClient, "resolvePlatformKey").mockImplementation(mocks.resolvePlatformKey);
 
   vi.spyOn(stripeLib, "createCustomer").mockImplementation(mocks.createCustomer);
   vi.spyOn(stripeLib, "createBalanceTransaction").mockImplementation(

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -5,39 +5,38 @@ const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
 // Now import the module — it will pick up the stubbed fetch
-import { resolveProviderKey } from "../../src/lib/key-client.js";
+import { resolvePlatformKey } from "../../src/lib/key-client.js";
 
-describe("resolveProviderKey", () => {
+describe("resolvePlatformKey", () => {
   beforeEach(() => {
     mockFetch.mockReset();
   });
 
-  it("sends correct URL with orgId and userId query params", async () => {
+  it("calls GET /keys/platform/{provider}/decrypt with no query params", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ key: "sk_test_123", keySource: "platform" }),
+      json: () => Promise.resolve({ provider: "stripe", key: "sk_test_123" }),
     });
 
-    const result = await resolveProviderKey("stripe", "org-uuid-abc", "user-uuid-123", {
+    const result = await resolvePlatformKey("stripe", {
       service: "billing",
       method: "GET",
       path: "/v1/accounts",
     });
 
-    expect(result).toEqual({ key: "sk_test_123", keySource: "platform" });
+    expect(result).toEqual({ provider: "stripe", key: "sk_test_123" });
     const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("/keys/stripe/decrypt?");
-    expect(url).toContain("orgId=org-uuid-abc");
-    expect(url).toContain("userId=user-uuid-123");
+    expect(url).toContain("/keys/platform/stripe/decrypt");
+    expect(url).not.toContain("?"); // no query params
   });
 
   it("sends x-caller-service, x-caller-method, x-caller-path headers", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ key: "sk_test_123", keySource: "org" }),
+      json: () => Promise.resolve({ provider: "stripe", key: "sk_test_123" }),
     });
 
-    await resolveProviderKey("stripe", "org-123", "user-456", {
+    await resolvePlatformKey("stripe", {
       service: "billing",
       method: "POST",
       path: "/v1/credits/deduct",
@@ -58,10 +57,10 @@ describe("resolveProviderKey", () => {
   it("uses default caller context when none provided", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ key: "sk_test_456", keySource: "platform" }),
+      json: () => Promise.resolve({ provider: "stripe", key: "sk_test_456" }),
     });
 
-    await resolveProviderKey("stripe", "org-123", "user-456");
+    await resolvePlatformKey("stripe");
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -82,40 +81,30 @@ describe("resolveProviderKey", () => {
       text: () => Promise.resolve("Key not found"),
     });
 
-    await expect(resolveProviderKey("stripe", "org-unknown", "user-123")).rejects.toThrow(
-      "Failed to resolve stripe key for org org-unknown: 404"
+    await expect(resolvePlatformKey("stripe")).rejects.toThrow(
+      "Failed to resolve platform key for stripe: 404"
     );
-  });
-
-  it("returns keySource 'org' when org key is used", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ key: "sk_org_key", keySource: "org" }),
-    });
-
-    const result = await resolveProviderKey("stripe", "org-123", "user-456");
-    expect(result.keySource).toBe("org");
   });
 
   it("encodes provider name in URL", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ key: "whsec_123", keySource: "platform" }),
+      json: () => Promise.resolve({ provider: "stripe-webhook", key: "whsec_123" }),
     });
 
-    await resolveProviderKey("stripe-webhook", "org-123", "user-456");
+    await resolvePlatformKey("stripe-webhook");
 
     const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("/keys/stripe-webhook/decrypt?");
+    expect(url).toContain("/keys/platform/stripe-webhook/decrypt");
   });
 
   it("sends x-api-key header", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ key: "sk_test", keySource: "platform" }),
+      json: () => Promise.resolve({ provider: "stripe", key: "sk_test" }),
     });
 
-    await resolveProviderKey("stripe", "org-123", "user-456");
+    await resolvePlatformKey("stripe");
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),

--- a/tests/unit/stripe.test.ts
+++ b/tests/unit/stripe.test.ts
@@ -1,19 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import Stripe from "stripe";
 
-describe("Stripe key resolution", () => {
+describe("Stripe platform key resolution", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.resetModules();
   });
 
-  it("resolves Stripe key via resolveProviderKey with orgId and userId", async () => {
-    const mockResolveProviderKey = vi.fn().mockResolvedValue({
+  it("resolves Stripe key via resolvePlatformKey (no orgId/userId)", async () => {
+    const mockResolvePlatformKey = vi.fn().mockResolvedValue({
+      provider: "stripe",
       key: "sk_test_mock",
-      keySource: "platform",
     });
     vi.doMock("../../src/lib/key-client.js", () => ({
-      resolveProviderKey: mockResolveProviderKey,
+      resolvePlatformKey: mockResolvePlatformKey,
     }));
 
     const { createCustomer } = await import("../../src/lib/stripe.js");
@@ -24,18 +24,16 @@ describe("Stripe key resolution", () => {
       // Stripe constructor may throw with mock key — that's fine
     }
 
-    expect(mockResolveProviderKey).toHaveBeenCalledWith(
-      "stripe", "org-123", "user-456"
-    );
+    expect(mockResolvePlatformKey).toHaveBeenCalledWith("stripe");
   });
 
-  it("caches Stripe instance by orgId", async () => {
-    const mockResolveProviderKey = vi.fn().mockResolvedValue({
+  it("caches Stripe instance (single platform key)", async () => {
+    const mockResolvePlatformKey = vi.fn().mockResolvedValue({
+      provider: "stripe",
       key: "sk_test_cached",
-      keySource: "platform",
     });
     vi.doMock("../../src/lib/key-client.js", () => ({
-      resolveProviderKey: mockResolveProviderKey,
+      resolvePlatformKey: mockResolvePlatformKey,
     }));
 
     // Mock Stripe constructor to avoid real API calls that trigger auth errors
@@ -51,18 +49,18 @@ describe("Stripe key resolution", () => {
     const { createCustomer } = await import("../../src/lib/stripe.js");
 
     await createCustomer("org-123", "user-456");
-    await createCustomer("org-123", "user-456");
+    await createCustomer("org-999", "user-000");
 
-    // Key should be resolved only once (cached)
-    expect(mockResolveProviderKey).toHaveBeenCalledTimes(1);
+    // Key should be resolved only once — platform key is global
+    expect(mockResolvePlatformKey).toHaveBeenCalledTimes(1);
   });
 
   it("evicts cached Stripe instance on auth error and retries with fresh key", async () => {
-    const mockResolveProviderKey = vi.fn()
-      .mockResolvedValueOnce({ key: "sk_expired_key", keySource: "platform" })
-      .mockResolvedValueOnce({ key: "sk_fresh_key", keySource: "platform" });
+    const mockResolvePlatformKey = vi.fn()
+      .mockResolvedValueOnce({ provider: "stripe", key: "sk_expired_key" })
+      .mockResolvedValueOnce({ provider: "stripe", key: "sk_fresh_key" });
     vi.doMock("../../src/lib/key-client.js", () => ({
-      resolveProviderKey: mockResolveProviderKey,
+      resolvePlatformKey: mockResolvePlatformKey,
     }));
 
     const { createCustomer } = await import("../../src/lib/stripe.js");
@@ -74,7 +72,7 @@ describe("Stripe key resolution", () => {
     }
 
     // Key was resolved at least once
-    expect(mockResolveProviderKey).toHaveBeenCalledWith("stripe", "org-123", "user-456");
+    expect(mockResolvePlatformKey).toHaveBeenCalledWith("stripe");
   });
 });
 


### PR DESCRIPTION
## Summary
- Switch key resolution from generic `GET /keys/:provider/decrypt?orgId=&userId=` to dedicated `GET /keys/platform/:provider/decrypt`
- Billing-service only uses platform Stripe keys — the explicit endpoint is semantically correct and needs no query params
- Simplify Stripe instance cache from `Map<string, Stripe>` (per-org) to single global instance (one platform key)
- Rename `resolveProviderKey` → `resolvePlatformKey` across codebase

## Test plan
- [x] All 72 tests pass (9 test files)
- [x] TypeScript strict mode compiles cleanly
- [x] Caching test verifies single `resolvePlatformKey` call across different orgIds

🤖 Generated with [Claude Code](https://claude.com/claude-code)