### PR TITLE
Rename workflow_name → workflow_slug

### DIFF
--- a/drizzle/0006_rename_workflow_slug.sql
+++ b/drizzle/0006_rename_workflow_slug.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "credit_provisions" RENAME COLUMN "workflow_name" TO "workflow_slug";

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,248 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "prevId": "4f87c80a-5740-4c24-b1d3-766234cfd70d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.billing_accounts": {
+      "name": "billing_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_balance_cents": {
+          "name": "credit_balance_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 200
+        },
+        "reload_amount_cents": {
+          "name": "reload_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reload_threshold_cents": {
+          "name": "reload_threshold_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 200
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_accounts_org_id": {
+          "name": "idx_billing_accounts_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_accounts_stripe_customer": {
+          "name": "idx_billing_accounts_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_provisions": {
+      "name": "credit_provisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_slug": {
+          "name": "workflow_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_slug": {
+          "name": "feature_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_provisions_org_id": {
+          "name": "idx_credit_provisions_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_provisions_status": {
+          "name": "idx_credit_provisions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1774416000000,
       "tag": "0005_true_madelyne_pryor",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1774934400000,
+      "tag": "0006_rename_workflow_slug",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -511,10 +511,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -621,10 +621,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -711,10 +711,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -811,10 +811,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -928,10 +928,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -1028,10 +1028,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -1158,10 +1158,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -1268,10 +1268,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -1378,10 +1378,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -1488,10 +1488,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -1606,10 +1606,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {
@@ -1734,10 +1734,10 @@
           {
             "schema": {
               "type": "string",
-              "description": "Workflow name injected by workflow-service"
+              "description": "Workflow slug injected by workflow-service"
             },
             "required": false,
-            "name": "x-workflow-name",
+            "name": "x-workflow-slug",
             "in": "header"
           },
           {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -46,7 +46,7 @@ export const creditProvisions = pgTable(
     description: text("description"),
     campaignId: text("campaign_id"),
     brandId: text("brand_id"),
-    workflowName: text("workflow_name"),
+    workflowSlug: text("workflow_slug"),
     featureSlug: text("feature_slug"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -3,7 +3,7 @@ import { Request, Response, NextFunction } from "express";
 export interface WorkflowHeaders {
   campaignId?: string;
   brandId?: string;
-  workflowName?: string;
+  workflowSlug?: string;
   featureSlug?: string;
 }
 
@@ -12,7 +12,7 @@ export function getWorkflowHeaders(req: Request): WorkflowHeaders {
   return {
     campaignId: req.headers["x-campaign-id"] as string | undefined,
     brandId: req.headers["x-brand-id"] as string | undefined,
-    workflowName: req.headers["x-workflow-name"] as string | undefined,
+    workflowSlug: req.headers["x-workflow-slug"] as string | undefined,
     featureSlug: req.headers["x-feature-slug"] as string | undefined,
   };
 }
@@ -22,7 +22,7 @@ export function forwardWorkflowHeaders(wf: WorkflowHeaders): Record<string, stri
   const headers: Record<string, string> = {};
   if (wf.campaignId) headers["x-campaign-id"] = wf.campaignId;
   if (wf.brandId) headers["x-brand-id"] = wf.brandId;
-  if (wf.workflowName) headers["x-workflow-name"] = wf.workflowName;
+  if (wf.workflowSlug) headers["x-workflow-slug"] = wf.workflowSlug;
   if (wf.featureSlug) headers["x-feature-slug"] = wf.featureSlug;
   return headers;
 }

--- a/src/routes/provisions.ts
+++ b/src/routes/provisions.ts
@@ -82,7 +82,7 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
           description,
           campaignId: wfHeaders.campaignId,
           brandId: wfHeaders.brandId,
-          workflowName: wfHeaders.workflowName,
+          workflowSlug: wfHeaders.workflowSlug,
           featureSlug: wfHeaders.featureSlug,
         })
         .returning();

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -190,7 +190,7 @@ const protectedHeaders = z.object({
   "x-run-id": z.string().uuid(),
   "x-campaign-id": z.string().optional().openapi({ description: "Campaign ID injected by workflow-service" }),
   "x-brand-id": z.string().optional().openapi({ description: "Brand ID injected by workflow-service" }),
-  "x-workflow-name": z.string().optional().openapi({ description: "Workflow name injected by workflow-service" }),
+  "x-workflow-slug": z.string().optional().openapi({ description: "Workflow slug injected by workflow-service" }),
   "x-feature-slug": z.string().optional().openapi({ description: "Feature slug for tracking" }),
 });
 

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -57,7 +57,7 @@ describe("Accounts endpoints", () => {
           ...getAuthHeaders(orgId),
           "x-campaign-id": "camp_42",
           "x-brand-id": "brand_7",
-          "x-workflow-name": "onboarding-flow",
+          "x-workflow-slug": "onboarding-flow",
         });
 
       expect(res.status).toBe(200);
@@ -68,7 +68,7 @@ describe("Accounts endpoints", () => {
         {
           "x-campaign-id": "camp_42",
           "x-brand-id": "brand_7",
-          "x-workflow-name": "onboarding-flow",
+          "x-workflow-slug": "onboarding-flow",
         }
       );
     });

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -224,7 +224,7 @@ describe("Credits deduction endpoint", () => {
         ...getAuthHeaders(orgId),
         "x-campaign-id": "camp_42",
         "x-brand-id": "brand_7",
-        "x-workflow-name": "outreach-flow",
+        "x-workflow-slug": "outreach-flow",
       })
       .send({
         amount_cents: 5,
@@ -242,7 +242,7 @@ describe("Credits deduction endpoint", () => {
       {
         "x-campaign-id": "camp_42",
         "x-brand-id": "brand_7",
-        "x-workflow-name": "outreach-flow",
+        "x-workflow-slug": "outreach-flow",
       }
     );
   });

--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -84,7 +84,7 @@ describe("Credit provision endpoints", () => {
           ...getAuthHeaders(orgId),
           "x-campaign-id": "camp_42",
           "x-brand-id": "brand_7",
-          "x-workflow-name": "outreach-flow",
+          "x-workflow-slug": "outreach-flow",
           "x-feature-slug": "press-outreach",
         })
         .send({ amount_cents: 50, description: "tracked provision" });
@@ -101,7 +101,7 @@ describe("Credit provision endpoints", () => {
 
       expect(row.campaignId).toBe("camp_42");
       expect(row.brandId).toBe("brand_7");
-      expect(row.workflowName).toBe("outreach-flow");
+      expect(row.workflowSlug).toBe("outreach-flow");
       expect(row.featureSlug).toBe("press-outreach");
     });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -28,7 +28,7 @@ beforeAll(async () => {
       "description" text,
       "campaign_id" text,
       "brand_id" text,
-      "workflow_name" text,
+      "workflow_slug" text,
       "feature_slug" text,
       "created_at" timestamp with time zone DEFAULT now() NOT NULL,
       "updated_at" timestamp with time zone DEFAULT now() NOT NULL
@@ -39,6 +39,15 @@ beforeAll(async () => {
 
   // Add feature_slug column if it doesn't exist (migration 0005)
   await sql`ALTER TABLE "credit_provisions" ADD COLUMN IF NOT EXISTS "feature_slug" text`;
+
+  // Rename workflow_name → workflow_slug if old column exists (migration 0006)
+  await sql`
+    DO $$ BEGIN
+      ALTER TABLE credit_provisions RENAME COLUMN workflow_name TO workflow_slug;
+    EXCEPTION WHEN undefined_column THEN
+      NULL;
+    END $$
+  `;
 
   // Drop billing_mode column if it still exists (migration 0004)
   await sql`

--- a/tests/unit/key-client.test.ts
+++ b/tests/unit/key-client.test.ts
@@ -131,7 +131,7 @@ describe("resolvePlatformKey", () => {
       workflowHeaders: {
         "x-campaign-id": "camp_42",
         "x-brand-id": "brand_7",
-        "x-workflow-name": "outreach-flow",
+        "x-workflow-slug": "outreach-flow",
       },
     });
 
@@ -141,7 +141,7 @@ describe("resolvePlatformKey", () => {
         headers: expect.objectContaining({
           "x-campaign-id": "camp_42",
           "x-brand-id": "brand_7",
-          "x-workflow-name": "outreach-flow",
+          "x-workflow-slug": "outreach-flow",
         }),
       })
     );


### PR DESCRIPTION
## Summary
- Renames DB column `workflow_name` → `workflow_slug` in `credit_provisions` table (migration 0006)
- Renames inbound header `x-workflow-name` → `x-workflow-slug`
- Renames outbound header propagation to match
- Updates Drizzle schema, Zod schemas, and regenerated `openapi.json`
- All 114 tests passing

Aligns billing-service with workflow-service naming refactor (PRs #180, #181).

## Test plan
- [x] All 114 existing tests pass with renamed column/headers
- [x] TypeScript compiles with no errors
- [x] OpenAPI spec regenerated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)