### PR TITLE
Auto-create billing account on first credit operation

### DIFF
--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -1,0 +1,56 @@
+import { eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { billingAccounts } from "../db/schema.js";
+import { createCustomer, createBalanceTransaction } from "./stripe.js";
+
+/**
+ * Find or auto-create a billing account for an org.
+ * Creates a Stripe customer and credits $2 trial balance on first access.
+ */
+export async function findOrCreateAccount(
+  orgId: string,
+  userId: string,
+  wfHeaders: Record<string, string>
+) {
+  const [existing] = await db
+    .select()
+    .from(billingAccounts)
+    .where(eq(billingAccounts.orgId, orgId))
+    .limit(1);
+
+  if (existing) return existing;
+
+  const stripeCustomer = await createCustomer(orgId, userId, undefined, wfHeaders);
+
+  await createBalanceTransaction(
+    orgId,
+    userId,
+    stripeCustomer.id,
+    -200,
+    "Trial credit: $2.00",
+    undefined,
+    wfHeaders
+  );
+
+  const [account] = await db
+    .insert(billingAccounts)
+    .values({
+      orgId,
+      stripeCustomerId: stripeCustomer.id,
+      creditBalanceCents: 200,
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  // Race condition: another request created it first
+  if (!account) {
+    const [refetched] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId))
+      .limit(1);
+    return refetched;
+  }
+
+  return account;
+}

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -10,6 +10,7 @@ import {
   listBalanceTransactions,
   isStripeAuthError,
 } from "../lib/stripe.js";
+import { findOrCreateAccount } from "../lib/account.js";
 
 const router = Router();
 
@@ -34,54 +35,7 @@ router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
     const userId = req.headers["x-user-id"] as string;
     const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
 
-    // Try to find existing account
-    const existing = await db
-      .select()
-      .from(billingAccounts)
-      .where(eq(billingAccounts.orgId, orgId))
-      .limit(1);
-
-    if (existing.length > 0) {
-      res.json(formatAccount(existing[0]));
-      return;
-    }
-
-    // Auto-create: Stripe customer + $2 trial credit
-    const stripeCustomer = await createCustomer(orgId, userId, undefined, wfHeaders);
-
-    // Credit $2 (negative amount = credit in Stripe)
-    await createBalanceTransaction(
-      orgId,
-      userId,
-      stripeCustomer.id,
-      -200,
-      "Trial credit: $2.00",
-      undefined,
-      wfHeaders
-    );
-
-    // Insert with ON CONFLICT for race condition safety
-    const [account] = await db
-      .insert(billingAccounts)
-      .values({
-        orgId,
-        stripeCustomerId: stripeCustomer.id,
-        creditBalanceCents: 200,
-      })
-      .onConflictDoNothing()
-      .returning();
-
-    // If conflict (another request created it), re-fetch
-    if (!account) {
-      const [refetched] = await db
-        .select()
-        .from(billingAccounts)
-        .where(eq(billingAccounts.orgId, orgId))
-        .limit(1);
-      res.json(formatAccount(refetched));
-      return;
-    }
-
+    const account = await findOrCreateAccount(orgId, userId, wfHeaders);
     res.json(formatAccount(account));
   } catch (err) {
     console.error("Error getting/creating account:", err);

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -5,6 +5,7 @@ import { billingAccounts } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { CreateCheckoutRequestSchema } from "../schemas.js";
 import { createCustomer, createCheckoutSession, isStripeAuthError } from "../lib/stripe.js";
+import { findOrCreateAccount } from "../lib/account.js";
 
 const router = Router();
 
@@ -25,33 +26,7 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
     const filter = eq(billingAccounts.orgId, orgId);
 
     // Get or create billing account
-    let [account] = await db
-      .select()
-      .from(billingAccounts)
-      .where(filter)
-      .limit(1);
-
-    if (!account) {
-      // Auto-create account with Stripe customer
-      const stripeCustomer = await createCustomer(orgId, userId, undefined, wfHeaders);
-
-      const [created] = await db
-        .insert(billingAccounts)
-        .values({
-          orgId,
-          stripeCustomerId: stripeCustomer.id,
-          creditBalanceCents: 200,
-        })
-        .onConflictDoNothing()
-        .returning();
-
-      account = created || (await db
-        .select()
-        .from(billingAccounts)
-        .where(filter)
-        .limit(1)
-      )[0];
-    }
+    let account = await findOrCreateAccount(orgId, userId, wfHeaders);
 
     if (!account.stripeCustomerId) {
       // Account exists but no Stripe customer — create one

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -11,6 +11,7 @@ import {
 } from "../lib/stripe.js";
 import { sendEmail } from "../lib/email-client.js";
 import { resolveRequiredCents } from "../lib/costs-client.js";
+import { findOrCreateAccount } from "../lib/account.js";
 
 const router = Router();
 
@@ -40,6 +41,9 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
     }
 
     const { amount_cents, description } = parsed.data;
+
+    // Ensure account exists (auto-create with $2 trial credit if new)
+    await findOrCreateAccount(orgId, userId, wfHeaders);
 
     // Use Drizzle transaction with FOR UPDATE lock to prevent double-spend
     const result = await db.transaction(async (tx) => {
@@ -257,6 +261,9 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
       res.status(502).json({ error: "Failed to resolve prices from costs-service" });
       return;
     }
+
+    // Ensure account exists (auto-create with $2 trial credit if new)
+    await findOrCreateAccount(orgId, userId, wfHeaders);
 
     const result = await db.transaction(async (tx) => {
       const rows = await tx.execute<{

--- a/src/routes/provisions.ts
+++ b/src/routes/provisions.ts
@@ -10,6 +10,7 @@ import {
   isStripeAuthError,
 } from "../lib/stripe.js";
 import { sendEmail } from "../lib/email-client.js";
+import { findOrCreateAccount } from "../lib/account.js";
 
 const router = Router();
 
@@ -29,6 +30,9 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
     }
 
     const { amount_cents, description } = parsed.data;
+
+    // Ensure account exists (auto-create with $2 trial credit if new)
+    await findOrCreateAccount(orgId, userId, fwdHeaders);
 
     const result = await db.transaction(async (tx) => {
       const rows = await tx.execute<{

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -159,7 +159,7 @@ describe("Credits deduction endpoint", () => {
     expect(res.body.balance_cents).toBe(-2);
   });
 
-  it("returns 404 for unknown org", async () => {
+  it("auto-creates account for unknown org and deducts from trial balance", async () => {
     const res = await request(app)
       .post("/v1/credits/deduct")
       .set(getAuthHeaders("00000000-0000-0000-0000-999999999999"))
@@ -168,7 +168,10 @@ describe("Credits deduction endpoint", () => {
         description: "test",
       });
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    // Auto-created with 200 cents ($2), then deducted 5
+    expect(res.body.balance_cents).toBe(195);
   });
 
   it("validates request body", async () => {
@@ -433,13 +436,16 @@ describe("Credits authorize endpoint", () => {
     });
   });
 
-  it("returns 404 for unknown org", async () => {
+  it("auto-creates account for unknown org and authorizes from trial balance", async () => {
     const res = await request(app)
       .post("/v1/credits/authorize")
       .set(getAuthHeaders("00000000-0000-0000-0000-999999999999"))
       .send(authorizeBody);
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
+    expect(res.body.sufficient).toBe(true);
+    // Auto-created with 200 cents ($2), costs-service mock returns 100
+    expect(res.body.balance_cents).toBe(200);
   });
 
   it("validates request body — rejects empty items", async () => {

--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -56,13 +56,16 @@ describe("Credit provision endpoints", () => {
       expect(res.body.depleted).toBe(true);
     });
 
-    it("returns 404 for unknown org", async () => {
+    it("auto-creates account for unknown org and provisions from trial balance", async () => {
       const res = await request(app)
         .post("/v1/credits/provision")
         .set(getAuthHeaders("00000000-0000-0000-0000-999999999999"))
         .send({ amount_cents: 100, description: "test" });
 
-      expect(res.status).toBe(404);
+      expect(res.status).toBe(200);
+      expect(res.body.provision_id).toBeDefined();
+      // Auto-created with 200 cents ($2), then provisioned 100
+      expect(res.body.balance_cents).toBe(100);
     });
 
     it("stores workflow headers in provision record", async () => {


### PR DESCRIPTION
## Summary
- Extracts `findOrCreateAccount()` shared helper used by all endpoints
- `POST /v1/credits/authorize`, `POST /v1/credits/deduct`, and `POST /v1/credits/provision` now auto-create the billing account (with Stripe customer + $2 trial credit) if it doesn't exist
- Previously, orgs that hadn't called `GET /v1/accounts` first would get 404 on credit operations — this caused the 502 errors in api-service campaign creation (org `b645207b`)
- Also deduplicates auto-creation logic from `GET /v1/accounts` and `POST /v1/checkout-sessions`

## Test plan
- [x] Updated: deduct/authorize/provision "unknown org" tests now verify auto-creation + correct balance
- [x] All existing tests still pass (114/114)
- [x] OpenAPI spec unchanged (no schema changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)