### PR TITLE
Forward required identity headers to key-service

### DIFF
--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -4,6 +4,11 @@ export interface CallerContext {
   path: string;
 }
 
+export interface IdentityContext {
+  orgId: string;
+  userId: string;
+}
+
 export interface PlatformKeyResponse {
   provider: string;
   key: string;
@@ -22,9 +27,10 @@ function getKeyServiceConfig() {
   return { url, apiKey };
 }
 
-/** Resolve a platform key from key-service. Platform keys are global — no orgId/userId needed. */
+/** Resolve a platform key from key-service. Forwards identity headers required by key-service. */
 export async function resolvePlatformKey(
   provider: string,
+  identity: IdentityContext,
   caller: CallerContext = DEFAULT_CALLER
 ): Promise<PlatformKeyResponse> {
   const config = getKeyServiceConfig();
@@ -37,6 +43,8 @@ export async function resolvePlatformKey(
     {
       headers: {
         "x-api-key": config.apiKey,
+        "x-org-id": identity.orgId,
+        "x-user-id": identity.userId,
         "x-caller-service": caller.service,
         "x-caller-method": caller.method,
         "x-caller-path": caller.path,

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,5 +1,5 @@
 import Stripe from "stripe";
-import { resolvePlatformKey } from "./key-client.js";
+import { resolvePlatformKey, type IdentityContext } from "./key-client.js";
 
 // --- Single Stripe instance (platform key is global) ---
 
@@ -9,11 +9,11 @@ let cachedWebhookSecret: string | null = null;
 // Test override
 let testStripeInstance: Stripe | null = null;
 
-async function getStripe(): Promise<Stripe> {
+async function getStripe(identity: IdentityContext): Promise<Stripe> {
   if (testStripeInstance) return testStripeInstance;
 
   if (!cachedStripe) {
-    const { key } = await resolvePlatformKey("stripe");
+    const { key } = await resolvePlatformKey("stripe", identity);
     cachedStripe = new Stripe(key, { apiVersion: "2024-12-18.acacia" as Stripe.LatestApiVersion });
   }
   return cachedStripe;
@@ -24,15 +24,15 @@ async function getStripe(): Promise<Stripe> {
  * If the Stripe key is expired/invalid, evicts the cached instance and retries
  * once with a freshly resolved key from key-service.
  */
-async function withAuthRetry<T>(fn: (stripe: Stripe) => Promise<T>): Promise<T> {
-  const stripe = await getStripe();
+async function withAuthRetry<T>(identity: IdentityContext, fn: (stripe: Stripe) => Promise<T>): Promise<T> {
+  const stripe = await getStripe(identity);
   try {
     return await fn(stripe);
   } catch (err) {
     if (isStripeAuthError(err)) {
       console.warn("Stripe auth error — evicting cached platform key and retrying");
       cachedStripe = null;
-      const freshStripe = await getStripe();
+      const freshStripe = await getStripe(identity);
       return fn(freshStripe);
     }
     throw err;
@@ -56,7 +56,7 @@ export async function createCustomer(
   userId: string,
   metadata?: Record<string, string>
 ): Promise<Stripe.Customer> {
-  return withAuthRetry((stripe) =>
+  return withAuthRetry({ orgId, userId }, (stripe) =>
     stripe.customers.create({
       metadata: { org_id: orgId, ...metadata },
     })
@@ -68,7 +68,7 @@ export async function getCustomer(
   userId: string,
   stripeCustomerId: string
 ): Promise<Stripe.Customer> {
-  return withAuthRetry((stripe) =>
+  return withAuthRetry({ orgId, userId }, (stripe) =>
     stripe.customers.retrieve(stripeCustomerId) as Promise<Stripe.Customer>
   );
 }
@@ -91,7 +91,7 @@ export async function createBalanceTransaction(
   description: string,
   metadata?: Record<string, string>
 ): Promise<Stripe.CustomerBalanceTransaction> {
-  return withAuthRetry((stripe) =>
+  return withAuthRetry({ orgId, userId }, (stripe) =>
     stripe.customers.createBalanceTransaction(stripeCustomerId, {
       amount: amountCents,
       currency: "usd",
@@ -107,7 +107,7 @@ export async function listBalanceTransactions(
   stripeCustomerId: string,
   limit = 50
 ): Promise<Stripe.ApiList<Stripe.CustomerBalanceTransaction>> {
-  return withAuthRetry((stripe) =>
+  return withAuthRetry({ orgId, userId }, (stripe) =>
     stripe.customers.listBalanceTransactions(stripeCustomerId, {
       limit,
     })
@@ -124,7 +124,7 @@ export async function createCheckoutSession(
   cancelUrl: string,
   reloadAmountCents: number
 ): Promise<Stripe.Checkout.Session> {
-  return withAuthRetry((stripe) =>
+  return withAuthRetry({ orgId, userId }, (stripe) =>
     stripe.checkout.sessions.create({
       customer: stripeCustomerId,
       mode: "payment",
@@ -160,7 +160,7 @@ export async function chargePaymentMethod(
   amountCents: number,
   description: string
 ): Promise<Stripe.PaymentIntent> {
-  return withAuthRetry((stripe) =>
+  return withAuthRetry({ orgId, userId }, (stripe) =>
     stripe.paymentIntents.create({
       amount: amountCents,
       currency: "usd",
@@ -181,14 +181,16 @@ export async function constructWebhookEvent(
   payload: Buffer,
   signature: string
 ): Promise<Stripe.Event> {
+  // Webhook calls come from Stripe, not from users — use "system" as userId
+  const identity: IdentityContext = { orgId, userId: "system" };
   if (!cachedWebhookSecret) {
-    const result = await resolvePlatformKey("stripe-webhook", {
+    const result = await resolvePlatformKey("stripe-webhook", identity, {
       service: "billing",
       method: "POST",
       path: "/v1/webhooks/stripe",
     });
     cachedWebhookSecret = result.key;
   }
-  const stripe = await getStripe();
+  const stripe = await getStripe(identity);
   return stripe.webhooks.constructEvent(payload, signature, cachedWebhookSecret);
 }

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -7,6 +7,8 @@ vi.stubGlobal("fetch", mockFetch);
 // Now import the module — it will pick up the stubbed fetch
 import { resolvePlatformKey } from "../../src/lib/key-client.js";
 
+const TEST_IDENTITY = { orgId: "org-123", userId: "user-456" };
+
 describe("resolvePlatformKey", () => {
   beforeEach(() => {
     mockFetch.mockReset();
@@ -18,7 +20,7 @@ describe("resolvePlatformKey", () => {
       json: () => Promise.resolve({ provider: "stripe", key: "sk_test_123" }),
     });
 
-    const result = await resolvePlatformKey("stripe", {
+    const result = await resolvePlatformKey("stripe", TEST_IDENTITY, {
       service: "billing",
       method: "GET",
       path: "/v1/accounts",
@@ -30,13 +32,32 @@ describe("resolvePlatformKey", () => {
     expect(url).not.toContain("?"); // no query params
   });
 
+  it("sends x-org-id and x-user-id headers", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "stripe", key: "sk_test_123" }),
+    });
+
+    await resolvePlatformKey("stripe", TEST_IDENTITY);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-org-id": "org-123",
+          "x-user-id": "user-456",
+        }),
+      })
+    );
+  });
+
   it("sends x-caller-service, x-caller-method, x-caller-path headers", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ provider: "stripe", key: "sk_test_123" }),
     });
 
-    await resolvePlatformKey("stripe", {
+    await resolvePlatformKey("stripe", TEST_IDENTITY, {
       service: "billing",
       method: "POST",
       path: "/v1/credits/deduct",
@@ -60,7 +81,7 @@ describe("resolvePlatformKey", () => {
       json: () => Promise.resolve({ provider: "stripe", key: "sk_test_456" }),
     });
 
-    await resolvePlatformKey("stripe");
+    await resolvePlatformKey("stripe", TEST_IDENTITY);
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -81,7 +102,7 @@ describe("resolvePlatformKey", () => {
       text: () => Promise.resolve("Key not found"),
     });
 
-    await expect(resolvePlatformKey("stripe")).rejects.toThrow(
+    await expect(resolvePlatformKey("stripe", TEST_IDENTITY)).rejects.toThrow(
       "Failed to resolve platform key for stripe: 404"
     );
   });
@@ -92,7 +113,7 @@ describe("resolvePlatformKey", () => {
       json: () => Promise.resolve({ provider: "stripe-webhook", key: "whsec_123" }),
     });
 
-    await resolvePlatformKey("stripe-webhook");
+    await resolvePlatformKey("stripe-webhook", TEST_IDENTITY);
 
     const url = mockFetch.mock.calls[0][0] as string;
     expect(url).toContain("/keys/platform/stripe-webhook/decrypt");
@@ -104,7 +125,7 @@ describe("resolvePlatformKey", () => {
       json: () => Promise.resolve({ provider: "stripe", key: "sk_test" }),
     });
 
-    await resolvePlatformKey("stripe");
+    await resolvePlatformKey("stripe", TEST_IDENTITY);
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.any(String),

--- a/tests/unit/stripe.test.ts
+++ b/tests/unit/stripe.test.ts
@@ -7,7 +7,7 @@ describe("Stripe platform key resolution", () => {
     vi.resetModules();
   });
 
-  it("resolves Stripe key via resolvePlatformKey (no orgId/userId)", async () => {
+  it("resolves Stripe key via resolvePlatformKey with identity context", async () => {
     const mockResolvePlatformKey = vi.fn().mockResolvedValue({
       provider: "stripe",
       key: "sk_test_mock",
@@ -24,7 +24,10 @@ describe("Stripe platform key resolution", () => {
       // Stripe constructor may throw with mock key — that's fine
     }
 
-    expect(mockResolvePlatformKey).toHaveBeenCalledWith("stripe");
+    expect(mockResolvePlatformKey).toHaveBeenCalledWith(
+      "stripe",
+      { orgId: "org-123", userId: "user-456" }
+    );
   });
 
   it("caches Stripe instance (single platform key)", async () => {
@@ -71,8 +74,46 @@ describe("Stripe platform key resolution", () => {
       // Expected — mock key can't actually reach Stripe
     }
 
-    // Key was resolved at least once
-    expect(mockResolvePlatformKey).toHaveBeenCalledWith("stripe");
+    // Key was resolved with identity context
+    expect(mockResolvePlatformKey).toHaveBeenCalledWith(
+      "stripe",
+      { orgId: "org-123", userId: "user-456" }
+    );
+  });
+
+  it("webhook uses orgId and 'system' userId for identity context", async () => {
+    const mockResolvePlatformKey = vi.fn().mockResolvedValue({
+      provider: "stripe-webhook",
+      key: "whsec_test",
+    });
+    vi.doMock("../../src/lib/key-client.js", () => ({
+      resolvePlatformKey: mockResolvePlatformKey,
+    }));
+
+    // Mock Stripe constructor
+    vi.doMock("stripe", () => {
+      const MockStripe = function () {
+        return {
+          customers: { create: vi.fn() },
+          webhooks: {
+            constructEvent: vi.fn().mockReturnValue({ type: "test", data: {} }),
+          },
+        };
+      };
+      MockStripe.errors = Stripe.errors;
+      return { default: MockStripe };
+    });
+
+    const { constructWebhookEvent } = await import("../../src/lib/stripe.js");
+
+    await constructWebhookEvent("org-webhook", Buffer.from("{}"), "sig_test");
+
+    // Webhook secret resolution should use orgId from param and "system" userId
+    expect(mockResolvePlatformKey).toHaveBeenCalledWith(
+      "stripe-webhook",
+      { orgId: "org-webhook", userId: "system" },
+      { service: "billing", method: "POST", path: "/v1/webhooks/stripe" }
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- key-service now requires `x-org-id` and `x-user-id` headers on `/keys/platform/{provider}/decrypt`
- Added `IdentityContext` (`orgId`, `userId`) parameter to `resolvePlatformKey()` and threaded it through `getStripe()` / `withAuthRetry()` in the Stripe wrapper
- Webhook calls (Stripe-initiated, no user context) use `"system"` as the userId since platform keys are global
- Added new test coverage for identity header forwarding and webhook identity context

## Test plan
- [x] All 74 existing tests pass (9 test files)
- [x] New unit test verifies `x-org-id` and `x-user-id` are sent on key-service calls
- [x] New unit test verifies webhook uses `orgId` from param + `"system"` userId
- [x] Integration tests confirm no regressions in accounts, credits, checkout, webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)