### PR TITLE
Fix migration 0005 skipped due to timestamp ordering

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -40,7 +40,7 @@
     {
       "idx": 5,
       "version": "7",
-      "when": 1774318485186,
+      "when": 1774416000000,
       "tag": "0005_true_madelyne_pryor",
       "breakpoints": true
     }

--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import request from "supertest";
+import { eq } from "drizzle-orm";
+import { db } from "../../src/db/index.js";
+import { creditProvisions } from "../../src/db/schema.js";
 import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
 import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
 import { setupStripeMocks } from "../helpers/mock-stripe.js";
@@ -88,6 +91,18 @@ describe("Credit provision endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.provision_id).toBeDefined();
+
+      // Verify all workflow headers including feature_slug are persisted
+      const [row] = await db
+        .select()
+        .from(creditProvisions)
+        .where(eq(creditProvisions.id, res.body.provision_id))
+        .limit(1);
+
+      expect(row.campaignId).toBe("camp_42");
+      expect(row.brandId).toBe("brand_7");
+      expect(row.workflowName).toBe("outreach-flow");
+      expect(row.featureSlug).toBe("press-outreach");
     });
 
     it("validates request body", async () => {


### PR DESCRIPTION
## Summary
- Migration `0005_true_madelyne_pryor` (adds `feature_slug` column to `credit_provisions`) was never applied in production because its journal timestamp (`1774318485186`) was older than migration `0004` (`1774329600000`). Drizzle's migrator only runs migrations newer than the last applied one, so it was silently skipped on every deploy.
- Fixed by updating the journal timestamp to `1774416000000` (~24h after `0004`), so it will be applied automatically on next deployment.
- Added regression test verifying `feature_slug` is persisted in the DB when `x-feature-slug` header is sent.

## Root cause
`drizzle-kit generate` assigned a timestamp to migration 0005 that was chronologically before 0004, likely due to 0004 having a manually-set round timestamp.

## Test plan
- [x] All 13 provision integration tests pass
- [ ] Verify `feature_slug` column appears in prod after next deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)