### PR TITLE
Validate UUID format on identity headers

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -47,6 +47,8 @@ export function requireApiKey(
   next();
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export function requireOrgHeaders(
   req: Request,
   res: Response,
@@ -58,16 +60,31 @@ export function requireOrgHeaders(
     res.status(400).json({ error: "x-org-id header is required" });
     return;
   }
+  if (!UUID_RE.test(orgId)) {
+    console.error(`[billing-400] ${req.method} ${req.path}: invalid x-org-id="${orgId}" (not a UUID)`);
+    res.status(400).json({ error: "x-org-id must be a valid UUID" });
+    return;
+  }
   const userId = req.headers["x-user-id"] as string;
   if (!userId) {
     console.error(`[billing-400] ${req.method} ${req.path}: missing x-user-id (orgId=${orgId})`);
     res.status(400).json({ error: "x-user-id header is required" });
     return;
   }
+  if (!UUID_RE.test(userId)) {
+    console.error(`[billing-400] ${req.method} ${req.path}: invalid x-user-id="${userId}" (not a UUID)`);
+    res.status(400).json({ error: "x-user-id must be a valid UUID" });
+    return;
+  }
   const runId = req.headers["x-run-id"] as string;
   if (!runId) {
     console.error(`[billing-400] ${req.method} ${req.path}: missing x-run-id (orgId=${orgId})`);
     res.status(400).json({ error: "x-run-id header is required" });
+    return;
+  }
+  if (!UUID_RE.test(runId)) {
+    console.error(`[billing-400] ${req.method} ${req.path}: invalid x-run-id="${runId}" (not a UUID)`);
+    res.status(400).json({ error: "x-run-id must be a valid UUID" });
     return;
   }
   next();

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -457,6 +457,21 @@ describe("Credits authorize endpoint", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 when x-org-id is not a UUID", async () => {
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set({
+        "x-api-key": process.env.BILLING_SERVICE_API_KEY ?? "test-key",
+        "x-org-id": "platform",
+        "x-user-id": userId,
+        "x-run-id": "00000000-0000-0000-0000-000000000001",
+      })
+      .send(authorizeBody);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("x-org-id must be a valid UUID");
+  });
+
   it("returns 502 when costs-service is unavailable", async () => {
     const costsClient = await import("../../src/lib/costs-client.js");
     vi.spyOn(costsClient, "resolveRequiredCents").mockRejectedValue(


### PR DESCRIPTION
## Summary
- `requireOrgHeaders` middleware now validates that `x-org-id`, `x-user-id`, and `x-run-id` are valid UUIDs before the request reaches any SQL query
- Returns a clear 400 with `"x-org-id must be a valid UUID"` instead of crashing in Postgres with a 500
- Regression test added for the `POST /v1/credits/authorize` endpoint with `x-org-id: "platform"`

## Test plan
- [x] New test: `returns 400 when x-org-id is not a UUID`
- [x] All 116 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)