### PR TITLE
Enable Stripe SDK retry for 429 rate limits

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -18,7 +18,10 @@ async function getStripe(identity: IdentityContext): Promise<Stripe> {
 
   if (!cachedStripe) {
     const { key } = await resolvePlatformKey("stripe", identity);
-    cachedStripe = new Stripe(key, { apiVersion: "2024-12-18.acacia" as Stripe.LatestApiVersion });
+    cachedStripe = new Stripe(key, {
+      apiVersion: "2024-12-18.acacia" as Stripe.LatestApiVersion,
+      maxNetworkRetries: 5,
+    });
   }
   return cachedStripe;
 }

--- a/tests/unit/stripe.test.ts
+++ b/tests/unit/stripe.test.ts
@@ -58,6 +58,33 @@ describe("Stripe platform key resolution", () => {
     expect(mockResolvePlatformKey).toHaveBeenCalledTimes(1);
   });
 
+  it("constructs Stripe client with maxNetworkRetries for 429 rate-limit handling", async () => {
+    const mockResolvePlatformKey = vi.fn().mockResolvedValue({
+      provider: "stripe",
+      key: "sk_test_retries",
+    });
+    vi.doMock("../../src/lib/key-client.js", () => ({
+      resolvePlatformKey: mockResolvePlatformKey,
+    }));
+
+    let capturedConfig: Record<string, unknown> | undefined;
+    const mockCreate = vi.fn().mockResolvedValue({ id: "cus_mock", object: "customer" });
+    vi.doMock("stripe", () => {
+      const MockStripe = function (_key: string, config: Record<string, unknown>) {
+        capturedConfig = config;
+        return { customers: { create: mockCreate } };
+      };
+      MockStripe.errors = Stripe.errors;
+      return { default: MockStripe };
+    });
+
+    const { createCustomer } = await import("../../src/lib/stripe.js");
+    await createCustomer("org-123", "user-456");
+
+    expect(capturedConfig).toBeDefined();
+    expect(capturedConfig!.maxNetworkRetries).toBe(5);
+  });
+
   it("evicts cached Stripe instance on auth error and retries with fresh key", async () => {
     const mockResolvePlatformKey = vi.fn()
       .mockResolvedValueOnce({ provider: "stripe", key: "sk_expired_key" })


### PR DESCRIPTION
## Summary
- Set `maxNetworkRetries: 5` on the Stripe client constructor to handle `endpoint-concurrency` 429 rate limiting during high-throughput campaigns
- The Stripe SDK handles retries with exponential backoff + jitter automatically — no custom retry logic needed

## Test plan
- [x] New unit test verifies Stripe client is constructed with `maxNetworkRetries: 5`
- [x] All 13 existing stripe unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)