### PR TITLE
Auto-reload in multiples for large amounts

### DIFF
--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -14,6 +14,17 @@ import { resolveRequiredCents } from "../lib/costs-client.js";
 
 const router = Router();
 
+/**
+ * Compute the reload charge needed to cover `requiredCents` given `currentBalance`.
+ * Returns the smallest multiple of `reloadUnit` such that balance + charge >= required.
+ */
+function computeReloadCharge(currentBalance: number, requiredCents: number, reloadUnit: number): number {
+  const deficit = requiredCents - currentBalance;
+  if (deficit <= 0) return 0;
+  const multiples = Math.ceil(deficit / reloadUnit);
+  return multiples * reloadUnit;
+}
+
 // POST /v1/credits/deduct — deduct credits from org balance (allows negative balances)
 router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
   try {
@@ -62,21 +73,22 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
       const filter = eq(billingAccounts.orgId, orgId);
       let reloadFailed = false;
 
-      // If insufficient balance, try auto-reload
+      // If insufficient balance, try auto-reload (charge enough multiples to cover)
       if (currentBalance < amount_cents) {
         if (
           account.stripe_payment_method_id &&
           account.stripe_customer_id &&
           account.reload_amount_cents
         ) {
+          const chargeAmount = computeReloadCharge(currentBalance, amount_cents, account.reload_amount_cents);
           try {
             await chargePaymentMethod(
               orgId,
               userId,
               account.stripe_customer_id,
               account.stripe_payment_method_id,
-              account.reload_amount_cents,
-              "Auto-reload",
+              chargeAmount,
+              `Auto-reload (${chargeAmount / account.reload_amount_cents}x)`,
               wfHeaders
             );
 
@@ -84,13 +96,13 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
               orgId,
               userId,
               account.stripe_customer_id,
-              -account.reload_amount_cents,
-              "Auto-reload credit",
+              -chargeAmount,
+              `Auto-reload credit ($${(chargeAmount / 100).toFixed(2)})`,
               undefined,
               wfHeaders
             );
 
-            currentBalance += account.reload_amount_cents;
+            currentBalance += chargeAmount;
             await tx
               .update(billingAccounts)
               .set({
@@ -275,21 +287,22 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
 
       let currentBalance = account.credit_balance_cents;
 
-      // If insufficient, try synchronous auto-reload
+      // If insufficient, try synchronous auto-reload (charge enough multiples to cover)
       if (currentBalance < requiredCents) {
         if (
           account.stripe_payment_method_id &&
           account.stripe_customer_id &&
           account.reload_amount_cents
         ) {
+          const chargeAmount = computeReloadCharge(currentBalance, requiredCents, account.reload_amount_cents);
           try {
             await chargePaymentMethod(
               orgId,
               userId,
               account.stripe_customer_id,
               account.stripe_payment_method_id,
-              account.reload_amount_cents,
-              "Auto-reload",
+              chargeAmount,
+              `Auto-reload (${chargeAmount / account.reload_amount_cents}x)`,
               wfHeaders
             );
 
@@ -297,13 +310,13 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
               orgId,
               userId,
               account.stripe_customer_id,
-              -account.reload_amount_cents,
-              "Auto-reload credit",
+              -chargeAmount,
+              `Auto-reload credit ($${(chargeAmount / 100).toFixed(2)})`,
               undefined,
               wfHeaders
             );
 
-            currentBalance += account.reload_amount_cents;
+            currentBalance += chargeAmount;
             await tx
               .update(billingAccounts)
               .set({

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -92,7 +92,41 @@ describe("Credits deduction endpoint", () => {
       "cus_123",
       "pm_123",
       2000,
-      "Auto-reload",
+      "Auto-reload (1x)",
+      {}
+    );
+  });
+
+  it("charges multiple reloads when amount exceeds single reload", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_123",
+      creditBalanceCents: 200,
+      reloadAmountCents: 1000, // $10 reload unit
+      reloadThresholdCents: 200,
+      stripePaymentMethodId: "pm_123",
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({
+        amount_cents: 3700, // $37 deduction, need $35 more → 4x $10 = $40
+        description: "large deduction",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    // Balance: 200 + 4000 (4x reload) - 3700 = 500
+    expect(res.body.balance_cents).toBe(500);
+    expect(res.body.depleted).toBe(false);
+    expect(stripeMocks.chargePaymentMethod).toHaveBeenCalledWith(
+      orgId,
+      userId,
+      "cus_123",
+      "pm_123",
+      4000,
+      "Auto-reload (4x)",
       {}
     );
   });
@@ -330,7 +364,44 @@ describe("Credits authorize endpoint", () => {
       "cus_123",
       "pm_123",
       2000,
-      "Auto-reload",
+      "Auto-reload (1x)",
+      {}
+    );
+  });
+
+  it("charges multiple reloads when required amount exceeds single reload", async () => {
+    // Override costs-client to return a large required amount
+    const costsClient = await import("../../src/lib/costs-client.js");
+    vi.spyOn(costsClient, "resolveRequiredCents").mockResolvedValue(3700);
+
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_123",
+      creditBalanceCents: 200,
+      reloadAmountCents: 1000, // $10 reload unit
+      reloadThresholdCents: 200,
+      stripePaymentMethodId: "pm_123",
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    // Need 3700, have 200 → deficit 3500 → ceil(3500/1000) = 4 → charge 4000
+    expect(res.body).toEqual({
+      sufficient: true,
+      balance_cents: 4200, // 200 + 4000
+      required_cents: 3700,
+    });
+    expect(stripeMocks.chargePaymentMethod).toHaveBeenCalledWith(
+      orgId,
+      userId,
+      "cus_123",
+      "pm_123",
+      4000,
+      "Auto-reload (4x)",
       {}
     );
   });


### PR DESCRIPTION
## Summary
- When a deduction or authorization exceeds the single reload amount, billing-service now charges the **smallest multiple** of `reload_amount_cents` that covers the deficit
- Example: $10 reload unit, $37 deduction with $2 balance → charges 4x $10 = $40 (not just $10)
- Previously, a single reload was charged, which left the balance insufficient for large operations — deduct would go negative, authorize would return `sufficient: false`

## Test plan
- [x] New test: deduct with multi-reload ($10 unit, $37 deduction → 4x charge)
- [x] New test: authorize with multi-reload ($10 unit, $37 required → 4x charge)
- [x] Existing 1x reload tests updated and passing
- [x] Full suite: 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)