### PR TITLE
Switch diagnostic logging to console.error

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -44,19 +44,19 @@ export function requireOrgHeaders(
 ) {
   const orgId = req.headers["x-org-id"] as string;
   if (!orgId) {
-    console.warn(`[billing] 400 on ${req.method} ${req.path}: missing x-org-id`);
+    console.error(`[billing-400] ${req.method} ${req.path}: missing x-org-id`);
     res.status(400).json({ error: "x-org-id header is required" });
     return;
   }
   const userId = req.headers["x-user-id"] as string;
   if (!userId) {
-    console.warn(`[billing] 400 on ${req.method} ${req.path}: missing x-user-id (orgId=${orgId})`);
+    console.error(`[billing-400] ${req.method} ${req.path}: missing x-user-id (orgId=${orgId})`);
     res.status(400).json({ error: "x-user-id header is required" });
     return;
   }
   const runId = req.headers["x-run-id"] as string;
   if (!runId) {
-    console.warn(`[billing] 400 on ${req.method} ${req.path}: missing x-run-id (orgId=${orgId})`);
+    console.error(`[billing-400] ${req.method} ${req.path}: missing x-run-id (orgId=${orgId})`);
     res.status(400).json({ error: "x-run-id header is required" });
     return;
   }


### PR DESCRIPTION
## Summary
- Railway log viewer wasn't surfacing `console.warn` output from PR #25
- Switch to `console.error` so missing-header 400s are actually visible in logs
- Needed to confirm whether the remaining 400s are caused by missing `x-run-id`

## Test plan
- Deploy, trigger a billing call, check Railway logs for `[billing-400]` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)