### PR TITLE
Add credit gate: provisions, check, negative balances

### DIFF
--- a/drizzle/0003_add_credit_provisions.sql
+++ b/drizzle/0003_add_credit_provisions.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "credit_provisions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"run_id" uuid,
+	"amount_cents" integer NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"description" text,
+	"campaign_id" text,
+	"brand_id" text,
+	"workflow_name" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_credit_provisions_org_id" ON "credit_provisions" USING btree ("org_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_credit_provisions_status" ON "credit_provisions" USING btree ("status");

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,249 @@
+{
+  "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "prevId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.billing_accounts": {
+      "name": "billing_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_mode": {
+          "name": "billing_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trial'"
+        },
+        "credit_balance_cents": {
+          "name": "credit_balance_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 200
+        },
+        "reload_amount_cents": {
+          "name": "reload_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reload_threshold_cents": {
+          "name": "reload_threshold_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 200
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_accounts_org_id": {
+          "name": "idx_billing_accounts_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_accounts_stripe_customer": {
+          "name": "idx_billing_accounts_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_provisions": {
+      "name": "credit_provisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_provisions_org_id": {
+          "name": "idx_credit_provisions_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_provisions_status": {
+          "name": "idx_credit_provisions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1772697600000,
       "tag": "0002_remove_app_id",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1774243200000,
+      "tag": "0003_add_credit_provisions",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -247,6 +247,159 @@
           "cancel_url",
           "reload_amount_cents"
         ]
+      },
+      "CheckResponse": {
+        "type": "object",
+        "properties": {
+          "sufficient": {
+            "type": "boolean"
+          },
+          "balance_cents": {
+            "type": "integer",
+            "nullable": true
+          },
+          "billing_mode": {
+            "$ref": "#/components/schemas/BillingMode"
+          }
+        },
+        "required": [
+          "sufficient",
+          "balance_cents",
+          "billing_mode"
+        ]
+      },
+      "CheckRequest": {
+        "type": "object",
+        "properties": {
+          "required_cents": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "required_cents"
+        ]
+      },
+      "ProvisionResponse": {
+        "type": "object",
+        "properties": {
+          "provision_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "balance_cents": {
+            "type": "integer",
+            "nullable": true
+          },
+          "billing_mode": {
+            "$ref": "#/components/schemas/BillingMode"
+          },
+          "depleted": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "provision_id",
+          "balance_cents",
+          "billing_mode",
+          "depleted"
+        ]
+      },
+      "ProvisionRequest": {
+        "type": "object",
+        "properties": {
+          "amount_cents": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "amount_cents",
+          "description"
+        ]
+      },
+      "ConfirmProvisionResponse": {
+        "type": "object",
+        "properties": {
+          "provision_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "confirmed"
+            ]
+          },
+          "original_amount_cents": {
+            "type": "integer"
+          },
+          "final_amount_cents": {
+            "type": "integer"
+          },
+          "adjustment_cents": {
+            "type": "integer"
+          },
+          "balance_cents": {
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "required": [
+          "provision_id",
+          "status",
+          "original_amount_cents",
+          "final_amount_cents",
+          "adjustment_cents",
+          "balance_cents"
+        ]
+      },
+      "ConfirmProvisionRequest": {
+        "type": "object",
+        "properties": {
+          "actual_amount_cents": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          }
+        }
+      },
+      "CancelProvisionResponse": {
+        "type": "object",
+        "properties": {
+          "provision_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "cancelled"
+            ]
+          },
+          "refunded_cents": {
+            "type": "integer"
+          },
+          "balance_cents": {
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "required": [
+          "provision_id",
+          "status",
+          "refunded_cents",
+          "balance_cents"
+        ]
       }
     },
     "parameters": {}
@@ -843,6 +996,445 @@
           },
           "502": {
             "description": "Payment provider authentication failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/credits/check": {
+      "post": {
+        "summary": "Pre-execution balance check (service-to-service). Sends depleted email if insufficient.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CheckRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Balance check result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Billing account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/credits/provision": {
+      "post": {
+        "summary": "Provision credits (deduct immediately, confirm or cancel later)",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProvisionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Provision created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvisionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Billing account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Payment provider authentication failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/credits/provision/{id}/confirm": {
+      "post": {
+        "summary": "Confirm a pending provision, optionally adjusting for actual cost",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmProvisionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Provision confirmed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfirmProvisionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Provision not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Provision already confirmed or cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/credits/provision/{id}/cancel": {
+      "post": {
+        "summary": "Cancel a pending provision, re-crediting the provisioned amount",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Provision cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelProvisionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Provision not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Provision already confirmed or cancelled",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -34,3 +34,32 @@ export const billingAccounts = pgTable(
 
 export type BillingAccount = typeof billingAccounts.$inferSelect;
 export type NewBillingAccount = typeof billingAccounts.$inferInsert;
+
+export const creditProvisions = pgTable(
+  "credit_provisions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id").notNull(),
+    userId: uuid("user_id").notNull(),
+    runId: uuid("run_id"),
+    amountCents: integer("amount_cents").notNull(),
+    status: text("status").notNull().default("pending"),
+    description: text("description"),
+    campaignId: text("campaign_id"),
+    brandId: text("brand_id"),
+    workflowName: text("workflow_name"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("idx_credit_provisions_org_id").on(table.orgId),
+    index("idx_credit_provisions_status").on(table.status),
+  ]
+);
+
+export type CreditProvision = typeof creditProvisions.$inferSelect;
+export type NewCreditProvision = typeof creditProvisions.$inferInsert;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { db } from "./db/index.js";
 import healthRoutes from "./routes/health.js";
 import accountsRoutes from "./routes/accounts.js";
 import creditsRoutes from "./routes/credits.js";
+import provisionsRoutes from "./routes/provisions.js";
 import checkoutRoutes from "./routes/checkout.js";
 import webhookRoutes from "./routes/webhooks.js";
 import { requireApiKey } from "./middleware/auth.js";
@@ -44,6 +45,7 @@ app.get("/openapi.json", (_req, res) => {
 app.use(requireApiKey);
 app.use(accountsRoutes);
 app.use(creditsRoutes);
+app.use(provisionsRoutes);
 app.use(checkoutRoutes);
 
 // 404 handler

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,5 +1,51 @@
-// Sentry initialization — install @sentry/node to enable
-// import * as Sentry from "@sentry/node";
-// if (process.env.SENTRY_DSN) {
-//   Sentry.init({ dsn: process.env.SENTRY_DSN, tracesSampleRate: 1.0 });
-// }
+// Deploy email templates at startup (idempotent upsert)
+async function deployEmailTemplates() {
+  const url = process.env.TRANSACTIONAL_EMAIL_SERVICE_URL;
+  const apiKey = process.env.TRANSACTIONAL_EMAIL_SERVICE_API_KEY;
+  if (!url || !apiKey) {
+    console.warn("TRANSACTIONAL_EMAIL_SERVICE not configured — skipping template deployment");
+    return;
+  }
+
+  const templates = [
+    {
+      name: "credits-depleted",
+      subject: "Your credits are depleted",
+      htmlBody: `<p>Your credit balance has been exhausted. Recharge your account to continue using the platform.</p>
+<p><a href="{{rechargeUrl}}">Recharge now</a></p>`,
+      textBody: "Your credit balance has been exhausted. Recharge your account to continue using the platform. Visit: {{rechargeUrl}}",
+    },
+    {
+      name: "credits-reload-failed",
+      subject: "Automatic reload failed",
+      htmlBody: `<p>We attempted to automatically reload your account, but the payment failed. Please update your payment method.</p>
+<p><a href="{{settingsUrl}}">Update payment method</a></p>`,
+      textBody: "We attempted to automatically reload your account, but the payment failed. Please update your payment method. Visit: {{settingsUrl}}",
+    },
+  ];
+
+  try {
+    const res = await fetch(`${url}/templates`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "x-org-id": "00000000-0000-0000-0000-000000000000",
+        "x-user-id": "00000000-0000-0000-0000-000000000000",
+        "x-run-id": "00000000-0000-0000-0000-000000000000",
+      },
+      body: JSON.stringify({ templates }),
+    });
+
+    if (!res.ok) {
+      console.error(`Failed to deploy email templates: ${res.status} ${await res.text()}`);
+      return;
+    }
+
+    console.log("Email templates deployed successfully");
+  } catch (err) {
+    console.error("Failed to deploy email templates:", err);
+  }
+}
+
+deployEmailTemplates();

--- a/src/lib/email-client.ts
+++ b/src/lib/email-client.ts
@@ -1,0 +1,45 @@
+/** Fire-and-forget client for transactional-email-service. */
+
+interface SendEmailParams {
+  eventType: string;
+  orgId: string;
+  userId: string;
+  runId: string;
+  metadata?: Record<string, string | null>;
+  workflowHeaders?: Record<string, string>;
+}
+
+function getEmailServiceConfig() {
+  const url = process.env.TRANSACTIONAL_EMAIL_SERVICE_URL;
+  const apiKey = process.env.TRANSACTIONAL_EMAIL_SERVICE_API_KEY;
+  if (!url || !apiKey) return null;
+  return { url, apiKey };
+}
+
+export function sendEmail(params: SendEmailParams): void {
+  const config = getEmailServiceConfig();
+  if (!config) {
+    console.warn("TRANSACTIONAL_EMAIL_SERVICE not configured — skipping email send");
+    return;
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": config.apiKey,
+    "x-org-id": params.orgId,
+    "x-user-id": params.userId,
+    "x-run-id": params.runId,
+    ...params.workflowHeaders,
+  };
+
+  fetch(`${config.url}/send`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      eventType: params.eventType,
+      metadata: params.metadata,
+    }),
+  }).catch((err) => {
+    console.error(`Failed to send ${params.eventType} email:`, err);
+  });
+}

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -3,20 +3,22 @@ import { eq, sql as rawSql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { billingAccounts } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
-import { DeductRequestSchema } from "../schemas.js";
+import { DeductRequestSchema, CheckRequestSchema } from "../schemas.js";
 import {
   createBalanceTransaction,
   chargePaymentMethod,
   isStripeAuthError,
 } from "../lib/stripe.js";
+import { sendEmail } from "../lib/email-client.js";
 
 const router = Router();
 
-// POST /v1/credits/deduct — deduct credits from org balance
+// POST /v1/credits/deduct — deduct credits from org balance (allows negative balances)
 router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
+    const runId = req.headers["x-run-id"] as string;
     const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
     const parsed = DeductRequestSchema.safeParse(req.body);
 
@@ -69,6 +71,7 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
 
       let currentBalance = account.credit_balance_cents;
       const filter = eq(billingAccounts.orgId, orgId);
+      let reloadFailed = false;
 
       // If insufficient balance, try auto-reload for PAYG
       if (currentBalance < amount_cents) {
@@ -79,7 +82,6 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
           account.reload_amount_cents
         ) {
           try {
-            // Charge the saved payment method
             await chargePaymentMethod(
               orgId,
               userId,
@@ -90,7 +92,6 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
               wfHeaders
             );
 
-            // Credit the Stripe balance
             await createBalanceTransaction(
               orgId,
               userId,
@@ -101,7 +102,6 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
               wfHeaders
             );
 
-            // Update local cache
             currentBalance += account.reload_amount_cents;
             await tx
               .update(billingAccounts)
@@ -112,27 +112,12 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
               .where(filter);
           } catch (reloadErr) {
             console.error("Auto-reload failed:", reloadErr);
-            return {
-              success: false as const,
-              balance_cents: currentBalance,
-              billing_mode: account.billing_mode as "trial" | "byok" | "payg",
-              depleted: true as const,
-            };
+            reloadFailed = true;
           }
-        }
-
-        // Still insufficient after potential reload
-        if (currentBalance < amount_cents) {
-          return {
-            success: false as const,
-            balance_cents: currentBalance,
-            billing_mode: account.billing_mode as "trial" | "byok" | "payg",
-            depleted: true as const,
-          };
         }
       }
 
-      // Deduct from DB
+      // Always deduct, even if it results in a negative balance
       const newBalance = currentBalance - amount_cents;
       await tx
         .update(billingAccounts)
@@ -148,7 +133,7 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
           orgId,
           userId,
           account.stripe_customer_id,
-          amount_cents, // positive = deduction in Stripe
+          amount_cents,
           description,
           { user_id: userId },
           wfHeaders
@@ -157,10 +142,11 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
         });
       }
 
-      // Check if post-deduction balance is below threshold and PAYG — trigger reload
+      // Check if post-deduction balance is below threshold and PAYG — trigger async reload
       const threshold = account.reload_threshold_cents ?? 200;
       if (
         newBalance < threshold &&
+        !reloadFailed &&
         account.billing_mode === "payg" &&
         account.stripe_payment_method_id &&
         account.stripe_customer_id &&
@@ -170,7 +156,6 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
         const customerId = account.stripe_customer_id;
         const pmId = account.stripe_payment_method_id;
 
-        // Fire auto-reload async (non-blocking)
         (async () => {
           try {
             await chargePaymentMethod(orgId, userId, customerId, pmId, reloadAmount, "Auto-reload", wfHeaders);
@@ -184,6 +169,13 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
               .where(eq(billingAccounts.orgId, orgId));
           } catch (err) {
             console.error("Async auto-reload failed:", err);
+            sendEmail({
+              eventType: "credits-reload-failed",
+              orgId,
+              userId,
+              runId,
+              workflowHeaders: wfHeaders,
+            });
           }
         })();
       }
@@ -192,7 +184,8 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
         success: true as const,
         balance_cents: newBalance,
         billing_mode: account.billing_mode as "trial" | "byok" | "payg",
-        depleted: false as const,
+        depleted: newBalance <= 0,
+        _reloadFailed: reloadFailed,
       };
     });
 
@@ -201,13 +194,96 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    res.json(result);
+    // Post-transaction emails
+    const reloadFailed = "_reloadFailed" in result && result._reloadFailed;
+    if (reloadFailed) {
+      sendEmail({
+        eventType: "credits-reload-failed",
+        orgId,
+        userId,
+        runId,
+        workflowHeaders: wfHeaders,
+      });
+    }
+    if (result.depleted) {
+      sendEmail({
+        eventType: "credits-depleted",
+        orgId,
+        userId,
+        runId,
+        workflowHeaders: wfHeaders,
+      });
+    }
+
+    // Strip internal fields from response
+    const { _reloadFailed, ...response } = result as Record<string, unknown>;
+    res.json(response);
   } catch (err) {
     console.error("Error deducting credits:", err);
     if (isStripeAuthError(err)) {
       res.status(502).json({ error: "Payment provider authentication failed" });
       return;
     }
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /v1/credits/check — pre-execution balance check (service-to-service)
+router.post("/v1/credits/check", requireOrgHeaders, async (req, res) => {
+  try {
+    const orgId = req.headers["x-org-id"] as string;
+    const userId = req.headers["x-user-id"] as string;
+    const runId = req.headers["x-run-id"] as string;
+    const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
+    const parsed = CheckRequestSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.message });
+      return;
+    }
+
+    const { required_cents } = parsed.data;
+
+    const [account] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId))
+      .limit(1);
+
+    if (!account) {
+      res.status(404).json({ error: "Billing account not found" });
+      return;
+    }
+
+    // BYOK — always sufficient, no credit tracking
+    if (account.billingMode === "byok") {
+      res.json({
+        sufficient: true,
+        balance_cents: null,
+        billing_mode: "byok",
+      });
+      return;
+    }
+
+    const sufficient = account.creditBalanceCents >= required_cents;
+
+    if (!sufficient) {
+      sendEmail({
+        eventType: "credits-depleted",
+        orgId,
+        userId,
+        runId,
+        workflowHeaders: wfHeaders,
+      });
+    }
+
+    res.json({
+      sufficient,
+      balance_cents: account.creditBalanceCents,
+      billing_mode: account.billingMode,
+    });
+  } catch (err) {
+    console.error("Error checking credits:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/routes/provisions.ts
+++ b/src/routes/provisions.ts
@@ -1,0 +1,362 @@
+import { Router } from "express";
+import { eq, sql as rawSql, and } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { billingAccounts, creditProvisions } from "../db/schema.js";
+import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
+import { ProvisionRequestSchema, ConfirmProvisionRequestSchema } from "../schemas.js";
+import {
+  createBalanceTransaction,
+  chargePaymentMethod,
+  isStripeAuthError,
+} from "../lib/stripe.js";
+import { sendEmail } from "../lib/email-client.js";
+
+const router = Router();
+
+// POST /v1/credits/provision — provision credits (deduct from balance immediately)
+router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
+  try {
+    const orgId = req.headers["x-org-id"] as string;
+    const userId = req.headers["x-user-id"] as string;
+    const runId = req.headers["x-run-id"] as string;
+    const wfHeaders = getWorkflowHeaders(req);
+    const fwdHeaders = forwardWorkflowHeaders(wfHeaders);
+    const parsed = ProvisionRequestSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.message });
+      return;
+    }
+
+    const { amount_cents, description } = parsed.data;
+
+    const result = await db.transaction(async (tx) => {
+      const rows = await tx.execute<{
+        id: string;
+        org_id: string;
+        stripe_customer_id: string | null;
+        billing_mode: string;
+        credit_balance_cents: number;
+        reload_amount_cents: number | null;
+        reload_threshold_cents: number | null;
+        stripe_payment_method_id: string | null;
+      }>(
+        rawSql`SELECT * FROM billing_accounts WHERE org_id = ${orgId} FOR UPDATE`
+      );
+
+      const account = (rows as unknown as Array<{
+        id: string;
+        org_id: string;
+        stripe_customer_id: string | null;
+        billing_mode: string;
+        credit_balance_cents: number;
+        reload_amount_cents: number | null;
+        reload_threshold_cents: number | null;
+        stripe_payment_method_id: string | null;
+      }>)[0];
+
+      if (!account) {
+        return { error: "Billing account not found" as const, status: 404 as const };
+      }
+
+      if (account.billing_mode === "byok") {
+        // BYOK — no credit tracking, create provision record for audit but don't touch balance
+        const [provision] = await tx
+          .insert(creditProvisions)
+          .values({
+            orgId,
+            userId,
+            runId,
+            amountCents: amount_cents,
+            status: "confirmed",
+            description,
+            campaignId: wfHeaders.campaignId,
+            brandId: wfHeaders.brandId,
+            workflowName: wfHeaders.workflowName,
+          })
+          .returning();
+
+        return {
+          provision_id: provision.id,
+          balance_cents: null,
+          billing_mode: "byok" as const,
+          depleted: false,
+        };
+      }
+
+      // Deduct from balance (allow negative)
+      const newBalance = account.credit_balance_cents - amount_cents;
+      await tx
+        .update(billingAccounts)
+        .set({
+          creditBalanceCents: newBalance,
+          updatedAt: new Date(),
+        })
+        .where(eq(billingAccounts.orgId, orgId));
+
+      const [provision] = await tx
+        .insert(creditProvisions)
+        .values({
+          orgId,
+          userId,
+          runId,
+          amountCents: amount_cents,
+          status: "pending",
+          description,
+          campaignId: wfHeaders.campaignId,
+          brandId: wfHeaders.brandId,
+          workflowName: wfHeaders.workflowName,
+        })
+        .returning();
+
+      return {
+        provision_id: provision.id,
+        balance_cents: newBalance,
+        billing_mode: account.billing_mode as "trial" | "byok" | "payg",
+        depleted: newBalance <= 0,
+        _account: account,
+      };
+    });
+
+    if ("error" in result && result.error) {
+      res.status(result.status as number).json({ error: result.error });
+      return;
+    }
+
+    // Post-transaction: async auto-reload if below threshold (PAYG)
+    if ("_account" in result && result._account) {
+      const account = result._account;
+      const threshold = account.reload_threshold_cents ?? 200;
+      if (
+        result.balance_cents !== null &&
+        result.balance_cents < threshold &&
+        account.billing_mode === "payg" &&
+        account.stripe_payment_method_id &&
+        account.stripe_customer_id &&
+        account.reload_amount_cents
+      ) {
+        const reloadAmount = account.reload_amount_cents;
+        const customerId = account.stripe_customer_id;
+        const pmId = account.stripe_payment_method_id;
+
+        (async () => {
+          try {
+            await chargePaymentMethod(orgId, userId, customerId, pmId, reloadAmount, "Auto-reload", fwdHeaders);
+            await createBalanceTransaction(orgId, userId, customerId, -reloadAmount, "Auto-reload credit", undefined, fwdHeaders);
+            await db
+              .update(billingAccounts)
+              .set({
+                creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${reloadAmount}`,
+                updatedAt: new Date(),
+              })
+              .where(eq(billingAccounts.orgId, orgId));
+          } catch (err) {
+            console.error("Async auto-reload failed:", err);
+            sendEmail({
+              eventType: "credits-reload-failed",
+              orgId,
+              userId,
+              runId,
+              workflowHeaders: fwdHeaders,
+            });
+          }
+        })();
+      }
+
+      // Send depleted email if needed
+      if (result.depleted) {
+        sendEmail({
+          eventType: "credits-depleted",
+          orgId,
+          userId,
+          runId,
+          workflowHeaders: fwdHeaders,
+        });
+      }
+    }
+
+    // Strip internal _account from response
+    const { _account, ...response } = result as Record<string, unknown>;
+    res.json(response);
+  } catch (err) {
+    console.error("Error creating provision:", err);
+    if (isStripeAuthError(err)) {
+      res.status(502).json({ error: "Payment provider authentication failed" });
+      return;
+    }
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /v1/credits/provision/:id/confirm — confirm provision, optionally adjust for actual cost
+router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, res) => {
+  try {
+    const orgId = req.headers["x-org-id"] as string;
+    const provisionId = req.params.id;
+    const parsed = ConfirmProvisionRequestSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.message });
+      return;
+    }
+
+    const { actual_amount_cents } = parsed.data;
+
+    const result = await db.transaction(async (tx) => {
+      // Lock the provision row
+      const provRows = await tx.execute<{
+        id: string;
+        org_id: string;
+        amount_cents: number;
+        status: string;
+      }>(
+        rawSql`SELECT * FROM credit_provisions WHERE id = ${provisionId} AND org_id = ${orgId} FOR UPDATE`
+      );
+
+      const provision = (provRows as unknown as Array<{
+        id: string;
+        org_id: string;
+        amount_cents: number;
+        status: string;
+      }>)[0];
+
+      if (!provision) {
+        return { error: "Provision not found" as const, status: 404 as const };
+      }
+
+      if (provision.status !== "pending") {
+        return { error: `Provision already ${provision.status}` as const, status: 409 as const };
+      }
+
+      // If actual cost differs, adjust balance
+      const adjustmentCents = actual_amount_cents !== undefined
+        ? provision.amount_cents - actual_amount_cents
+        : 0;
+
+      if (adjustmentCents !== 0) {
+        // Positive adjustment = we over-provisioned, credit back
+        // Negative adjustment = we under-provisioned, deduct more
+        await tx
+          .update(billingAccounts)
+          .set({
+            creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${adjustmentCents}`,
+            updatedAt: new Date(),
+          })
+          .where(eq(billingAccounts.orgId, orgId));
+      }
+
+      const finalAmount = actual_amount_cents ?? provision.amount_cents;
+
+      await tx
+        .update(creditProvisions)
+        .set({
+          status: "confirmed",
+          amountCents: finalAmount,
+          updatedAt: new Date(),
+        })
+        .where(eq(creditProvisions.id, provisionId));
+
+      // Get updated balance
+      const [account] = await tx
+        .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId))
+        .limit(1);
+
+      return {
+        provision_id: provisionId,
+        status: "confirmed" as const,
+        original_amount_cents: provision.amount_cents,
+        final_amount_cents: finalAmount,
+        adjustment_cents: adjustmentCents,
+        balance_cents: account?.creditBalanceCents ?? null,
+      };
+    });
+
+    if ("error" in result && result.error) {
+      res.status(result.status as number).json({ error: result.error });
+      return;
+    }
+
+    res.json(result);
+  } catch (err) {
+    console.error("Error confirming provision:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /v1/credits/provision/:id/cancel — cancel provision, re-credit balance
+router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, res) => {
+  try {
+    const orgId = req.headers["x-org-id"] as string;
+    const provisionId = req.params.id;
+
+    const result = await db.transaction(async (tx) => {
+      const provRows = await tx.execute<{
+        id: string;
+        org_id: string;
+        amount_cents: number;
+        status: string;
+      }>(
+        rawSql`SELECT * FROM credit_provisions WHERE id = ${provisionId} AND org_id = ${orgId} FOR UPDATE`
+      );
+
+      const provision = (provRows as unknown as Array<{
+        id: string;
+        org_id: string;
+        amount_cents: number;
+        status: string;
+      }>)[0];
+
+      if (!provision) {
+        return { error: "Provision not found" as const, status: 404 as const };
+      }
+
+      if (provision.status !== "pending") {
+        return { error: `Provision already ${provision.status}` as const, status: 409 as const };
+      }
+
+      // Re-credit the provisioned amount
+      await tx
+        .update(billingAccounts)
+        .set({
+          creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${provision.amount_cents}`,
+          updatedAt: new Date(),
+        })
+        .where(eq(billingAccounts.orgId, orgId));
+
+      await tx
+        .update(creditProvisions)
+        .set({
+          status: "cancelled",
+          updatedAt: new Date(),
+        })
+        .where(eq(creditProvisions.id, provisionId));
+
+      const [account] = await tx
+        .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId))
+        .limit(1);
+
+      return {
+        provision_id: provisionId,
+        status: "cancelled" as const,
+        refunded_cents: provision.amount_cents,
+        balance_cents: account?.creditBalanceCents ?? null,
+      };
+    });
+
+    if ("error" in result && result.error) {
+      res.status(result.status as number).json({ error: result.error });
+      return;
+    }
+
+    res.json(result);
+  } catch (err) {
+    console.error("Error cancelling provision:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -51,6 +51,67 @@ export const DeductResponseSchema = z
   })
   .openapi("DeductResponse");
 
+// --- Provision ---
+
+export const ProvisionRequestSchema = z
+  .object({
+    amount_cents: z.number().int().positive(),
+    description: z.string().min(1),
+  })
+  .openapi("ProvisionRequest");
+
+export const ProvisionResponseSchema = z
+  .object({
+    provision_id: z.string().uuid(),
+    balance_cents: z.number().int().nullable(),
+    billing_mode: BillingModeSchema,
+    depleted: z.boolean(),
+  })
+  .openapi("ProvisionResponse");
+
+export const ConfirmProvisionRequestSchema = z
+  .object({
+    actual_amount_cents: z.number().int().positive().optional(),
+  })
+  .openapi("ConfirmProvisionRequest");
+
+export const ConfirmProvisionResponseSchema = z
+  .object({
+    provision_id: z.string().uuid(),
+    status: z.literal("confirmed"),
+    original_amount_cents: z.number().int(),
+    final_amount_cents: z.number().int(),
+    adjustment_cents: z.number().int(),
+    balance_cents: z.number().int().nullable(),
+  })
+  .openapi("ConfirmProvisionResponse");
+
+export const CancelProvisionResponseSchema = z
+  .object({
+    provision_id: z.string().uuid(),
+    status: z.literal("cancelled"),
+    refunded_cents: z.number().int(),
+    balance_cents: z.number().int().nullable(),
+  })
+  .openapi("CancelProvisionResponse");
+
+// --- Check ---
+
+export const CheckRequestSchema = z
+  .object({
+    required_cents: z.number().int().positive(),
+    description: z.string().optional(),
+  })
+  .openapi("CheckRequest");
+
+export const CheckResponseSchema = z
+  .object({
+    sufficient: z.boolean(),
+    balance_cents: z.number().int().nullable(),
+    billing_mode: BillingModeSchema,
+  })
+  .openapi("CheckResponse");
+
 // --- Mode ---
 
 export const UpdateModeRequestSchema = z
@@ -257,6 +318,105 @@ registry.registerPath({
     },
     502: {
       description: "Payment provider authentication failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/credits/check",
+  summary: "Pre-execution balance check (service-to-service). Sends depleted email if insufficient.",
+  request: {
+    headers: protectedHeaders,
+    body: {
+      content: { "application/json": { schema: CheckRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Balance check result",
+      content: { "application/json": { schema: CheckResponseSchema } },
+    },
+    404: {
+      description: "Billing account not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/credits/provision",
+  summary: "Provision credits (deduct immediately, confirm or cancel later)",
+  request: {
+    headers: protectedHeaders,
+    body: {
+      content: { "application/json": { schema: ProvisionRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Provision created",
+      content: { "application/json": { schema: ProvisionResponseSchema } },
+    },
+    404: {
+      description: "Billing account not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "Payment provider authentication failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/credits/provision/{id}/confirm",
+  summary: "Confirm a pending provision, optionally adjusting for actual cost",
+  request: {
+    headers: protectedHeaders,
+    params: z.object({ id: z.string().uuid() }),
+    body: {
+      content: { "application/json": { schema: ConfirmProvisionRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Provision confirmed",
+      content: { "application/json": { schema: ConfirmProvisionResponseSchema } },
+    },
+    404: {
+      description: "Provision not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    409: {
+      description: "Provision already confirmed or cancelled",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/credits/provision/{id}/cancel",
+  summary: "Cancel a pending provision, re-crediting the provisioned amount",
+  request: {
+    headers: protectedHeaders,
+    params: z.object({ id: z.string().uuid() }),
+  },
+  responses: {
+    200: {
+      description: "Provision cancelled",
+      content: { "application/json": { schema: CancelProvisionResponseSchema } },
+    },
+    404: {
+      description: "Provision not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    409: {
+      description: "Provision already confirmed or cancelled",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import healthRoutes from "../../src/routes/health.js";
 import accountsRoutes from "../../src/routes/accounts.js";
 import creditsRoutes from "../../src/routes/credits.js";
+import provisionsRoutes from "../../src/routes/provisions.js";
 import checkoutRoutes from "../../src/routes/checkout.js";
 import webhookRoutes from "../../src/routes/webhooks.js";
 import { requireApiKey } from "../../src/middleware/auth.js";
@@ -25,6 +26,7 @@ export function createTestApp() {
   app.use(requireApiKey);
   app.use(accountsRoutes);
   app.use(creditsRoutes);
+  app.use(provisionsRoutes);
   app.use(checkoutRoutes);
 
   app.use((_req: express.Request, res: express.Response) => {

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,7 +1,8 @@
 import { db, sql } from "../../src/db/index.js";
-import { billingAccounts } from "../../src/db/schema.js";
+import { billingAccounts, creditProvisions } from "../../src/db/schema.js";
 
 export async function cleanTestData() {
+  await db.delete(creditProvisions);
   await db.delete(billingAccounts);
 }
 

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -18,7 +18,6 @@ describe("Credits deduction endpoint", () => {
 
   afterAll(async () => {
     await cleanTestData();
-    await closeDb();
   });
 
   it("deducts credits successfully", async () => {
@@ -45,7 +44,7 @@ describe("Credits deduction endpoint", () => {
     });
   });
 
-  it("returns depleted when insufficient balance (trial)", async () => {
+  it("allows negative balance when insufficient (trial)", async () => {
     await insertTestAccount({
       orgId,
       stripeCustomerId: "cus_123",
@@ -62,9 +61,9 @@ describe("Credits deduction endpoint", () => {
       });
 
     expect(res.status).toBe(200);
-    expect(res.body.success).toBe(false);
+    expect(res.body.success).toBe(true);
     expect(res.body.depleted).toBe(true);
-    expect(res.body.balance_cents).toBe(3);
+    expect(res.body.balance_cents).toBe(-2);
   });
 
   it("bypasses deduction for BYOK mode", async () => {
@@ -125,7 +124,7 @@ describe("Credits deduction endpoint", () => {
     );
   });
 
-  it("returns depleted when PAYG auto-reload fails", async () => {
+  it("deducts into negative when PAYG auto-reload fails", async () => {
     await insertTestAccount({
       orgId,
       stripeCustomerId: "cus_123",
@@ -149,8 +148,9 @@ describe("Credits deduction endpoint", () => {
       });
 
     expect(res.status).toBe(200);
-    expect(res.body.success).toBe(false);
+    expect(res.body.success).toBe(true);
     expect(res.body.depleted).toBe(true);
+    expect(res.body.balance_cents).toBe(-2);
   });
 
   it("returns 404 for unknown org", async () => {
@@ -260,5 +260,100 @@ describe("Credits deduction endpoint", () => {
 
     const res3 = await request(app).post("/v1/credits/deduct").set(headers).send(body);
     expect(res3.body.balance_cents).toBe(70);
+  });
+});
+
+describe("Credits check endpoint", () => {
+  const app = createTestApp();
+  const orgId = "00000000-0000-0000-0000-000000000001";
+  let stripeMocks: ReturnType<typeof setupStripeMocks>;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    stripeMocks = setupStripeMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("returns sufficient: true when balance covers required amount", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_123",
+      creditBalanceCents: 500,
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/check")
+      .set(getAuthHeaders(orgId))
+      .send({ required_cents: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      sufficient: true,
+      balance_cents: 500,
+      billing_mode: "trial",
+    });
+  });
+
+  it("returns sufficient: false when balance is insufficient", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_123",
+      creditBalanceCents: 50,
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/check")
+      .set(getAuthHeaders(orgId))
+      .send({ required_cents: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      sufficient: false,
+      balance_cents: 50,
+      billing_mode: "trial",
+    });
+  });
+
+  it("always returns sufficient for BYOK mode", async () => {
+    await insertTestAccount({
+      orgId,
+      billingMode: "byok",
+      creditBalanceCents: 0,
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/check")
+      .set(getAuthHeaders(orgId))
+      .send({ required_cents: 9999 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      sufficient: true,
+      balance_cents: null,
+      billing_mode: "byok",
+    });
+  });
+
+  it("returns 404 for unknown org", async () => {
+    const res = await request(app)
+      .post("/v1/credits/check")
+      .set(getAuthHeaders("00000000-0000-0000-0000-999999999999"))
+      .send({ required_cents: 100 });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("validates request body", async () => {
+    const res = await request(app)
+      .post("/v1/credits/check")
+      .set(getAuthHeaders(orgId))
+      .send({ required_cents: -5 });
+
+    expect(res.status).toBe(400);
   });
 });

--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
+import { setupStripeMocks } from "../helpers/mock-stripe.js";
+
+describe("Credit provision endpoints", () => {
+  const app = createTestApp();
+  const orgId = "00000000-0000-0000-0000-000000000001";
+  let stripeMocks: ReturnType<typeof setupStripeMocks>;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    stripeMocks = setupStripeMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  describe("POST /v1/credits/provision", () => {
+    it("provisions credits and deducts from balance", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const res = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "estimated cost" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provision_id).toBeDefined();
+      expect(res.body.balance_cents).toBe(400);
+      expect(res.body.billing_mode).toBe("trial");
+      expect(res.body.depleted).toBe(false);
+    });
+
+    it("allows negative balance on provision", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 50,
+      });
+
+      const res = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 200, description: "large task" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.balance_cents).toBe(-150);
+      expect(res.body.depleted).toBe(true);
+    });
+
+    it("bypasses balance for BYOK mode", async () => {
+      await insertTestAccount({
+        orgId,
+        billingMode: "byok",
+        creditBalanceCents: 0,
+      });
+
+      const res = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 500, description: "byok task" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.balance_cents).toBeNull();
+      expect(res.body.billing_mode).toBe("byok");
+    });
+
+    it("returns 404 for unknown org", async () => {
+      const res = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders("00000000-0000-0000-0000-999999999999"))
+        .send({ amount_cents: 100, description: "test" });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("stores workflow headers in provision record", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const res = await request(app)
+        .post("/v1/credits/provision")
+        .set({
+          ...getAuthHeaders(orgId),
+          "x-campaign-id": "camp_42",
+          "x-brand-id": "brand_7",
+          "x-workflow-name": "outreach-flow",
+        })
+        .send({ amount_cents: 50, description: "tracked provision" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provision_id).toBeDefined();
+    });
+
+    it("validates request body", async () => {
+      const res = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: -5 });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("POST /v1/credits/provision/:id/confirm", () => {
+    it("confirms a pending provision with no adjustment", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const provRes = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "test" });
+
+      const provisionId = provRes.body.provision_id;
+
+      const res = await request(app)
+        .post(`/v1/credits/provision/${provisionId}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("confirmed");
+      expect(res.body.original_amount_cents).toBe(100);
+      expect(res.body.final_amount_cents).toBe(100);
+      expect(res.body.adjustment_cents).toBe(0);
+      expect(res.body.balance_cents).toBe(400);
+    });
+
+    it("adjusts balance when actual cost is lower", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const provRes = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "test" });
+
+      // Balance is now 400. Confirm with actual 60 → credit back 40 → balance 440
+      const res = await request(app)
+        .post(`/v1/credits/provision/${provRes.body.provision_id}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({ actual_amount_cents: 60 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.adjustment_cents).toBe(40);
+      expect(res.body.final_amount_cents).toBe(60);
+      expect(res.body.balance_cents).toBe(440);
+    });
+
+    it("adjusts balance when actual cost is higher", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const provRes = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "test" });
+
+      // Balance is now 400. Confirm with actual 150 → deduct 50 more → balance 350
+      const res = await request(app)
+        .post(`/v1/credits/provision/${provRes.body.provision_id}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({ actual_amount_cents: 150 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.adjustment_cents).toBe(-50);
+      expect(res.body.final_amount_cents).toBe(150);
+      expect(res.body.balance_cents).toBe(350);
+    });
+
+    it("returns 409 for already confirmed provision", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const provRes = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "test" });
+
+      const provisionId = provRes.body.provision_id;
+
+      await request(app)
+        .post(`/v1/credits/provision/${provisionId}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({});
+
+      const res = await request(app)
+        .post(`/v1/credits/provision/${provisionId}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({});
+
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 404 for unknown provision", async () => {
+      await insertTestAccount({ orgId });
+
+      const res = await request(app)
+        .post("/v1/credits/provision/00000000-0000-0000-0000-000000000999/confirm")
+        .set(getAuthHeaders(orgId))
+        .send({});
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /v1/credits/provision/:id/cancel", () => {
+    it("cancels a pending provision and re-credits balance", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const provRes = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "test" });
+
+      // Balance is now 400. Cancel → re-credit 100 → balance 500
+      const res = await request(app)
+        .post(`/v1/credits/provision/${provRes.body.provision_id}/cancel`)
+        .set(getAuthHeaders(orgId))
+        .send();
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("cancelled");
+      expect(res.body.refunded_cents).toBe(100);
+      expect(res.body.balance_cents).toBe(500);
+    });
+
+    it("returns 409 for already cancelled provision", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const provRes = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "test" });
+
+      const provisionId = provRes.body.provision_id;
+
+      await request(app)
+        .post(`/v1/credits/provision/${provisionId}/cancel`)
+        .set(getAuthHeaders(orgId))
+        .send();
+
+      const res = await request(app)
+        .post(`/v1/credits/provision/${provisionId}/cancel`)
+        .set(getAuthHeaders(orgId))
+        .send();
+
+      expect(res.status).toBe(409);
+    });
+
+    it("cannot cancel a confirmed provision", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const provRes = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "test" });
+
+      await request(app)
+        .post(`/v1/credits/provision/${provRes.body.provision_id}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({});
+
+      const res = await request(app)
+        .post(`/v1/credits/provision/${provRes.body.provision_id}/cancel`)
+        .set(getAuthHeaders(orgId))
+        .send();
+
+      expect(res.status).toBe(409);
+    });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,5 +10,28 @@ process.env.STRIPE_SECRET_KEY = "sk_test_fake";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec_test_fake";
 process.env.NODE_ENV = "test";
 
-beforeAll(() => console.log("Test suite starting..."));
+beforeAll(async () => {
+  console.log("Test suite starting...");
+
+  // Ensure credit_provisions table exists (migration may not have run on test DB)
+  const { sql } = await import("../src/db/index.js");
+  await sql`
+    CREATE TABLE IF NOT EXISTS "credit_provisions" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+      "org_id" uuid NOT NULL,
+      "user_id" uuid NOT NULL,
+      "run_id" uuid,
+      "amount_cents" integer NOT NULL,
+      "status" text DEFAULT 'pending' NOT NULL,
+      "description" text,
+      "campaign_id" text,
+      "brand_id" text,
+      "workflow_name" text,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+    )
+  `;
+  await sql`CREATE INDEX IF NOT EXISTS "idx_credit_provisions_org_id" ON "credit_provisions" USING btree ("org_id")`;
+  await sql`CREATE INDEX IF NOT EXISTS "idx_credit_provisions_status" ON "credit_provisions" USING btree ("status")`;
+});
 afterAll(() => console.log("Test suite complete."));

--- a/tests/unit/credits.test.ts
+++ b/tests/unit/credits.test.ts
@@ -8,10 +8,11 @@ describe("Credit deduction logic", () => {
     expect(newBalance).toBe(195);
   });
 
-  it("detects insufficient balance", () => {
+  it("allows negative balance (deducts even when insufficient)", () => {
     const balance = 3;
     const amount = 5;
-    expect(balance < amount).toBe(true);
+    const newBalance = balance - amount;
+    expect(newBalance).toBe(-2);
   });
 
   it("calculates balance after reload + deduction", () => {
@@ -44,5 +45,41 @@ describe("Credit deduction logic", () => {
     const amount = 1000;
     const shouldBypass = mode === "byok";
     expect(shouldBypass).toBe(true);
+  });
+
+  it("marks depleted when balance goes to zero or negative", () => {
+    expect(0 <= 0).toBe(true);
+    expect(-5 <= 0).toBe(true);
+    expect(1 <= 0).toBe(false);
+  });
+});
+
+describe("Credit provision logic", () => {
+  it("calculates balance adjustment when actual is lower", () => {
+    const provisioned = 100;
+    const actual = 60;
+    const adjustment = provisioned - actual;
+    expect(adjustment).toBe(40);
+  });
+
+  it("calculates balance adjustment when actual is higher", () => {
+    const provisioned = 100;
+    const actual = 150;
+    const adjustment = provisioned - actual;
+    expect(adjustment).toBe(-50);
+  });
+
+  it("no adjustment when actual equals provisioned", () => {
+    const provisioned = 100;
+    const actual = 100;
+    const adjustment = provisioned - actual;
+    expect(adjustment).toBe(0);
+  });
+
+  it("cancel re-credits the full provisioned amount", () => {
+    const balance = 400;
+    const provisioned = 100;
+    const newBalance = balance + provisioned;
+    expect(newBalance).toBe(500);
   });
 });


### PR DESCRIPTION
## Summary
- **POST /v1/credits/provision** + **/confirm** + **/cancel** — full provision lifecycle (reserve → confirm with actual cost adjustment, or cancel → re-credit)
- **POST /v1/credits/check** — pre-execution balance check for service-to-service calls (sends depleted email if insufficient)
- **POST /v1/credits/deduct** — now allows negative balances (deducts even when insufficient + reload fails)
- Fire-and-forget emails via transactional-email-service on `credits-depleted` and `credits-reload-failed` events (dedup handled by transactional-email-service)
- Deploy two email templates at startup via `PUT /templates`
- Persist `x-campaign-id`, `x-brand-id`, `x-workflow-name` on provision records
- Migration 0003: `credit_provisions` table

## Test plan
- [x] 101 tests passing (unit + integration)
- [x] Provision create/confirm/cancel with balance adjustments
- [x] Negative balance on insufficient deduction (trial + PAYG reload failure)
- [x] Check endpoint: sufficient/insufficient/BYOK/404/validation
- [x] TypeScript strict type-check passes
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)