### PR TITLE
Add reload_threshold_cents and portal-sessions endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -162,10 +162,37 @@
             "type": "integer",
             "minimum": 0,
             "exclusiveMinimum": true
+          },
+          "reload_threshold_cents": {
+            "type": "integer",
+            "minimum": 0
           }
         },
         "required": [
           "mode"
+        ]
+      },
+      "PortalSessionResponse": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      },
+      "CreatePortalSessionRequest": {
+        "type": "object",
+        "properties": {
+          "return_url": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "return_url"
         ]
       },
       "DeductResponse": {
@@ -820,6 +847,126 @@
           },
           "400": {
             "description": "Invalid transition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/portal-sessions": {
+      "post": {
+        "summary": "Create Stripe Customer Portal session for payment method management",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow name injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-name",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePortalSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Portal session URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PortalSessionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "No Stripe customer or invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Billing account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Payment provider authentication failed",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import accountsRoutes from "./routes/accounts.js";
 import creditsRoutes from "./routes/credits.js";
 import provisionsRoutes from "./routes/provisions.js";
 import checkoutRoutes from "./routes/checkout.js";
+import portalRoutes from "./routes/portal.js";
 import webhookRoutes from "./routes/webhooks.js";
 import { requireApiKey } from "./middleware/auth.js";
 
@@ -47,6 +48,7 @@ app.use(accountsRoutes);
 app.use(creditsRoutes);
 app.use(provisionsRoutes);
 app.use(checkoutRoutes);
+app.use(portalRoutes);
 
 // 404 handler
 app.use((_req, res) => {

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -184,6 +184,23 @@ export async function chargePaymentMethod(
   );
 }
 
+// --- Portal ---
+
+export async function createPortalSession(
+  orgId: string,
+  userId: string,
+  stripeCustomerId: string,
+  returnUrl: string,
+  workflowHeaders?: Record<string, string>
+): Promise<Stripe.BillingPortal.Session> {
+  return withAuthRetry(buildIdentity(orgId, userId, workflowHeaders), (stripe) =>
+    stripe.billingPortal.sessions.create({
+      customer: stripeCustomerId,
+      return_url: returnUrl,
+    })
+  );
+}
+
 // --- Webhook ---
 
 export async function constructWebhookEvent(

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -195,7 +195,7 @@ router.patch("/v1/accounts/mode", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    const { mode, reload_amount_cents } = parsed.data;
+    const { mode, reload_amount_cents, reload_threshold_cents } = parsed.data;
 
     const [account] = await db
       .select()
@@ -235,6 +235,10 @@ router.patch("/v1/accounts/mode", requireOrgHeaders, async (req, res) => {
 
     if (mode === "payg" && reload_amount_cents) {
       updateData.reloadAmountCents = reload_amount_cents;
+    }
+
+    if (reload_threshold_cents !== undefined) {
+      updateData.reloadThresholdCents = reload_threshold_cents;
     }
 
     const [updated] = await db

--- a/src/routes/portal.ts
+++ b/src/routes/portal.ts
@@ -1,0 +1,61 @@
+import { Router } from "express";
+import { eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { billingAccounts } from "../db/schema.js";
+import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
+import { CreatePortalSessionRequestSchema } from "../schemas.js";
+import { createPortalSession, isStripeAuthError } from "../lib/stripe.js";
+
+const router = Router();
+
+// POST /v1/portal-sessions — create Stripe Customer Portal session
+router.post("/v1/portal-sessions", requireOrgHeaders, async (req, res) => {
+  try {
+    const orgId = req.headers["x-org-id"] as string;
+    const userId = req.headers["x-user-id"] as string;
+    const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
+    const parsed = CreatePortalSessionRequestSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.message });
+      return;
+    }
+
+    const { return_url } = parsed.data;
+
+    const [account] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId))
+      .limit(1);
+
+    if (!account) {
+      res.status(404).json({ error: "Billing account not found" });
+      return;
+    }
+
+    if (!account.stripeCustomerId) {
+      res.status(400).json({ error: "No Stripe customer associated with this account" });
+      return;
+    }
+
+    const session = await createPortalSession(
+      orgId,
+      userId,
+      account.stripeCustomerId,
+      return_url,
+      wfHeaders
+    );
+
+    res.json({ url: session.url });
+  } catch (err) {
+    console.error("Error creating portal session:", err);
+    if (isStripeAuthError(err)) {
+      res.status(502).json({ error: "Payment provider authentication failed" });
+      return;
+    }
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -126,6 +126,7 @@ export const UpdateModeRequestSchema = z
   .object({
     mode: z.enum(["byok", "payg"]),
     reload_amount_cents: z.number().int().positive().optional(),
+    reload_threshold_cents: z.number().int().min(0).optional(),
   })
   .openapi("UpdateModeRequest");
 
@@ -145,6 +146,20 @@ export const CheckoutResponseSchema = z
     session_id: z.string(),
   })
   .openapi("CheckoutResponse");
+
+// --- Portal Sessions ---
+
+export const CreatePortalSessionRequestSchema = z
+  .object({
+    return_url: z.string().url(),
+  })
+  .openapi("CreatePortalSessionRequest");
+
+export const PortalSessionResponseSchema = z
+  .object({
+    url: z.string(),
+  })
+  .openapi("PortalSessionResponse");
 
 // --- Balance ---
 
@@ -280,6 +295,38 @@ registry.registerPath({
     },
     400: {
       description: "Invalid transition",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/portal-sessions",
+  summary: "Create Stripe Customer Portal session for payment method management",
+  request: {
+    headers: protectedHeaders,
+    body: {
+      content: {
+        "application/json": { schema: CreatePortalSessionRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Portal session URL",
+      content: { "application/json": { schema: PortalSessionResponseSchema } },
+    },
+    400: {
+      description: "No Stripe customer or invalid request",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "Billing account not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "Payment provider authentication failed",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -37,6 +37,9 @@ export function setupStripeMocks() {
       status: "succeeded",
       amount: 2000,
     }),
+    createPortalSession: vi.fn().mockResolvedValue({
+      url: "https://billing.stripe.com/p/session/test_portal",
+    }),
     constructWebhookEvent: vi.fn(),
     resolvePlatformKey: vi.fn().mockResolvedValue({
       provider: "stripe",
@@ -62,6 +65,9 @@ export function setupStripeMocks() {
   );
   vi.spyOn(stripeLib, "chargePaymentMethod").mockImplementation(
     mocks.chargePaymentMethod
+  );
+  vi.spyOn(stripeLib, "createPortalSession").mockImplementation(
+    mocks.createPortalSession
   );
   vi.spyOn(stripeLib, "constructWebhookEvent").mockImplementation(
     mocks.constructWebhookEvent

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -5,6 +5,7 @@ import accountsRoutes from "../../src/routes/accounts.js";
 import creditsRoutes from "../../src/routes/credits.js";
 import provisionsRoutes from "../../src/routes/provisions.js";
 import checkoutRoutes from "../../src/routes/checkout.js";
+import portalRoutes from "../../src/routes/portal.js";
 import webhookRoutes from "../../src/routes/webhooks.js";
 import { requireApiKey } from "../../src/middleware/auth.js";
 
@@ -28,6 +29,7 @@ export function createTestApp() {
   app.use(creditsRoutes);
   app.use(provisionsRoutes);
   app.use(checkoutRoutes);
+  app.use(portalRoutes);
 
   app.use((_req: express.Request, res: express.Response) => {
     res.status(404).json({ error: "Not found" });

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -284,6 +284,67 @@ describe("Accounts endpoints", () => {
       expect(res.body.billingMode).toBe("payg");
     });
 
+    it("stores reload_threshold_cents when switching to payg", async () => {
+      await insertTestAccount({
+        orgId,
+        billingMode: "trial",
+        stripePaymentMethodId: "pm_123",
+      });
+
+      const res = await request(app)
+        .patch("/v1/accounts/mode")
+        .set(getAuthHeaders(orgId))
+        .send({
+          mode: "payg",
+          reload_amount_cents: 5000,
+          reload_threshold_cents: 1000,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.billingMode).toBe("payg");
+      expect(res.body.reloadAmountCents).toBe(5000);
+      expect(res.body.reloadThresholdCents).toBe(1000);
+    });
+
+    it("allows reload_threshold_cents of 0", async () => {
+      await insertTestAccount({
+        orgId,
+        billingMode: "trial",
+        stripePaymentMethodId: "pm_123",
+      });
+
+      const res = await request(app)
+        .patch("/v1/accounts/mode")
+        .set(getAuthHeaders(orgId))
+        .send({
+          mode: "payg",
+          reload_amount_cents: 5000,
+          reload_threshold_cents: 0,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.reloadThresholdCents).toBe(0);
+    });
+
+    it("rejects negative reload_threshold_cents", async () => {
+      await insertTestAccount({
+        orgId,
+        billingMode: "trial",
+        stripePaymentMethodId: "pm_123",
+      });
+
+      const res = await request(app)
+        .patch("/v1/accounts/mode")
+        .set(getAuthHeaders(orgId))
+        .send({
+          mode: "payg",
+          reload_amount_cents: 5000,
+          reload_threshold_cents: -100,
+        });
+
+      expect(res.status).toBe(400);
+    });
+
     it("rejects switching back to trial", async () => {
       await insertTestAccount({ orgId, billingMode: "byok" });
 

--- a/tests/integration/portal.test.ts
+++ b/tests/integration/portal.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
+import { setupStripeMocks, createStripeAuthError } from "../helpers/mock-stripe.js";
+
+describe("Portal Sessions endpoint", () => {
+  const app = createTestApp();
+  const orgId = "00000000-0000-0000-0000-000000000001";
+  let stripeMocks: ReturnType<typeof setupStripeMocks>;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    stripeMocks = setupStripeMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  describe("POST /v1/portal-sessions", () => {
+    it("creates a portal session for account with Stripe customer", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+      });
+
+      const res = await request(app)
+        .post("/v1/portal-sessions")
+        .set(getAuthHeaders(orgId))
+        .send({ return_url: "https://app.example.com/billing" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.url).toBe("https://billing.stripe.com/p/session/test_portal");
+      expect(stripeMocks.createPortalSession).toHaveBeenCalledWith(
+        orgId,
+        "00000000-0000-0000-0000-000000000099",
+        "cus_123",
+        "https://app.example.com/billing",
+        {}
+      );
+    });
+
+    it("returns 400 for invalid return_url", async () => {
+      await insertTestAccount({ orgId, stripeCustomerId: "cus_123" });
+
+      const res = await request(app)
+        .post("/v1/portal-sessions")
+        .set(getAuthHeaders(orgId))
+        .send({ return_url: "not-a-url" });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 when missing return_url", async () => {
+      await insertTestAccount({ orgId, stripeCustomerId: "cus_123" });
+
+      const res = await request(app)
+        .post("/v1/portal-sessions")
+        .set(getAuthHeaders(orgId))
+        .send({});
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 when account does not exist", async () => {
+      const res = await request(app)
+        .post("/v1/portal-sessions")
+        .set(getAuthHeaders(orgId))
+        .send({ return_url: "https://app.example.com/billing" });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 when account has no Stripe customer", async () => {
+      await insertTestAccount({ orgId, stripeCustomerId: undefined });
+
+      const res = await request(app)
+        .post("/v1/portal-sessions")
+        .set(getAuthHeaders(orgId))
+        .send({ return_url: "https://app.example.com/billing" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("No Stripe customer");
+    });
+
+    it("returns 502 when Stripe key is expired", async () => {
+      await insertTestAccount({ orgId, stripeCustomerId: "cus_123" });
+      stripeMocks.createPortalSession.mockRejectedValue(
+        createStripeAuthError("Expired API Key provided")
+      );
+
+      const res = await request(app)
+        .post("/v1/portal-sessions")
+        .set(getAuthHeaders(orgId))
+        .send({ return_url: "https://app.example.com/billing" });
+
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("Payment provider authentication failed");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **`reload_threshold_cents` in PATCH /v1/accounts/mode**: Added optional `reload_threshold_cents` (integer, min 0) to the request body. Dashboard users can now configure both the reload amount AND the threshold that triggers auto-reload.
- **POST /v1/portal-sessions**: New endpoint that creates a Stripe Customer Portal session. Request: `{ return_url: string }`. Response: `{ url: string }`. Enables "Manage payment method" button in the dashboard without building card management UI.

## Test plan
- [x] Integration tests for `reload_threshold_cents` persistence (including edge cases: 0 value, negative rejected)
- [x] Integration tests for portal sessions (happy path, missing customer, missing account, expired Stripe key)
- [x] Full test suite passes (113 tests)
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)