### PR TITLE
Fixed Stripe webhook route without orgId param

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1676,26 +1676,16 @@
         }
       }
     },
-    "/v1/webhooks/stripe/{orgId}": {
+    "/v1/webhooks/stripe": {
       "post": {
-        "summary": "Stripe webhook handler (per-org)",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "required": true,
-            "name": "orgId",
-            "in": "path"
-          }
-        ],
+        "summary": "Stripe webhook handler",
+        "description": "Fixed URL for Stripe webhook. Organization is resolved from the Stripe customer ID in the event payload.",
         "responses": {
           "200": {
             "description": "Webhook processed"
           },
           "400": {
-            "description": "Invalid signature"
+            "description": "Invalid signature or missing stripe-signature header"
           }
         }
       }

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -204,12 +204,11 @@ export async function createPortalSession(
 // --- Webhook ---
 
 export async function constructWebhookEvent(
-  orgId: string,
   payload: Buffer,
   signature: string
 ): Promise<Stripe.Event> {
-  // Webhook calls come from Stripe, not from users — use "system" as userId
-  const identity: IdentityContext = { orgId, userId: "system" };
+  // Webhook calls come from Stripe, not from users — use "system" identity
+  const identity: IdentityContext = { orgId: "system", userId: "system" };
   if (!cachedWebhookSecret) {
     const result = await resolvePlatformKey("stripe-webhook", identity, {
       service: "billing",

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -10,11 +10,10 @@ import type Stripe from "stripe";
 
 const router = Router();
 
-// POST /v1/webhooks/stripe/:orgId — Stripe webhook handler (per-org)
+// POST /v1/webhooks/stripe — Stripe webhook handler (fixed URL, org resolved from customer)
 // NOTE: This route uses express.raw() body parser (mounted before express.json() in index.ts)
-router.post("/v1/webhooks/stripe/:orgId", async (req, res) => {
+router.post("/v1/webhooks/stripe", async (req, res) => {
   try {
-    const orgId = req.params.orgId;
     const signature = req.headers["stripe-signature"] as string;
     if (!signature) {
       res.status(400).json({ error: "Missing stripe-signature header" });
@@ -23,7 +22,7 @@ router.post("/v1/webhooks/stripe/:orgId", async (req, res) => {
 
     let event: Stripe.Event;
     try {
-      event = await constructWebhookEvent(orgId, req.body as Buffer, signature);
+      event = await constructWebhookEvent(req.body as Buffer, signature);
     } catch (err) {
       console.error("Webhook signature verification failed:", err);
       res.status(400).json({ error: "Invalid signature" });
@@ -33,7 +32,6 @@ router.post("/v1/webhooks/stripe/:orgId", async (req, res) => {
     switch (event.type) {
       case "checkout.session.completed": {
         await handleCheckoutCompleted(
-          orgId,
           event.data.object as Stripe.Checkout.Session
         );
         break;
@@ -63,7 +61,7 @@ router.post("/v1/webhooks/stripe/:orgId", async (req, res) => {
   }
 });
 
-async function handleCheckoutCompleted(orgId: string, session: Stripe.Checkout.Session) {
+async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
   const customerId = session.customer as string;
   if (!customerId) return;
 
@@ -92,7 +90,7 @@ async function handleCheckoutCompleted(orgId: string, session: Stripe.Checkout.S
   // Credit the balance with the reload amount
   if (reloadAmountCents && account.stripeCustomerId) {
     await createBalanceTransaction(
-      orgId,
+      account.orgId,
       "system",
       account.stripeCustomerId,
       -reloadAmountCents,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -504,15 +504,12 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
-  path: "/v1/webhooks/stripe/{orgId}",
-  summary: "Stripe webhook handler (per-org)",
-  request: {
-    params: z.object({
-      orgId: z.string().uuid(),
-    }),
-  },
+  path: "/v1/webhooks/stripe",
+  summary: "Stripe webhook handler",
+  description:
+    "Fixed URL for Stripe webhook. Organization is resolved from the Stripe customer ID in the event payload.",
   responses: {
     200: { description: "Webhook processed" },
-    400: { description: "Invalid signature" },
+    400: { description: "Invalid signature or missing stripe-signature header" },
   },
 });

--- a/tests/integration/webhooks.test.ts
+++ b/tests/integration/webhooks.test.ts
@@ -25,7 +25,7 @@ describe("Stripe webhooks", () => {
 
   it("rejects requests without stripe-signature", async () => {
     const res = await request(app)
-      .post(`/v1/webhooks/stripe/${orgId}`)
+      .post("/v1/webhooks/stripe")
       .set("Content-Type", "application/json")
       .send(JSON.stringify({ type: "test" }));
 
@@ -39,7 +39,7 @@ describe("Stripe webhooks", () => {
     });
 
     const res = await request(app)
-      .post(`/v1/webhooks/stripe/${orgId}`)
+      .post("/v1/webhooks/stripe")
       .set("Content-Type", "application/json")
       .set("stripe-signature", "invalid_sig")
       .send(JSON.stringify({ type: "test" }));
@@ -69,7 +69,7 @@ describe("Stripe webhooks", () => {
     });
 
     const res = await request(app)
-      .post(`/v1/webhooks/stripe/${orgId}`)
+      .post("/v1/webhooks/stripe")
       .set("Content-Type", "application/json")
       .set("stripe-signature", "valid_sig")
       .send(JSON.stringify({ type: "checkout.session.completed" }));
@@ -107,7 +107,7 @@ describe("Stripe webhooks", () => {
     });
 
     const res = await request(app)
-      .post(`/v1/webhooks/stripe/${orgId}`)
+      .post("/v1/webhooks/stripe")
       .set("Content-Type", "application/json")
       .set("stripe-signature", "valid_sig")
       .send(JSON.stringify({ type: "payment_intent.succeeded" }));
@@ -131,7 +131,7 @@ describe("Stripe webhooks", () => {
     });
 
     const res = await request(app)
-      .post(`/v1/webhooks/stripe/${orgId}`)
+      .post("/v1/webhooks/stripe")
       .set("Content-Type", "application/json")
       .set("stripe-signature", "valid_sig")
       .send(JSON.stringify({ type: "some.unknown.event" }));

--- a/tests/unit/stripe.test.ts
+++ b/tests/unit/stripe.test.ts
@@ -81,7 +81,7 @@ describe("Stripe platform key resolution", () => {
     );
   });
 
-  it("webhook uses orgId and 'system' userId for identity context", async () => {
+  it("webhook uses 'system' identity for platform webhook secret", async () => {
     const mockResolvePlatformKey = vi.fn().mockResolvedValue({
       provider: "stripe-webhook",
       key: "whsec_test",
@@ -106,12 +106,12 @@ describe("Stripe platform key resolution", () => {
 
     const { constructWebhookEvent } = await import("../../src/lib/stripe.js");
 
-    await constructWebhookEvent("org-webhook", Buffer.from("{}"), "sig_test");
+    await constructWebhookEvent(Buffer.from("{}"), "sig_test");
 
-    // Webhook secret resolution should use orgId from param and "system" userId
+    // Webhook secret resolution uses system identity (no org needed)
     expect(mockResolvePlatformKey).toHaveBeenCalledWith(
       "stripe-webhook",
-      { orgId: "org-webhook", userId: "system" },
+      { orgId: "system", userId: "system" },
       { service: "billing", method: "POST", path: "/v1/webhooks/stripe" }
     );
   });


### PR DESCRIPTION
## Summary
- Changed `POST /v1/webhooks/stripe/:orgId` → `POST /v1/webhooks/stripe` (fixed URL)
- Org is now resolved from the Stripe customer ID in the event payload via the `billing_accounts` table
- Webhook secret uses a system identity since it's a platform-level secret, not per-org

## Test plan
- [x] All 114 existing tests pass
- [x] Webhook integration tests updated to use the new fixed route
- [x] Unit test updated for new `constructWebhookEvent` signature (no orgId param)

🤖 Generated with [Claude Code](https://claude.com/claude-code)