### PR TITLE
Add x-feature-slug header

### DIFF
--- a/drizzle/0005_true_madelyne_pryor.sql
+++ b/drizzle/0005_true_madelyne_pryor.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "credit_provisions" ADD COLUMN "feature_slug" text;--> statement-breakpoint
+ALTER TABLE "billing_accounts" DROP COLUMN IF EXISTS "billing_mode";

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,248 @@
+{
+  "id": "4f87c80a-5740-4c24-b1d3-766234cfd70d",
+  "prevId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.billing_accounts": {
+      "name": "billing_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_balance_cents": {
+          "name": "credit_balance_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 200
+        },
+        "reload_amount_cents": {
+          "name": "reload_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reload_threshold_cents": {
+          "name": "reload_threshold_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 200
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_accounts_org_id": {
+          "name": "idx_billing_accounts_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_accounts_stripe_customer": {
+          "name": "idx_billing_accounts_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_provisions": {
+      "name": "credit_provisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_slug": {
+          "name": "feature_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_provisions_org_id": {
+          "name": "idx_credit_provisions_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_provisions_status": {
+          "name": "idx_credit_provisions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1774329600000,
       "tag": "0004_remove_billing_mode",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1774318485186,
+      "tag": "0005_true_madelyne_pryor",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -516,6 +516,15 @@
             "required": false,
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -617,6 +626,15 @@
             "required": false,
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -697,6 +715,15 @@
             },
             "required": false,
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -788,6 +815,15 @@
             },
             "required": false,
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -897,6 +933,15 @@
             "required": false,
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "responses": {
@@ -987,6 +1032,15 @@
             },
             "required": false,
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -1109,6 +1163,15 @@
             "required": false,
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1209,6 +1272,15 @@
             },
             "required": false,
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -1311,6 +1383,15 @@
             "required": false,
             "name": "x-workflow-name",
             "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -1411,6 +1492,15 @@
             },
             "required": false,
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -1520,6 +1610,15 @@
             },
             "required": false,
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],
@@ -1639,6 +1738,15 @@
             },
             "required": false,
             "name": "x-workflow-name",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
             "in": "header"
           }
         ],

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -47,6 +47,7 @@ export const creditProvisions = pgTable(
     campaignId: text("campaign_id"),
     brandId: text("brand_id"),
     workflowName: text("workflow_name"),
+    featureSlug: text("feature_slug"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,6 +4,7 @@ export interface WorkflowHeaders {
   campaignId?: string;
   brandId?: string;
   workflowName?: string;
+  featureSlug?: string;
 }
 
 /** Extract optional workflow-tracking headers injected by workflow-service. */
@@ -12,6 +13,7 @@ export function getWorkflowHeaders(req: Request): WorkflowHeaders {
     campaignId: req.headers["x-campaign-id"] as string | undefined,
     brandId: req.headers["x-brand-id"] as string | undefined,
     workflowName: req.headers["x-workflow-name"] as string | undefined,
+    featureSlug: req.headers["x-feature-slug"] as string | undefined,
   };
 }
 
@@ -21,6 +23,7 @@ export function forwardWorkflowHeaders(wf: WorkflowHeaders): Record<string, stri
   if (wf.campaignId) headers["x-campaign-id"] = wf.campaignId;
   if (wf.brandId) headers["x-brand-id"] = wf.brandId;
   if (wf.workflowName) headers["x-workflow-name"] = wf.workflowName;
+  if (wf.featureSlug) headers["x-feature-slug"] = wf.featureSlug;
   return headers;
 }
 

--- a/src/routes/provisions.ts
+++ b/src/routes/provisions.ts
@@ -83,6 +83,7 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
           campaignId: wfHeaders.campaignId,
           brandId: wfHeaders.brandId,
           workflowName: wfHeaders.workflowName,
+          featureSlug: wfHeaders.featureSlug,
         })
         .returning();
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -191,6 +191,7 @@ const protectedHeaders = z.object({
   "x-campaign-id": z.string().optional().openapi({ description: "Campaign ID injected by workflow-service" }),
   "x-brand-id": z.string().optional().openapi({ description: "Brand ID injected by workflow-service" }),
   "x-workflow-name": z.string().optional().openapi({ description: "Workflow name injected by workflow-service" }),
+  "x-feature-slug": z.string().optional().openapi({ description: "Feature slug for tracking" }),
 });
 
 registry.registerPath({

--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -82,6 +82,7 @@ describe("Credit provision endpoints", () => {
           "x-campaign-id": "camp_42",
           "x-brand-id": "brand_7",
           "x-workflow-name": "outreach-flow",
+          "x-feature-slug": "press-outreach",
         })
         .send({ amount_cents: 50, description: "tracked provision" });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -29,12 +29,16 @@ beforeAll(async () => {
       "campaign_id" text,
       "brand_id" text,
       "workflow_name" text,
+      "feature_slug" text,
       "created_at" timestamp with time zone DEFAULT now() NOT NULL,
       "updated_at" timestamp with time zone DEFAULT now() NOT NULL
     )
   `;
   await sql`CREATE INDEX IF NOT EXISTS "idx_credit_provisions_org_id" ON "credit_provisions" USING btree ("org_id")`;
   await sql`CREATE INDEX IF NOT EXISTS "idx_credit_provisions_status" ON "credit_provisions" USING btree ("status")`;
+
+  // Add feature_slug column if it doesn't exist (migration 0005)
+  await sql`ALTER TABLE "credit_provisions" ADD COLUMN IF NOT EXISTS "feature_slug" text`;
 
   // Drop billing_mode column if it still exists (migration 0004)
   await sql`


### PR DESCRIPTION
## Summary
- Accept `x-feature-slug` header on all authenticated endpoints
- Propagate it in all downstream service-to-service calls
- Store `feature_slug` in `credit_provisions` table (new column via migration 0005)
- Updated OpenAPI spec with the new header

## Test plan
- [x] Existing test updated to include `x-feature-slug` in workflow headers test
- [x] All 114 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)