### PR TITLE
Authorize endpoint with costs-service price resolution

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -248,7 +248,7 @@
           "reload_amount_cents"
         ]
       },
-      "CheckResponse": {
+      "AuthorizeResponse": {
         "type": "object",
         "properties": {
           "sufficient": {
@@ -268,7 +268,7 @@
           "billing_mode"
         ]
       },
-      "CheckRequest": {
+      "AuthorizeRequest": {
         "type": "object",
         "properties": {
           "required_cents": {
@@ -1007,9 +1007,9 @@
         }
       }
     },
-    "/v1/credits/check": {
+    "/v1/credits/authorize": {
       "post": {
-        "summary": "Pre-execution balance check (service-to-service). Sends depleted email if insufficient.",
+        "summary": "Synchronous pre-execution authorization. Attempts auto-reload if insufficient (PAYG). Sends email on failure.",
         "parameters": [
           {
             "schema": {
@@ -1078,24 +1078,34 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CheckRequest"
+                "$ref": "#/components/schemas/AuthorizeRequest"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Balance check result",
+            "description": "Authorization result",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CheckResponse"
+                  "$ref": "#/components/schemas/AuthorizeResponse"
                 }
               }
             }
           },
           "404": {
             "description": "Billing account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Payment provider authentication failed",
             "content": {
               "application/json": {
                 "schema": {

--- a/openapi.json
+++ b/openapi.json
@@ -260,28 +260,52 @@
           },
           "billing_mode": {
             "$ref": "#/components/schemas/BillingMode"
+          },
+          "required_cents": {
+            "type": "integer"
           }
         },
         "required": [
           "sufficient",
           "balance_cents",
-          "billing_mode"
+          "billing_mode",
+          "required_cents"
+        ]
+      },
+      "AuthorizeCostItem": {
+        "type": "object",
+        "properties": {
+          "costName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "quantity": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          }
+        },
+        "required": [
+          "costName",
+          "quantity"
         ]
       },
       "AuthorizeRequest": {
         "type": "object",
         "properties": {
-          "required_cents": {
-            "type": "integer",
-            "minimum": 0,
-            "exclusiveMinimum": true
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuthorizeCostItem"
+            },
+            "minItems": 1
           },
           "description": {
             "type": "string"
           }
         },
         "required": [
-          "required_cents"
+          "items"
         ]
       },
       "ProvisionResponse": {

--- a/src/lib/costs-client.ts
+++ b/src/lib/costs-client.ts
@@ -1,0 +1,66 @@
+/** Client for resolving platform prices from costs-service. */
+
+export interface CostItem {
+  costName: string;
+  quantity: number;
+}
+
+export interface ResolvedPrice {
+  name: string;
+  pricePerUnitInUsdCents: string;
+}
+
+function getCostsServiceConfig() {
+  const url = process.env.COSTS_SERVICE_URL;
+  const apiKey = process.env.COSTS_SERVICE_API_KEY;
+  if (!url || !apiKey) return null;
+  return { url, apiKey };
+}
+
+/** Resolve the platform price for a single cost name. */
+export async function resolvePlatformPrice(
+  costName: string,
+  headers: Record<string, string>
+): Promise<ResolvedPrice> {
+  const config = getCostsServiceConfig();
+  if (!config) {
+    throw new Error("COSTS_SERVICE not configured");
+  }
+
+  const res = await fetch(
+    `${config.url}/v1/platform-prices/${encodeURIComponent(costName)}`,
+    {
+      headers: {
+        "x-api-key": config.apiKey,
+        ...headers,
+      },
+    }
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Failed to resolve price for ${costName}: ${res.status} ${body}`
+    );
+  }
+
+  return (await res.json()) as ResolvedPrice;
+}
+
+/** Resolve all items and compute total required cents. */
+export async function resolveRequiredCents(
+  items: CostItem[],
+  headers: Record<string, string>
+): Promise<number> {
+  const prices = await Promise.all(
+    items.map((item) => resolvePlatformPrice(item.costName, headers))
+  );
+
+  let totalCents = 0;
+  for (let i = 0; i < items.length; i++) {
+    const unitCost = parseFloat(prices[i].pricePerUnitInUsdCents);
+    totalCents += items[i].quantity * unitCost;
+  }
+
+  return Math.ceil(totalCents);
+}

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -3,7 +3,7 @@ import { eq, sql as rawSql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { billingAccounts } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
-import { DeductRequestSchema, CheckRequestSchema } from "../schemas.js";
+import { DeductRequestSchema, AuthorizeRequestSchema } from "../schemas.js";
 import {
   createBalanceTransaction,
   chargePaymentMethod,
@@ -228,14 +228,14 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
   }
 });
 
-// POST /v1/credits/check — pre-execution balance check (service-to-service)
-router.post("/v1/credits/check", requireOrgHeaders, async (req, res) => {
+// POST /v1/credits/authorize — synchronous pre-execution authorization with auto-reload attempt
+router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
     const runId = req.headers["x-run-id"] as string;
     const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
-    const parsed = CheckRequestSchema.safeParse(req.body);
+    const parsed = AuthorizeRequestSchema.safeParse(req.body);
 
     if (!parsed.success) {
       res.status(400).json({ error: parsed.error.message });
@@ -244,32 +244,115 @@ router.post("/v1/credits/check", requireOrgHeaders, async (req, res) => {
 
     const { required_cents } = parsed.data;
 
-    const [account] = await db
-      .select()
-      .from(billingAccounts)
-      .where(eq(billingAccounts.orgId, orgId))
-      .limit(1);
+    const result = await db.transaction(async (tx) => {
+      const rows = await tx.execute<{
+        id: string;
+        org_id: string;
+        stripe_customer_id: string | null;
+        billing_mode: string;
+        credit_balance_cents: number;
+        reload_amount_cents: number | null;
+        reload_threshold_cents: number | null;
+        stripe_payment_method_id: string | null;
+      }>(
+        rawSql`SELECT * FROM billing_accounts WHERE org_id = ${orgId} FOR UPDATE`
+      );
 
-    if (!account) {
-      res.status(404).json({ error: "Billing account not found" });
+      const account = (rows as unknown as Array<{
+        id: string;
+        org_id: string;
+        stripe_customer_id: string | null;
+        billing_mode: string;
+        credit_balance_cents: number;
+        reload_amount_cents: number | null;
+        reload_threshold_cents: number | null;
+        stripe_payment_method_id: string | null;
+      }>)[0];
+
+      if (!account) {
+        return { error: "Billing account not found" as const, status: 404 as const };
+      }
+
+      // BYOK — always sufficient, no credit tracking
+      if (account.billing_mode === "byok") {
+        return {
+          sufficient: true as const,
+          balance_cents: null,
+          billing_mode: "byok" as const,
+        };
+      }
+
+      let currentBalance = account.credit_balance_cents;
+
+      // If insufficient, try synchronous auto-reload for PAYG
+      if (currentBalance < required_cents) {
+        if (
+          account.billing_mode === "payg" &&
+          account.stripe_payment_method_id &&
+          account.stripe_customer_id &&
+          account.reload_amount_cents
+        ) {
+          try {
+            await chargePaymentMethod(
+              orgId,
+              userId,
+              account.stripe_customer_id,
+              account.stripe_payment_method_id,
+              account.reload_amount_cents,
+              "Auto-reload",
+              wfHeaders
+            );
+
+            await createBalanceTransaction(
+              orgId,
+              userId,
+              account.stripe_customer_id,
+              -account.reload_amount_cents,
+              "Auto-reload credit",
+              undefined,
+              wfHeaders
+            );
+
+            currentBalance += account.reload_amount_cents;
+            await tx
+              .update(billingAccounts)
+              .set({
+                creditBalanceCents: currentBalance,
+                updatedAt: new Date(),
+              })
+              .where(eq(billingAccounts.orgId, orgId));
+          } catch (reloadErr) {
+            console.error("Auto-reload failed during authorize:", reloadErr);
+            return {
+              sufficient: false as const,
+              balance_cents: currentBalance,
+              billing_mode: account.billing_mode as "trial" | "payg",
+              _emailEvent: "credits-reload-failed" as const,
+            };
+          }
+        }
+      }
+
+      const sufficient = currentBalance >= required_cents;
+
+      return {
+        sufficient: sufficient as boolean,
+        balance_cents: currentBalance,
+        billing_mode: account.billing_mode as "trial" | "byok" | "payg",
+        _emailEvent: sufficient ? null : "credits-depleted" as const,
+      };
+    });
+
+    if ("error" in result && result.error) {
+      res.status(result.status as number).json({ error: result.error });
       return;
     }
 
-    // BYOK — always sufficient, no credit tracking
-    if (account.billingMode === "byok") {
-      res.json({
-        sufficient: true,
-        balance_cents: null,
-        billing_mode: "byok",
-      });
-      return;
-    }
-
-    const sufficient = account.creditBalanceCents >= required_cents;
-
-    if (!sufficient) {
+    // Fire-and-forget email notification
+    const emailEvent = "_emailEvent" in result ? result._emailEvent : null;
+    if (emailEvent) {
       sendEmail({
-        eventType: "credits-depleted",
+        eventType: emailEvent,
         orgId,
         userId,
         runId,
@@ -277,13 +360,15 @@ router.post("/v1/credits/check", requireOrgHeaders, async (req, res) => {
       });
     }
 
-    res.json({
-      sufficient,
-      balance_cents: account.creditBalanceCents,
-      billing_mode: account.billingMode,
-    });
+    // Strip internal fields
+    const { _emailEvent, ...response } = result as Record<string, unknown>;
+    res.json(response);
   } catch (err) {
-    console.error("Error checking credits:", err);
+    console.error("Error authorizing credits:", err);
+    if (isStripeAuthError(err)) {
+      res.status(502).json({ error: "Payment provider authentication failed" });
+      return;
+    }
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -10,6 +10,7 @@ import {
   isStripeAuthError,
 } from "../lib/stripe.js";
 import { sendEmail } from "../lib/email-client.js";
+import { resolveRequiredCents } from "../lib/costs-client.js";
 
 const router = Router();
 
@@ -229,6 +230,7 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
 });
 
 // POST /v1/credits/authorize — synchronous pre-execution authorization with auto-reload attempt
+// Resolves prices from costs-service, then checks balance.
 router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
@@ -242,7 +244,22 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    const { required_cents } = parsed.data;
+    const { items } = parsed.data;
+
+    // Resolve prices from costs-service (outside transaction — read-only, no lock needed)
+    let requiredCents: number;
+    try {
+      requiredCents = await resolveRequiredCents(items, {
+        "x-org-id": orgId,
+        "x-user-id": userId,
+        "x-run-id": runId,
+        ...wfHeaders,
+      });
+    } catch (costErr) {
+      console.error("Failed to resolve prices from costs-service:", costErr);
+      res.status(502).json({ error: "Failed to resolve prices from costs-service" });
+      return;
+    }
 
     const result = await db.transaction(async (tx) => {
       const rows = await tx.execute<{
@@ -279,13 +296,14 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
           sufficient: true as const,
           balance_cents: null,
           billing_mode: "byok" as const,
+          required_cents: requiredCents,
         };
       }
 
       let currentBalance = account.credit_balance_cents;
 
       // If insufficient, try synchronous auto-reload for PAYG
-      if (currentBalance < required_cents) {
+      if (currentBalance < requiredCents) {
         if (
           account.billing_mode === "payg" &&
           account.stripe_payment_method_id &&
@@ -327,18 +345,20 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
               sufficient: false as const,
               balance_cents: currentBalance,
               billing_mode: account.billing_mode as "trial" | "payg",
+              required_cents: requiredCents,
               _emailEvent: "credits-reload-failed" as const,
             };
           }
         }
       }
 
-      const sufficient = currentBalance >= required_cents;
+      const sufficient = currentBalance >= requiredCents;
 
       return {
         sufficient: sufficient as boolean,
         balance_cents: currentBalance,
         billing_mode: account.billing_mode as "trial" | "byok" | "payg",
+        required_cents: requiredCents,
         _emailEvent: sufficient ? null : "credits-depleted" as const,
       };
     });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -97,9 +97,16 @@ export const CancelProvisionResponseSchema = z
 
 // --- Authorize ---
 
+export const AuthorizeCostItemSchema = z
+  .object({
+    costName: z.string().min(1),
+    quantity: z.number().int().positive(),
+  })
+  .openapi("AuthorizeCostItem");
+
 export const AuthorizeRequestSchema = z
   .object({
-    required_cents: z.number().int().positive(),
+    items: z.array(AuthorizeCostItemSchema).min(1),
     description: z.string().optional(),
   })
   .openapi("AuthorizeRequest");
@@ -109,6 +116,7 @@ export const AuthorizeResponseSchema = z
     sufficient: z.boolean(),
     balance_cents: z.number().int().nullable(),
     billing_mode: BillingModeSchema,
+    required_cents: z.number().int(),
   })
   .openapi("AuthorizeResponse");
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -95,22 +95,22 @@ export const CancelProvisionResponseSchema = z
   })
   .openapi("CancelProvisionResponse");
 
-// --- Check ---
+// --- Authorize ---
 
-export const CheckRequestSchema = z
+export const AuthorizeRequestSchema = z
   .object({
     required_cents: z.number().int().positive(),
     description: z.string().optional(),
   })
-  .openapi("CheckRequest");
+  .openapi("AuthorizeRequest");
 
-export const CheckResponseSchema = z
+export const AuthorizeResponseSchema = z
   .object({
     sufficient: z.boolean(),
     balance_cents: z.number().int().nullable(),
     billing_mode: BillingModeSchema,
   })
-  .openapi("CheckResponse");
+  .openapi("AuthorizeResponse");
 
 // --- Mode ---
 
@@ -325,21 +325,25 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/credits/check",
-  summary: "Pre-execution balance check (service-to-service). Sends depleted email if insufficient.",
+  path: "/v1/credits/authorize",
+  summary: "Synchronous pre-execution authorization. Attempts auto-reload if insufficient (PAYG). Sends email on failure.",
   request: {
     headers: protectedHeaders,
     body: {
-      content: { "application/json": { schema: CheckRequestSchema } },
+      content: { "application/json": { schema: AuthorizeRequestSchema } },
     },
   },
   responses: {
     200: {
-      description: "Balance check result",
-      content: { "application/json": { schema: CheckResponseSchema } },
+      description: "Authorization result",
+      content: { "application/json": { schema: AuthorizeResponseSchema } },
     },
     404: {
       description: "Billing account not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "Payment provider authentication failed",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -263,9 +263,10 @@ describe("Credits deduction endpoint", () => {
   });
 });
 
-describe("Credits check endpoint", () => {
+describe("Credits authorize endpoint", () => {
   const app = createTestApp();
   const orgId = "00000000-0000-0000-0000-000000000001";
+  const userId = "00000000-0000-0000-0000-000000000099";
   let stripeMocks: ReturnType<typeof setupStripeMocks>;
 
   beforeEach(async () => {
@@ -287,7 +288,7 @@ describe("Credits check endpoint", () => {
     });
 
     const res = await request(app)
-      .post("/v1/credits/check")
+      .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
       .send({ required_cents: 100 });
 
@@ -299,7 +300,7 @@ describe("Credits check endpoint", () => {
     });
   });
 
-  it("returns sufficient: false when balance is insufficient", async () => {
+  it("returns sufficient: false when balance is insufficient (trial, no reload)", async () => {
     await insertTestAccount({
       orgId,
       stripeCustomerId: "cus_123",
@@ -307,7 +308,7 @@ describe("Credits check endpoint", () => {
     });
 
     const res = await request(app)
-      .post("/v1/credits/check")
+      .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
       .send({ required_cents: 100 });
 
@@ -319,6 +320,67 @@ describe("Credits check endpoint", () => {
     });
   });
 
+  it("auto-reloads for PAYG and returns sufficient after reload", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_123",
+      billingMode: "payg",
+      creditBalanceCents: 50,
+      reloadAmountCents: 2000,
+      reloadThresholdCents: 200,
+      stripePaymentMethodId: "pm_123",
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send({ required_cents: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      sufficient: true,
+      balance_cents: 2050, // 50 + 2000 reload
+      billing_mode: "payg",
+    });
+    expect(stripeMocks.chargePaymentMethod).toHaveBeenCalledWith(
+      orgId,
+      userId,
+      "cus_123",
+      "pm_123",
+      2000,
+      "Auto-reload",
+      {}
+    );
+  });
+
+  it("returns sufficient: false when PAYG auto-reload fails", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_123",
+      billingMode: "payg",
+      creditBalanceCents: 50,
+      reloadAmountCents: 2000,
+      reloadThresholdCents: 200,
+      stripePaymentMethodId: "pm_123",
+    });
+
+    stripeMocks.chargePaymentMethod.mockRejectedValue(
+      new Error("Card declined")
+    );
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send({ required_cents: 100 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      sufficient: false,
+      balance_cents: 50,
+      billing_mode: "payg",
+    });
+  });
+
   it("always returns sufficient for BYOK mode", async () => {
     await insertTestAccount({
       orgId,
@@ -327,7 +389,7 @@ describe("Credits check endpoint", () => {
     });
 
     const res = await request(app)
-      .post("/v1/credits/check")
+      .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
       .send({ required_cents: 9999 });
 
@@ -341,7 +403,7 @@ describe("Credits check endpoint", () => {
 
   it("returns 404 for unknown org", async () => {
     const res = await request(app)
-      .post("/v1/credits/check")
+      .post("/v1/credits/authorize")
       .set(getAuthHeaders("00000000-0000-0000-0000-999999999999"))
       .send({ required_cents: 100 });
 
@@ -350,7 +412,7 @@ describe("Credits check endpoint", () => {
 
   it("validates request body", async () => {
     const res = await request(app)
-      .post("/v1/credits/check")
+      .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
       .send({ required_cents: -5 });
 

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -269,10 +269,22 @@ describe("Credits authorize endpoint", () => {
   const userId = "00000000-0000-0000-0000-000000000099";
   let stripeMocks: ReturnType<typeof setupStripeMocks>;
 
+  const authorizeBody = {
+    items: [
+      { costName: "anthropic-sonnet-4-5-tokens-input", quantity: 1000 },
+      { costName: "anthropic-sonnet-4-5-tokens-output", quantity: 500 },
+    ],
+    description: "content-generation — claude-sonnet-4-5",
+  };
+
   beforeEach(async () => {
     vi.restoreAllMocks();
     stripeMocks = setupStripeMocks();
     await cleanTestData();
+
+    // Mock costs-client to return deterministic prices
+    const costsClient = await import("../../src/lib/costs-client.js");
+    vi.spyOn(costsClient, "resolveRequiredCents").mockResolvedValue(100);
   });
 
   afterAll(async () => {
@@ -290,13 +302,14 @@ describe("Credits authorize endpoint", () => {
     const res = await request(app)
       .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
-      .send({ required_cents: 100 });
+      .send(authorizeBody);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       sufficient: true,
       balance_cents: 500,
       billing_mode: "trial",
+      required_cents: 100,
     });
   });
 
@@ -310,13 +323,14 @@ describe("Credits authorize endpoint", () => {
     const res = await request(app)
       .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
-      .send({ required_cents: 100 });
+      .send(authorizeBody);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       sufficient: false,
       balance_cents: 50,
       billing_mode: "trial",
+      required_cents: 100,
     });
   });
 
@@ -334,13 +348,14 @@ describe("Credits authorize endpoint", () => {
     const res = await request(app)
       .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
-      .send({ required_cents: 100 });
+      .send(authorizeBody);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       sufficient: true,
-      balance_cents: 2050, // 50 + 2000 reload
+      balance_cents: 2050,
       billing_mode: "payg",
+      required_cents: 100,
     });
     expect(stripeMocks.chargePaymentMethod).toHaveBeenCalledWith(
       orgId,
@@ -371,13 +386,14 @@ describe("Credits authorize endpoint", () => {
     const res = await request(app)
       .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
-      .send({ required_cents: 100 });
+      .send(authorizeBody);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       sufficient: false,
       balance_cents: 50,
       billing_mode: "payg",
+      required_cents: 100,
     });
   });
 
@@ -391,13 +407,14 @@ describe("Credits authorize endpoint", () => {
     const res = await request(app)
       .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
-      .send({ required_cents: 9999 });
+      .send(authorizeBody);
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       sufficient: true,
       balance_cents: null,
       billing_mode: "byok",
+      required_cents: 100,
     });
   });
 
@@ -405,17 +422,38 @@ describe("Credits authorize endpoint", () => {
     const res = await request(app)
       .post("/v1/credits/authorize")
       .set(getAuthHeaders("00000000-0000-0000-0000-999999999999"))
-      .send({ required_cents: 100 });
+      .send(authorizeBody);
 
     expect(res.status).toBe(404);
   });
 
-  it("validates request body", async () => {
+  it("validates request body — rejects empty items", async () => {
     const res = await request(app)
       .post("/v1/credits/authorize")
       .set(getAuthHeaders(orgId))
-      .send({ required_cents: -5 });
+      .send({ items: [] });
 
     expect(res.status).toBe(400);
+  });
+
+  it("returns 502 when costs-service is unavailable", async () => {
+    const costsClient = await import("../../src/lib/costs-client.js");
+    vi.spyOn(costsClient, "resolveRequiredCents").mockRejectedValue(
+      new Error("COSTS_SERVICE not configured")
+    );
+
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_123",
+      creditBalanceCents: 500,
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toContain("costs-service");
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,6 +8,8 @@ process.env.KEY_SERVICE_URL = "http://localhost:9999";
 process.env.KEY_SERVICE_API_KEY = "test-key-service-key";
 process.env.STRIPE_SECRET_KEY = "sk_test_fake";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec_test_fake";
+process.env.COSTS_SERVICE_URL = "http://localhost:9998";
+process.env.COSTS_SERVICE_API_KEY = "test-costs-service-key";
 process.env.NODE_ENV = "test";
 
 beforeAll(async () => {


### PR DESCRIPTION
## Summary
- **`POST /v1/credits/authorize`** now accepts `items: [{costName, quantity}]` instead of `required_cents`. Billing-service resolves prices internally via `GET /v1/platform-prices/{name}` on costs-service.
- Added `src/lib/costs-client.ts` — resolves unit prices and computes total required cents (`Math.ceil` of sum).
- Updated OpenAPI spec, Zod schemas, and 8 integration tests (all mock `resolveRequiredCents`).
- Returns 502 when costs-service is unavailable.

## Test plan
- [x] 8 authorize integration tests (sufficient, insufficient-trial, payg-reload, reload-fail, byok, 404, validation, costs-service-down)
- [x] All 104 tests pass across 10 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)