### PR TITLE
Support multi-brand x-brand-id header (CSV format)

### DIFF
--- a/drizzle/0007_multi_brand_ids.sql
+++ b/drizzle/0007_multi_brand_ids.sql
@@ -1,0 +1,5 @@
+-- Migrate brand_id (single text) to brand_ids (text array) for multi-brand support
+ALTER TABLE "credit_provisions" ADD COLUMN "brand_ids" text[];--> statement-breakpoint
+UPDATE "credit_provisions" SET "brand_ids" = ARRAY["brand_id"] WHERE "brand_id" IS NOT NULL;--> statement-breakpoint
+ALTER TABLE "credit_provisions" DROP COLUMN "brand_id";--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_credit_provisions_brand_ids" ON "credit_provisions" USING gin ("brand_ids");

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,263 @@
+{
+  "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "prevId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.billing_accounts": {
+      "name": "billing_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_balance_cents": {
+          "name": "credit_balance_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 200
+        },
+        "reload_amount_cents": {
+          "name": "reload_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reload_threshold_cents": {
+          "name": "reload_threshold_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 200
+        },
+        "stripe_payment_method_id": {
+          "name": "stripe_payment_method_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_accounts_org_id": {
+          "name": "idx_billing_accounts_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_accounts_stripe_customer": {
+          "name": "idx_billing_accounts_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_provisions": {
+      "name": "credit_provisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_id": {
+          "name": "campaign_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_ids": {
+          "name": "brand_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_slug": {
+          "name": "workflow_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_slug": {
+          "name": "feature_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_provisions_org_id": {
+          "name": "idx_credit_provisions_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_provisions_status": {
+          "name": "idx_credit_provisions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_provisions_brand_ids": {
+          "name": "idx_credit_provisions_brand_ids",
+          "columns": [
+            {
+              "expression": "brand_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1774934400000,
       "tag": "0006_rename_workflow_slug",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1775020800000,
+      "tag": "0007_multi_brand_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -502,7 +502,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -612,7 +613,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -702,7 +704,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -802,7 +805,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -919,7 +923,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -1019,7 +1024,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -1149,7 +1155,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -1259,7 +1266,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -1369,7 +1377,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -1479,7 +1488,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -1597,7 +1607,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",
@@ -1725,7 +1736,8 @@
           {
             "schema": {
               "type": "string",
-              "description": "Brand ID injected by workflow-service"
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
             },
             "required": false,
             "name": "x-brand-id",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -45,7 +45,7 @@ export const creditProvisions = pgTable(
     status: text("status").notNull().default("pending"),
     description: text("description"),
     campaignId: text("campaign_id"),
-    brandId: text("brand_id"),
+    brandIds: text("brand_ids").array(),
     workflowSlug: text("workflow_slug"),
     featureSlug: text("feature_slug"),
     createdAt: timestamp("created_at", { withTimezone: true })

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -2,16 +2,23 @@ import { Request, Response, NextFunction } from "express";
 
 export interface WorkflowHeaders {
   campaignId?: string;
-  brandId?: string;
+  brandIds?: string[];
   workflowSlug?: string;
   featureSlug?: string;
+}
+
+/** Parse the x-brand-id header as a comma-separated list of UUIDs. */
+function parseBrandIds(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  const ids = String(raw).split(",").map(s => s.trim()).filter(Boolean);
+  return ids.length > 0 ? ids : undefined;
 }
 
 /** Extract optional workflow-tracking headers injected by workflow-service. */
 export function getWorkflowHeaders(req: Request): WorkflowHeaders {
   return {
     campaignId: req.headers["x-campaign-id"] as string | undefined,
-    brandId: req.headers["x-brand-id"] as string | undefined,
+    brandIds: parseBrandIds(req.headers["x-brand-id"] as string | undefined),
     workflowSlug: req.headers["x-workflow-slug"] as string | undefined,
     featureSlug: req.headers["x-feature-slug"] as string | undefined,
   };
@@ -21,7 +28,7 @@ export function getWorkflowHeaders(req: Request): WorkflowHeaders {
 export function forwardWorkflowHeaders(wf: WorkflowHeaders): Record<string, string> {
   const headers: Record<string, string> = {};
   if (wf.campaignId) headers["x-campaign-id"] = wf.campaignId;
-  if (wf.brandId) headers["x-brand-id"] = wf.brandId;
+  if (wf.brandIds && wf.brandIds.length > 0) headers["x-brand-id"] = wf.brandIds.join(",");
   if (wf.workflowSlug) headers["x-workflow-slug"] = wf.workflowSlug;
   if (wf.featureSlug) headers["x-feature-slug"] = wf.featureSlug;
   return headers;

--- a/src/routes/provisions.ts
+++ b/src/routes/provisions.ts
@@ -81,7 +81,7 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
           status: "pending",
           description,
           campaignId: wfHeaders.campaignId,
-          brandId: wfHeaders.brandId,
+          brandIds: wfHeaders.brandIds,
           workflowSlug: wfHeaders.workflowSlug,
           featureSlug: wfHeaders.featureSlug,
         })

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -189,7 +189,7 @@ const protectedHeaders = z.object({
   "x-user-id": z.string().uuid(),
   "x-run-id": z.string().uuid(),
   "x-campaign-id": z.string().optional().openapi({ description: "Campaign ID injected by workflow-service" }),
-  "x-brand-id": z.string().optional().openapi({ description: "Brand ID injected by workflow-service" }),
+  "x-brand-id": z.string().optional().openapi({ description: "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)", example: "uuid1,uuid2,uuid3" }),
   "x-workflow-slug": z.string().optional().openapi({ description: "Workflow slug injected by workflow-service" }),
   "x-feature-slug": z.string().optional().openapi({ description: "Feature slug for tracking" }),
 });

--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -100,9 +100,36 @@ describe("Credit provision endpoints", () => {
         .limit(1);
 
       expect(row.campaignId).toBe("camp_42");
-      expect(row.brandId).toBe("brand_7");
+      expect(row.brandIds).toEqual(["brand_7"]);
       expect(row.workflowSlug).toBe("outreach-flow");
       expect(row.featureSlug).toBe("press-outreach");
+    });
+
+    it("stores multiple brand IDs from CSV x-brand-id header", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const res = await request(app)
+        .post("/v1/credits/provision")
+        .set({
+          ...getAuthHeaders(orgId),
+          "x-brand-id": "brand_1, brand_2, brand_3",
+        })
+        .send({ amount_cents: 50, description: "multi-brand provision" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provision_id).toBeDefined();
+
+      const [row] = await db
+        .select()
+        .from(creditProvisions)
+        .where(eq(creditProvisions.id, res.body.provision_id))
+        .limit(1);
+
+      expect(row.brandIds).toEqual(["brand_1", "brand_2", "brand_3"]);
     });
 
     it("validates request body", async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -27,7 +27,7 @@ beforeAll(async () => {
       "status" text DEFAULT 'pending' NOT NULL,
       "description" text,
       "campaign_id" text,
-      "brand_id" text,
+      "brand_ids" text[],
       "workflow_slug" text,
       "feature_slug" text,
       "created_at" timestamp with time zone DEFAULT now() NOT NULL,
@@ -39,6 +39,18 @@ beforeAll(async () => {
 
   // Add feature_slug column if it doesn't exist (migration 0005)
   await sql`ALTER TABLE "credit_provisions" ADD COLUMN IF NOT EXISTS "feature_slug" text`;
+
+  // Migrate brand_id → brand_ids (migration 0007)
+  await sql`ALTER TABLE "credit_provisions" ADD COLUMN IF NOT EXISTS "brand_ids" text[]`;
+  await sql`
+    DO $$ BEGIN
+      UPDATE credit_provisions SET brand_ids = ARRAY[brand_id] WHERE brand_id IS NOT NULL AND brand_ids IS NULL;
+      ALTER TABLE credit_provisions DROP COLUMN IF EXISTS brand_id;
+    EXCEPTION WHEN undefined_column THEN
+      NULL;
+    END $$
+  `;
+  await sql`CREATE INDEX IF NOT EXISTS "idx_credit_provisions_brand_ids" ON "credit_provisions" USING gin ("brand_ids")`;
 
   // Rename workflow_name → workflow_slug if old column exists (migration 0006)
   await sql`


### PR DESCRIPTION
## Summary
- Parse `x-brand-id` header as comma-separated UUIDs instead of a single value
- Migrate `credit_provisions.brand_id` (text) → `brand_ids` (text[]) with GIN index
- Forward header as CSV to downstream services, preserving backward compatibility for single-brand campaigns

## Test plan
- [x] Existing test updated: single brand stored as `["brand_7"]` array
- [x] New test: multi-brand CSV header `"brand_1, brand_2, brand_3"` stored as array
- [x] All 115 tests pass
- [ ] Run migration 0007 on staging and verify existing data migrated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)