### PR TITLE
Accept and forward workflow-tracking headers

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -319,6 +319,33 @@
             "required": true,
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "responses": {
@@ -393,6 +420,33 @@
             "required": true,
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "responses": {
@@ -446,6 +500,33 @@
             },
             "required": true,
             "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
             "in": "header"
           }
         ],
@@ -510,6 +591,33 @@
             },
             "required": true,
             "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
             "in": "header"
           }
         ],
@@ -584,6 +692,33 @@
             "required": true,
             "name": "x-run-id",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -656,6 +791,33 @@
             },
             "required": true,
             "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
             "in": "header"
           }
         ],

--- a/src/lib/key-client.ts
+++ b/src/lib/key-client.ts
@@ -7,6 +7,7 @@ export interface CallerContext {
 export interface IdentityContext {
   orgId: string;
   userId: string;
+  workflowHeaders?: Record<string, string>;
 }
 
 export interface PlatformKeyResponse {
@@ -48,6 +49,7 @@ export async function resolvePlatformKey(
         "x-caller-service": caller.service,
         "x-caller-method": caller.method,
         "x-caller-path": caller.path,
+        ...identity.workflowHeaders,
       },
     }
   );

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -9,6 +9,10 @@ let cachedWebhookSecret: string | null = null;
 // Test override
 let testStripeInstance: Stripe | null = null;
 
+function buildIdentity(orgId: string, userId: string, workflowHeaders?: Record<string, string>): IdentityContext {
+  return { orgId, userId, workflowHeaders };
+}
+
 async function getStripe(identity: IdentityContext): Promise<Stripe> {
   if (testStripeInstance) return testStripeInstance;
 
@@ -54,9 +58,10 @@ export function setStripeInstance(mock: Stripe): void {
 export async function createCustomer(
   orgId: string,
   userId: string,
-  metadata?: Record<string, string>
+  metadata?: Record<string, string>,
+  workflowHeaders?: Record<string, string>
 ): Promise<Stripe.Customer> {
-  return withAuthRetry({ orgId, userId }, (stripe) =>
+  return withAuthRetry(buildIdentity(orgId, userId, workflowHeaders), (stripe) =>
     stripe.customers.create({
       metadata: { org_id: orgId, ...metadata },
     })
@@ -66,9 +71,10 @@ export async function createCustomer(
 export async function getCustomer(
   orgId: string,
   userId: string,
-  stripeCustomerId: string
+  stripeCustomerId: string,
+  workflowHeaders?: Record<string, string>
 ): Promise<Stripe.Customer> {
-  return withAuthRetry({ orgId, userId }, (stripe) =>
+  return withAuthRetry(buildIdentity(orgId, userId, workflowHeaders), (stripe) =>
     stripe.customers.retrieve(stripeCustomerId) as Promise<Stripe.Customer>
   );
 }
@@ -89,9 +95,10 @@ export async function createBalanceTransaction(
   stripeCustomerId: string,
   amountCents: number,
   description: string,
-  metadata?: Record<string, string>
+  metadata?: Record<string, string>,
+  workflowHeaders?: Record<string, string>
 ): Promise<Stripe.CustomerBalanceTransaction> {
-  return withAuthRetry({ orgId, userId }, (stripe) =>
+  return withAuthRetry(buildIdentity(orgId, userId, workflowHeaders), (stripe) =>
     stripe.customers.createBalanceTransaction(stripeCustomerId, {
       amount: amountCents,
       currency: "usd",
@@ -105,9 +112,10 @@ export async function listBalanceTransactions(
   orgId: string,
   userId: string,
   stripeCustomerId: string,
-  limit = 50
+  limit = 50,
+  workflowHeaders?: Record<string, string>
 ): Promise<Stripe.ApiList<Stripe.CustomerBalanceTransaction>> {
-  return withAuthRetry({ orgId, userId }, (stripe) =>
+  return withAuthRetry(buildIdentity(orgId, userId, workflowHeaders), (stripe) =>
     stripe.customers.listBalanceTransactions(stripeCustomerId, {
       limit,
     })
@@ -122,9 +130,10 @@ export async function createCheckoutSession(
   stripeCustomerId: string,
   successUrl: string,
   cancelUrl: string,
-  reloadAmountCents: number
+  reloadAmountCents: number,
+  workflowHeaders?: Record<string, string>
 ): Promise<Stripe.Checkout.Session> {
-  return withAuthRetry({ orgId, userId }, (stripe) =>
+  return withAuthRetry(buildIdentity(orgId, userId, workflowHeaders), (stripe) =>
     stripe.checkout.sessions.create({
       customer: stripeCustomerId,
       mode: "payment",
@@ -158,9 +167,10 @@ export async function chargePaymentMethod(
   stripeCustomerId: string,
   paymentMethodId: string,
   amountCents: number,
-  description: string
+  description: string,
+  workflowHeaders?: Record<string, string>
 ): Promise<Stripe.PaymentIntent> {
-  return withAuthRetry({ orgId, userId }, (stripe) =>
+  return withAuthRetry(buildIdentity(orgId, userId, workflowHeaders), (stripe) =>
     stripe.paymentIntents.create({
       amount: amountCents,
       currency: "usd",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,5 +1,29 @@
 import { Request, Response, NextFunction } from "express";
 
+export interface WorkflowHeaders {
+  campaignId?: string;
+  brandId?: string;
+  workflowName?: string;
+}
+
+/** Extract optional workflow-tracking headers injected by workflow-service. */
+export function getWorkflowHeaders(req: Request): WorkflowHeaders {
+  return {
+    campaignId: req.headers["x-campaign-id"] as string | undefined,
+    brandId: req.headers["x-brand-id"] as string | undefined,
+    workflowName: req.headers["x-workflow-name"] as string | undefined,
+  };
+}
+
+/** Build a header record for forwarding workflow headers to downstream services. */
+export function forwardWorkflowHeaders(wf: WorkflowHeaders): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (wf.campaignId) headers["x-campaign-id"] = wf.campaignId;
+  if (wf.brandId) headers["x-brand-id"] = wf.brandId;
+  if (wf.workflowName) headers["x-workflow-name"] = wf.workflowName;
+  return headers;
+}
+
 export function requireApiKey(
   req: Request,
   res: Response,

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { billingAccounts } from "../db/schema.js";
-import { requireOrgHeaders } from "../middleware/auth.js";
+import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import {
   UpdateModeRequestSchema,
   BillingModeSchema,
@@ -35,6 +35,7 @@ router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
+    const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
 
     // Try to find existing account
     const existing = await db
@@ -49,7 +50,7 @@ router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
     }
 
     // Auto-create: Stripe customer + $2 trial credit
-    const stripeCustomer = await createCustomer(orgId, userId);
+    const stripeCustomer = await createCustomer(orgId, userId, undefined, wfHeaders);
 
     // Credit $2 (negative amount = credit in Stripe)
     await createBalanceTransaction(
@@ -57,7 +58,9 @@ router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
       userId,
       stripeCustomer.id,
       -200,
-      "Trial credit: $2.00"
+      "Trial credit: $2.00",
+      undefined,
+      wfHeaders
     );
 
     // Insert with ON CONFLICT for race condition safety
@@ -129,6 +132,7 @@ router.get(
     try {
       const orgId = req.headers["x-org-id"] as string;
       const userId = req.headers["x-user-id"] as string;
+      const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
 
       const [account] = await db
         .select()
@@ -146,7 +150,7 @@ router.get(
         return;
       }
 
-      const result = await listBalanceTransactions(orgId, userId, account.stripeCustomerId);
+      const result = await listBalanceTransactions(orgId, userId, account.stripeCustomerId, 50, wfHeaders);
 
       const transactions = result.data.map((txn) => ({
         id: txn.id,

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { billingAccounts } from "../db/schema.js";
-import { requireOrgHeaders } from "../middleware/auth.js";
+import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { CreateCheckoutRequestSchema } from "../schemas.js";
 import { createCustomer, createCheckoutSession, isStripeAuthError } from "../lib/stripe.js";
 
@@ -13,6 +13,7 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
+    const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
     const parsed = CreateCheckoutRequestSchema.safeParse(req.body);
 
     if (!parsed.success) {
@@ -32,7 +33,7 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
 
     if (!account) {
       // Auto-create account with Stripe customer
-      const stripeCustomer = await createCustomer(orgId, userId);
+      const stripeCustomer = await createCustomer(orgId, userId, undefined, wfHeaders);
 
       const [created] = await db
         .insert(billingAccounts)
@@ -55,7 +56,7 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
 
     if (!account.stripeCustomerId) {
       // Account exists but no Stripe customer — create one
-      const stripeCustomer = await createCustomer(orgId, userId);
+      const stripeCustomer = await createCustomer(orgId, userId, undefined, wfHeaders);
       [account] = await db
         .update(billingAccounts)
         .set({
@@ -72,7 +73,8 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
       account.stripeCustomerId!,
       success_url,
       cancel_url,
-      reload_amount_cents
+      reload_amount_cents,
+      wfHeaders
     );
 
     // Store the reload amount for when checkout completes

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { eq, sql as rawSql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { billingAccounts } from "../db/schema.js";
-import { requireOrgHeaders } from "../middleware/auth.js";
+import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { DeductRequestSchema } from "../schemas.js";
 import {
   createBalanceTransaction,
@@ -17,6 +17,7 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
+    const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
     const parsed = DeductRequestSchema.safeParse(req.body);
 
     if (!parsed.success) {
@@ -85,7 +86,8 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
               account.stripe_customer_id,
               account.stripe_payment_method_id,
               account.reload_amount_cents,
-              "Auto-reload"
+              "Auto-reload",
+              wfHeaders
             );
 
             // Credit the Stripe balance
@@ -94,7 +96,9 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
               userId,
               account.stripe_customer_id,
               -account.reload_amount_cents,
-              "Auto-reload credit"
+              "Auto-reload credit",
+              undefined,
+              wfHeaders
             );
 
             // Update local cache
@@ -146,7 +150,8 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
           account.stripe_customer_id,
           amount_cents, // positive = deduction in Stripe
           description,
-          { user_id: userId }
+          { user_id: userId },
+          wfHeaders
         ).catch((err) => {
           console.error("Stripe balance transaction failed (async):", err);
         });
@@ -168,8 +173,8 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
         // Fire auto-reload async (non-blocking)
         (async () => {
           try {
-            await chargePaymentMethod(orgId, userId, customerId, pmId, reloadAmount, "Auto-reload");
-            await createBalanceTransaction(orgId, userId, customerId, -reloadAmount, "Auto-reload credit");
+            await chargePaymentMethod(orgId, userId, customerId, pmId, reloadAmount, "Auto-reload", wfHeaders);
+            await createBalanceTransaction(orgId, userId, customerId, -reloadAmount, "Auto-reload credit", undefined, wfHeaders);
             await db
               .update(billingAccounts)
               .set({

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -113,6 +113,9 @@ const protectedHeaders = z.object({
   "x-org-id": z.string().uuid(),
   "x-user-id": z.string().uuid(),
   "x-run-id": z.string().uuid(),
+  "x-campaign-id": z.string().optional().openapi({ description: "Campaign ID injected by workflow-service" }),
+  "x-brand-id": z.string().optional().openapi({ description: "Brand ID injected by workflow-service" }),
+  "x-workflow-name": z.string().optional().openapi({ description: "Workflow name injected by workflow-service" }),
 });
 
 registry.registerPath({

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -35,14 +35,41 @@ describe("Accounts endpoints", () => {
       expect(res.body).not.toHaveProperty("appId");
       expect(stripeMocks.createCustomer).toHaveBeenCalledWith(
         orgId,
-        userId
+        userId,
+        undefined,
+        {}
       );
       expect(stripeMocks.createBalanceTransaction).toHaveBeenCalledWith(
         orgId,
         userId,
         "cus_mock123",
         -200,
-        "Trial credit: $2.00"
+        "Trial credit: $2.00",
+        undefined,
+        {}
+      );
+    });
+
+    it("forwards workflow headers to downstream calls", async () => {
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set({
+          ...getAuthHeaders(orgId),
+          "x-campaign-id": "camp_42",
+          "x-brand-id": "brand_7",
+          "x-workflow-name": "onboarding-flow",
+        });
+
+      expect(res.status).toBe(200);
+      expect(stripeMocks.createCustomer).toHaveBeenCalledWith(
+        orgId,
+        userId,
+        undefined,
+        {
+          "x-campaign-id": "camp_42",
+          "x-brand-id": "brand_7",
+          "x-workflow-name": "onboarding-flow",
+        }
       );
     });
 

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -45,7 +45,8 @@ describe("Checkout endpoint", () => {
       "cus_123",
       "https://app.example.com/success",
       "https://app.example.com/cancel",
-      2000
+      2000,
+      {}
     );
   });
 

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -120,7 +120,8 @@ describe("Credits deduction endpoint", () => {
       "cus_123",
       "pm_123",
       2000,
-      "Auto-reload"
+      "Auto-reload",
+      {}
     );
   });
 
@@ -197,7 +198,44 @@ describe("Credits deduction endpoint", () => {
       "cus_123",
       5,
       "test deduction",
-      { user_id: userId }
+      { user_id: userId },
+      {}
+    );
+  });
+
+  it("forwards workflow headers to Stripe calls", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_123",
+      creditBalanceCents: 200,
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set({
+        ...getAuthHeaders(orgId),
+        "x-campaign-id": "camp_42",
+        "x-brand-id": "brand_7",
+        "x-workflow-name": "outreach-flow",
+      })
+      .send({
+        amount_cents: 5,
+        description: "test deduction",
+      });
+
+    expect(res.status).toBe(200);
+    expect(stripeMocks.createBalanceTransaction).toHaveBeenCalledWith(
+      orgId,
+      userId,
+      "cus_123",
+      5,
+      "test deduction",
+      { user_id: userId },
+      {
+        "x-campaign-id": "camp_42",
+        "x-brand-id": "brand_7",
+        "x-workflow-name": "outreach-flow",
+      }
     );
   });
 

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -119,6 +119,34 @@ describe("resolvePlatformKey", () => {
     expect(url).toContain("/keys/platform/stripe-webhook/decrypt");
   });
 
+  it("forwards workflow headers to key-service", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ provider: "stripe", key: "sk_test" }),
+    });
+
+    await resolvePlatformKey("stripe", {
+      orgId: "org-123",
+      userId: "user-456",
+      workflowHeaders: {
+        "x-campaign-id": "camp_42",
+        "x-brand-id": "brand_7",
+        "x-workflow-name": "outreach-flow",
+      },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-campaign-id": "camp_42",
+          "x-brand-id": "brand_7",
+          "x-workflow-name": "outreach-flow",
+        }),
+      })
+    );
+  });
+
   it("sends x-api-key header", async () => {
     mockFetch.mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary
- Accept 3 new optional headers injected by workflow-service: `x-campaign-id`, `x-brand-id`, `x-workflow-name`
- Forward them to key-service on all downstream calls
- Declare them in Zod schemas and regenerated `openapi.json`
- No DB changes — `billing_accounts` is account-level, not per-request

## Test plan
- [x] Existing 74 tests pass (assertions updated for new function signatures)
- [x] New test: workflow headers forwarded to Stripe/key-service calls (accounts)
- [x] New test: workflow headers forwarded on credit deduction
- [x] New test: workflow headers forwarded to key-service (unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)