### PR TITLE
Add diagnostic logging for billing 400s

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -44,16 +44,19 @@ export function requireOrgHeaders(
 ) {
   const orgId = req.headers["x-org-id"] as string;
   if (!orgId) {
+    console.warn(`[billing] 400 on ${req.method} ${req.path}: missing x-org-id`);
     res.status(400).json({ error: "x-org-id header is required" });
     return;
   }
   const userId = req.headers["x-user-id"] as string;
   if (!userId) {
+    console.warn(`[billing] 400 on ${req.method} ${req.path}: missing x-user-id (orgId=${orgId})`);
     res.status(400).json({ error: "x-user-id header is required" });
     return;
   }
   const runId = req.headers["x-run-id"] as string;
   if (!runId) {
+    console.warn(`[billing] 400 on ${req.method} ${req.path}: missing x-run-id (orgId=${orgId})`);
     res.status(400).json({ error: "x-run-id header is required" });
     return;
   }


### PR DESCRIPTION
## Summary
- Adds console.warn logging in `requireOrgHeaders` middleware to identify which header is missing when billing-service returns 400
- Needed to debug persistent `billing-service returned 400` errors from runs-service

## Test plan
- Deploy and check Railway logs for billing-service to see which header is consistently missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)