### PR TITLE
Rename check to authorize with sync auto-reload

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -248,7 +248,7 @@
           "reload_amount_cents"
         ]
       },
-      "CheckResponse": {
+      "AuthorizeResponse": {
         "type": "object",
         "properties": {
           "sufficient": {
@@ -268,7 +268,7 @@
           "billing_mode"
         ]
       },
-      "CheckRequest": {
+      "AuthorizeRequest": {
         "type": "object",
         "properties": {
           "required_cents": {
@@ -1007,9 +1007,9 @@
         }
       }
     },
-    "/v1/credits/check": {
+    "/v1/credits/authorize": {
       "post": {
-        "summary": "Pre-execution balance check (service-to-service). Sends depleted email if insufficient.",
+        "summary": "Synchronous pre-execution authorization. Attempts auto-reload if insufficient (PAYG). Sends email on failure.",
         "parameters": [
           {
             "schema": {
@@ -1078,24 +1078,34 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CheckRequest"
+                "$ref": "#/components/schemas/AuthorizeRequest"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Balance check result",
+            "description": "Authorization result",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CheckResponse"
+                  "$ref": "#/components/schemas/AuthorizeResponse"
                 }
               }
             }
           },
           "404": {
             "description": "Billing account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Payment provider authentication failed",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -3,7 +3,7 @@ import { eq, sql as rawSql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { billingAccounts } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
-import { DeductRequestSchema, CheckRequestSchema } from "../schemas.js";
+import { DeductRequestSchema, AuthorizeRequestSchema } from "../schemas.js";
 import {
   createBalanceTransaction,
   chargePaymentMethod,
@@ -228,14 +228,14 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
   }
 });
 
-// POST /v1/credits/check — pre-execution balance check (service-to-service)
-router.post("/v1/credits/check", requireOrgHeaders, async (req, res) => {
+// POST /v1/credits/authorize — synchronous pre-execution authorization with auto-reload attempt
+router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
     const runId = req.headers["x-run-id"] as string;
     const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
-    const parsed = CheckRequestSchema.safeParse(req.body);
+    const parsed = AuthorizeRequestSchema.safeParse(req.body);
 
     if (!parsed.success) {
       res.status(400).json({ error: parsed.error.message });
@@ -244,32 +244,115 @@ router.post("/v1/credits/check", requireOrgHeaders, async (req, res) => {
 
     const { required_cents } = parsed.data;
 
-    const [account] = await db
-      .select()
-      .from(billingAccounts)
-      .where(eq(billingAccounts.orgId, orgId))
-      .limit(1);
+    const result = await db.transaction(async (tx) => {
+      const rows = await tx.execute<{
+        id: string;
+        org_id: string;
+        stripe_customer_id: string | null;
+        billing_mode: string;
+        credit_balance_cents: number;
+        reload_amount_cents: number | null;
+        reload_threshold_cents: number | null;
+        stripe_payment_method_id: string | null;
+      }>(
+        rawSql`SELECT * FROM billing_accounts WHERE org_id = ${orgId} FOR UPDATE`
+      );
 
-    if (!account) {
-      res.status(404).json({ error: "Billing account not found" });
+      const account = (rows as unknown as Array<{
+        id: string;
+        org_id: string;
+        stripe_customer_id: string | null;
+        billing_mode: string;
+        credit_balance_cents: number;
+        reload_amount_cents: number | null;
+        reload_threshold_cents: number | null;
+        stripe_payment_method_id: string | null;
+      }>)[0];
+
+      if (!account) {
+        return { error: "Billing account not found" as const, status: 404 as const };
+      }
+
+      // BYOK — always sufficient, no credit tracking
+      if (account.billing_mode === "byok") {
+        return {
+          sufficient: true as const,
+          balance_cents: null,
+          billing_mode: "byok" as const,
+        };
+      }
+
+      let currentBalance = account.credit_balance_cents;
+
+      // If insufficient, try synchronous auto-reload for PAYG
+      if (currentBalance < required_cents) {
+        if (
+          account.billing_mode === "payg" &&
+          account.stripe_payment_method_id &&
+          account.stripe_customer_id &&
+          account.reload_amount_cents
+        ) {
+          try {
+            await chargePaymentMethod(
+              orgId,
+              userId,
+              account.stripe_customer_id,
+              account.stripe_payment_method_id,
+              account.reload_amount_cents,
+              "Auto-reload",
+              wfHeaders
+            );
+
+            await createBalanceTransaction(
+              orgId,
+              userId,
+              account.stripe_customer_id,
+              -account.reload_amount_cents,
+              "Auto-reload credit",
+              undefined,
+              wfHeaders
+            );
+
+            currentBalance += account.reload_amount_cents;
+            await tx
+              .update(billingAccounts)
+              .set({
+                creditBalanceCents: currentBalance,
+                updatedAt: new Date(),
+              })
+              .where(eq(billingAccounts.orgId, orgId));
+          } catch (reloadErr) {
+            console.error("Auto-reload failed during authorize:", reloadErr);
+            return {
+              sufficient: false as const,
+              balance_cents: currentBalance,
+              billing_mode: account.billing_mode as "trial" | "payg",
+              _emailEvent: "credits-reload-failed" as const,
+            };
+          }
+        }
+      }
+
+      const sufficient = currentBalance >= required_cents;
+
+      return {
+        sufficient: sufficient as boolean,
+        balance_cents: currentBalance,
+        billing_mode: account.billing_mode as "trial" | "byok" | "payg",
+        _emailEvent: sufficient ? null : "credits-depleted" as const,
+      };
+    });
+
+    if ("error" in result && result.error) {
+      res.status(result.status as number).json({ error: result.error });
       return;
     }
 
-    // BYOK — always sufficient, no credit tracking
-    if (account.billingMode === "byok") {
-      res.json({
-        sufficient: true,
-        balance_cents: null,
-        billing_mode: "byok",
-      });
-      return;
-    }
-
-    const sufficient = account.creditBalanceCents >= required_cents;
-
-    if (!sufficient) {
+    // Fire-and-forget email notification
+    const emailEvent = "_emailEvent" in result ? result._emailEvent : null;
+    if (emailEvent) {
       sendEmail({
-        eventType: "credits-depleted",
+        eventType: emailEvent,
         orgId,
         userId,
         runId,
@@ -277,13 +360,15 @@ router.post("/v1/credits/check", requireOrgHeaders, async (req, res) => {
       });
     }
 
-    res.json({
-      sufficient,
-      balance_cents: account.creditBalanceCents,
-      billing_mode: account.billingMode,
-    });
+    // Strip internal fields
+    const { _emailEvent, ...response } = result as Record<string, unknown>;
+    res.json(response);
   } catch (err) {
-    console.error("Error checking credits:", err);
+    console.error("Error authorizing credits:", err);
+    if (isStripeAuthError(err)) {
+      res.status(502).json({ error: "Payment provider authentication failed" });
+      return;
+    }
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -95,22 +95,22 @@ export const CancelProvisionResponseSchema = z
   })
   .openapi("CancelProvisionResponse");
 
-// --- Check ---
+// --- Authorize ---
 
-export const CheckRequestSchema = z
+export const AuthorizeRequestSchema = z
   .object({
     required_cents: z.number().int().positive(),
     description: z.string().optional(),
   })
-  .openapi("CheckRequest");
+  .openapi("AuthorizeRequest");
 
-export const CheckResponseSchema = z
+export const AuthorizeResponseSchema = z
   .object({
     sufficient: z.boolean(),
     balance_cents: z.number().int().nullable(),
     billing_mode: BillingModeSchema,
   })
-  .openapi("CheckResponse");
+  .openapi("AuthorizeResponse");
 
 // --- Mode ---
 
@@ -325,21 +325,25 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/credits/check",
-  summary: "Pre-execution balance check (service-to-service). Sends depleted email if insufficient.",
+  path: "/v1/credits/authorize",
+  summary: "Synchronous pre-execution authorization. Attempts auto-reload if insufficient (PAYG). Sends email on failure.",
   request: {
     headers: protectedHeaders,
     body: {
-      content: { "application/json": { schema: CheckRequestSchema } },
+      content: { "application/json": { schema: AuthorizeRequestSchema } },
     },
   },
   responses: {
     200: {
-      description: "Balance check result",
-      content: { "application/json": { schema: CheckResponseSchema } },
+      description: "Authorization result",
+      content: { "application/json": { schema: AuthorizeResponseSchema } },
     },
     404: {
       description: "Billing account not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "Payment provider authentication failed",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -263,9 +263,10 @@ describe("Credits deduction endpoint", () => {
   });
 });
 
-describe("Credits check endpoint", () => {
+describe("Credits authorize endpoint", () => {
   const app = createTestApp();
   const orgId = "00000000-0000-0000-0000-000000000001";
+  const userId = "00000000-0000-0000-0000-000000000099";
   let stripeMocks: ReturnType<typeof setupStripeMocks>;
 
   beforeEach(async () => {
@@ -287,7 +288,7 @@ describe("Credits check endpoint", () => {
     });
 
     const res = await request(app)
-      .post("/v1/credits/check")
+      .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
       .send({ required_cents: 100 });
 
@@ -299,7 +300,7 @@ describe("Credits check endpoint", () => {
     });
   });
 
-  it("returns sufficient: false when balance is insufficient", async () => {
+  it("returns sufficient: false when balance is insufficient (trial, no reload)", async () => {
     await insertTestAccount({
       orgId,
       stripeCustomerId: "cus_123",
@@ -307,7 +308,7 @@ describe("Credits check endpoint", () => {
     });
 
     const res = await request(app)
-      .post("/v1/credits/check")
+      .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
       .send({ required_cents: 100 });
 
@@ -319,6 +320,67 @@ describe("Credits check endpoint", () => {
     });
   });
 
+  it("auto-reloads for PAYG and returns sufficient after reload", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_123",
+      billingMode: "payg",
+      creditBalanceCents: 50,
+      reloadAmountCents: 2000,
+      reloadThresholdCents: 200,
+      stripePaymentMethodId: "pm_123",
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send({ required_cents: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      sufficient: true,
+      balance_cents: 2050, // 50 + 2000 reload
+      billing_mode: "payg",
+    });
+    expect(stripeMocks.chargePaymentMethod).toHaveBeenCalledWith(
+      orgId,
+      userId,
+      "cus_123",
+      "pm_123",
+      2000,
+      "Auto-reload",
+      {}
+    );
+  });
+
+  it("returns sufficient: false when PAYG auto-reload fails", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_123",
+      billingMode: "payg",
+      creditBalanceCents: 50,
+      reloadAmountCents: 2000,
+      reloadThresholdCents: 200,
+      stripePaymentMethodId: "pm_123",
+    });
+
+    stripeMocks.chargePaymentMethod.mockRejectedValue(
+      new Error("Card declined")
+    );
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send({ required_cents: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      sufficient: false,
+      balance_cents: 50,
+      billing_mode: "payg",
+    });
+  });
+
   it("always returns sufficient for BYOK mode", async () => {
     await insertTestAccount({
       orgId,
@@ -327,7 +389,7 @@ describe("Credits check endpoint", () => {
     });
 
     const res = await request(app)
-      .post("/v1/credits/check")
+      .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
       .send({ required_cents: 9999 });
 
@@ -341,7 +403,7 @@ describe("Credits check endpoint", () => {
 
   it("returns 404 for unknown org", async () => {
     const res = await request(app)
-      .post("/v1/credits/check")
+      .post("/v1/credits/authorize")
       .set(getAuthHeaders("00000000-0000-0000-0000-999999999999"))
       .send({ required_cents: 100 });
 
@@ -350,7 +412,7 @@ describe("Credits check endpoint", () => {
 
   it("validates request body", async () => {
     const res = await request(app)
-      .post("/v1/credits/check")
+      .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
       .send({ required_cents: -5 });
 


### PR DESCRIPTION
## Summary
- Replaces `POST /v1/credits/check` with `POST /v1/credits/authorize`
- Key difference: `authorize` uses `FOR UPDATE` lock and **synchronously** attempts Stripe auto-reload before returning `sufficient: false` (PAYG accounts)
- Sends `credits-depleted` email on insufficient balance, `credits-reload-failed` on Stripe charge failure
- The caller waits for the full flow — no fire-and-forget on the reload attempt

## Test plan
- [x] 103 tests passing
- [x] Authorize returns sufficient after successful auto-reload (PAYG)
- [x] Authorize returns insufficient when reload fails (card declined)
- [x] BYOK always sufficient, trial no reload attempt, 404/validation cases
- [x] TypeScript strict, OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)