### PR TITLE
Fix payment method not saved after Stripe Checkout

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -201,6 +201,17 @@ export async function createPortalSession(
   );
 }
 
+// --- PaymentIntent retrieval ---
+
+export async function retrievePaymentIntent(
+  paymentIntentId: string
+): Promise<Stripe.PaymentIntent> {
+  const identity: IdentityContext = { orgId: "system", userId: "system" };
+  return withAuthRetry(identity, (stripe) =>
+    stripe.paymentIntents.retrieve(paymentIntentId)
+  );
+}
+
 // --- Webhook ---
 
 export async function constructWebhookEvent(

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -5,6 +5,7 @@ import { billingAccounts } from "../db/schema.js";
 import {
   constructWebhookEvent,
   createBalanceTransaction,
+  retrievePaymentIntent,
 } from "../lib/stripe.js";
 import type Stripe from "stripe";
 
@@ -78,9 +79,19 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
     return;
   }
 
-  // Extract payment method from the session
-  const sessionAny = session as unknown as Record<string, unknown>;
-  const paymentMethodId = (sessionAny.payment_method as string) ?? null;
+  // Extract payment method from the PaymentIntent (not on the session directly)
+  let paymentMethodId: string | null = null;
+  const piId =
+    typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : session.payment_intent?.id;
+  if (piId) {
+    const paymentIntent = await retrievePaymentIntent(piId);
+    paymentMethodId =
+      typeof paymentIntent.payment_method === "string"
+        ? paymentIntent.payment_method
+        : paymentIntent.payment_method?.id ?? null;
+  }
 
   // Get reload amount from session metadata or account
   const reloadAmountCents = session.metadata?.reload_amount_cents

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -40,6 +40,11 @@ export function setupStripeMocks() {
     createPortalSession: vi.fn().mockResolvedValue({
       url: "https://billing.stripe.com/p/session/test_portal",
     }),
+    retrievePaymentIntent: vi.fn().mockResolvedValue({
+      id: "pi_mock",
+      payment_method: "pm_mock",
+      status: "succeeded",
+    }),
     constructWebhookEvent: vi.fn(),
     resolvePlatformKey: vi.fn().mockResolvedValue({
       provider: "stripe",
@@ -68,6 +73,9 @@ export function setupStripeMocks() {
   );
   vi.spyOn(stripeLib, "createPortalSession").mockImplementation(
     mocks.createPortalSession
+  );
+  vi.spyOn(stripeLib, "retrievePaymentIntent").mockImplementation(
+    mocks.retrievePaymentIntent
   );
   vi.spyOn(stripeLib, "constructWebhookEvent").mockImplementation(
     mocks.constructWebhookEvent

--- a/tests/integration/webhooks.test.ts
+++ b/tests/integration/webhooks.test.ts
@@ -62,10 +62,16 @@ describe("Stripe webhooks", () => {
           customer: "cus_123",
           payment_intent: "pi_123",
           payment_method_types: ["card"],
-          payment_method: "pm_new_123",
           metadata: { reload_amount_cents: "2000" },
         },
       },
+    });
+
+    // The payment method is on the PaymentIntent, not the session
+    stripeMocks.retrievePaymentIntent.mockResolvedValue({
+      id: "pi_123",
+      payment_method: "pm_new_123",
+      status: "succeeded",
     });
 
     const res = await request(app)


### PR DESCRIPTION
## Summary
- **Bug**: `checkout.session.completed` handler read `session.payment_method` directly, which is always undefined on payment-mode Checkout sessions — the payment method lives on the PaymentIntent, not the session
- **Fix**: Retrieve the PaymentIntent from Stripe via the session's `payment_intent` ID, extract the `payment_method`, and persist it to `billing_accounts.stripe_payment_method_id`
- Added `retrievePaymentIntent` helper to `stripe.ts`; updated test to mock the PI retrieval instead of putting `payment_method` on the session

## Test plan
- [x] Existing webhook test updated to verify payment method is extracted from PaymentIntent
- [x] All 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)