### PR TITLE
feat: add POST /internal/transfer-brand endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -448,6 +448,57 @@
         "required": [
           "code"
         ]
+      },
+      "TransferBrandTableResult": {
+        "type": "object",
+        "properties": {
+          "tableName": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "tableName",
+          "count"
+        ]
+      },
+      "TransferBrandResponse": {
+        "type": "object",
+        "properties": {
+          "updatedTables": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TransferBrandTableResult"
+            }
+          }
+        },
+        "required": [
+          "updatedTables"
+        ]
+      },
+      "TransferBrandRequest": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceOrgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "targetOrgId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "brandId",
+          "sourceOrgId",
+          "targetOrgId"
+        ]
       }
     },
     "parameters": {}
@@ -1958,6 +2009,53 @@
           },
           "400": {
             "description": "Invalid signature or missing stripe-signature header"
+          }
+        }
+      }
+    },
+    "/internal/transfer-brand": {
+      "post": {
+        "summary": "Transfer all solo-brand rows from one org to another",
+        "description": "For every table that stores brand references alongside org_id, re-assigns rows where org_id = sourceOrgId and the row references only the given brandId. Skips co-branding rows (multiple brand IDs). Idempotent.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferBrandRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transfer result with per-table update counts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransferBrandResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import checkoutRoutes from "./routes/checkout.js";
 import portalRoutes from "./routes/portal.js";
 import promoRoutes from "./routes/promo.js";
 import webhookRoutes from "./routes/webhooks.js";
+import internalRoutes from "./routes/internal.js";
 import { requireApiKey } from "./middleware/auth.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -45,6 +46,7 @@ app.get("/openapi.json", (_req, res) => {
 
 // Protected routes (service-to-service)
 app.use(requireApiKey);
+app.use(internalRoutes);
 app.use(accountsRoutes);
 app.use(creditsRoutes);
 app.use(provisionsRoutes);

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,0 +1,41 @@
+import { Router } from "express";
+import { eq, and, sql } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { creditProvisions } from "../db/schema.js";
+import { TransferBrandRequestSchema } from "../schemas.js";
+
+const router = Router();
+
+router.post("/internal/transfer-brand", async (req, res) => {
+  const parsed = TransferBrandRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.issues[0].message });
+    return;
+  }
+
+  const { brandId, sourceOrgId, targetOrgId } = parsed.data;
+
+  // Update credit_provisions where org_id = sourceOrgId AND brand_ids has exactly one element AND that element is brandId
+  const result = await db.execute(sql`
+    UPDATE credit_provisions
+    SET org_id = ${targetOrgId},
+        updated_at = NOW()
+    WHERE org_id = ${sourceOrgId}
+      AND array_length(brand_ids, 1) = 1
+      AND brand_ids[1] = ${brandId}
+  `);
+
+  const creditProvisionsCount = Number(result.count ?? 0);
+
+  console.log(
+    `[billing-service] transfer-brand: brandId=${brandId} from=${sourceOrgId} to=${targetOrgId} credit_provisions=${creditProvisionsCount}`
+  );
+
+  res.json({
+    updatedTables: [
+      { tableName: "credit_provisions", count: creditProvisionsCount },
+    ],
+  });
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -197,6 +197,29 @@ export const RedeemPromoResponseSchema = z
   })
   .openapi("RedeemPromoResponse");
 
+// --- Transfer Brand ---
+
+export const TransferBrandRequestSchema = z
+  .object({
+    brandId: z.string().uuid(),
+    sourceOrgId: z.string().uuid(),
+    targetOrgId: z.string().uuid(),
+  })
+  .openapi("TransferBrandRequest");
+
+export const TransferBrandTableResultSchema = z
+  .object({
+    tableName: z.string(),
+    count: z.number().int(),
+  })
+  .openapi("TransferBrandTableResult");
+
+export const TransferBrandResponseSchema = z
+  .object({
+    updatedTables: z.array(TransferBrandTableResultSchema),
+  })
+  .openapi("TransferBrandResponse");
+
 // --- OpenAPI Path Registrations ---
 
 const protectedHeaders = z.object({
@@ -558,5 +581,35 @@ registry.registerPath({
   responses: {
     200: { description: "Webhook processed" },
     400: { description: "Invalid signature or missing stripe-signature header" },
+  },
+});
+
+const internalHeaders = z.object({
+  "x-api-key": z.string(),
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/internal/transfer-brand",
+  summary: "Transfer all solo-brand rows from one org to another",
+  description:
+    "For every table that stores brand references alongside org_id, " +
+    "re-assigns rows where org_id = sourceOrgId and the row references only the given brandId. " +
+    "Skips co-branding rows (multiple brand IDs). Idempotent.",
+  request: {
+    headers: internalHeaders,
+    body: {
+      content: { "application/json": { schema: TransferBrandRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Transfer result with per-table update counts",
+      content: { "application/json": { schema: TransferBrandResponseSchema } },
+    },
+    400: {
+      description: "Invalid request body",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
   },
 });

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -8,6 +8,7 @@ import checkoutRoutes from "../../src/routes/checkout.js";
 import portalRoutes from "../../src/routes/portal.js";
 import promoRoutes from "../../src/routes/promo.js";
 import webhookRoutes from "../../src/routes/webhooks.js";
+import internalRoutes from "../../src/routes/internal.js";
 import { requireApiKey } from "../../src/middleware/auth.js";
 
 export function createTestApp() {
@@ -26,6 +27,7 @@ export function createTestApp() {
 
   // Protected routes
   app.use(requireApiKey);
+  app.use(internalRoutes);
   app.use(accountsRoutes);
   app.use(creditsRoutes);
   app.use(provisionsRoutes);

--- a/tests/integration/transfer-brand.test.ts
+++ b/tests/integration/transfer-brand.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import { db } from "../../src/db/index.js";
+import { creditProvisions } from "../../src/db/schema.js";
+import { createTestApp } from "../helpers/test-app.js";
+import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
+
+describe("POST /internal/transfer-brand", () => {
+  const app = createTestApp();
+  const sourceOrgId = "00000000-0000-0000-0000-000000000001";
+  const targetOrgId = "00000000-0000-0000-0000-000000000002";
+  const brandId = "00000000-0000-0000-0000-00000000b001";
+  const otherBrandId = "00000000-0000-0000-0000-00000000b002";
+  const userId = "00000000-0000-0000-0000-000000000099";
+
+  const internalHeaders = {
+    "X-API-Key": "test-api-key",
+    "Content-Type": "application/json",
+  };
+
+  beforeEach(async () => {
+    await cleanTestData();
+    await insertTestAccount({ orgId: sourceOrgId });
+    await insertTestAccount({ orgId: targetOrgId });
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("transfers solo-brand provisions from source to target org", async () => {
+    // Insert a solo-brand provision for the source org
+    await db.insert(creditProvisions).values({
+      orgId: sourceOrgId,
+      userId,
+      amountCents: 100,
+      brandIds: [brandId],
+      description: "solo brand provision",
+    });
+
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ brandId, sourceOrgId, targetOrgId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.updatedTables).toEqual([
+      { tableName: "credit_provisions", count: 1 },
+    ]);
+  });
+
+  it("skips co-branding provisions (multiple brand IDs)", async () => {
+    // Insert a co-branding provision (two brands)
+    await db.insert(creditProvisions).values({
+      orgId: sourceOrgId,
+      userId,
+      amountCents: 200,
+      brandIds: [brandId, otherBrandId],
+      description: "co-brand provision",
+    });
+
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ brandId, sourceOrgId, targetOrgId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.updatedTables).toEqual([
+      { tableName: "credit_provisions", count: 0 },
+    ]);
+  });
+
+  it("skips provisions for a different brand", async () => {
+    await db.insert(creditProvisions).values({
+      orgId: sourceOrgId,
+      userId,
+      amountCents: 100,
+      brandIds: [otherBrandId],
+      description: "different brand",
+    });
+
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ brandId, sourceOrgId, targetOrgId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.updatedTables).toEqual([
+      { tableName: "credit_provisions", count: 0 },
+    ]);
+  });
+
+  it("skips provisions with null brand_ids", async () => {
+    await db.insert(creditProvisions).values({
+      orgId: sourceOrgId,
+      userId,
+      amountCents: 100,
+      brandIds: null,
+      description: "no brand",
+    });
+
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ brandId, sourceOrgId, targetOrgId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.updatedTables).toEqual([
+      { tableName: "credit_provisions", count: 0 },
+    ]);
+  });
+
+  it("is idempotent — second call is a no-op", async () => {
+    await db.insert(creditProvisions).values({
+      orgId: sourceOrgId,
+      userId,
+      amountCents: 100,
+      brandIds: [brandId],
+      description: "solo brand",
+    });
+
+    // First call
+    const res1 = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ brandId, sourceOrgId, targetOrgId });
+
+    expect(res1.status).toBe(200);
+    expect(res1.body.updatedTables).toEqual([
+      { tableName: "credit_provisions", count: 1 },
+    ]);
+
+    // Second call — rows already moved, nothing to update
+    const res2 = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ brandId, sourceOrgId, targetOrgId });
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.updatedTables).toEqual([
+      { tableName: "credit_provisions", count: 0 },
+    ]);
+  });
+
+  it("returns 400 for invalid body", async () => {
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ brandId: "not-a-uuid" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("returns 401 without api key", async () => {
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set({ "Content-Type": "application/json" })
+      .send({ brandId, sourceOrgId, targetOrgId });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("transfers multiple solo-brand provisions at once", async () => {
+    await db.insert(creditProvisions).values([
+      {
+        orgId: sourceOrgId,
+        userId,
+        amountCents: 100,
+        brandIds: [brandId],
+        description: "provision 1",
+      },
+      {
+        orgId: sourceOrgId,
+        userId,
+        amountCents: 200,
+        brandIds: [brandId],
+        description: "provision 2",
+      },
+      {
+        orgId: sourceOrgId,
+        userId,
+        amountCents: 300,
+        brandIds: [brandId, otherBrandId],
+        description: "co-brand — should skip",
+      },
+    ]);
+
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ brandId, sourceOrgId, targetOrgId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.updatedTables).toEqual([
+      { tableName: "credit_provisions", count: 2 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /internal/transfer-brand` endpoint that re-assigns solo-brand `credit_provisions` rows from `sourceOrgId` to `targetOrgId`
- Skips co-branding rows (where `brand_ids` has multiple elements) — only transfers rows with exactly one brand ID matching the given `brandId`
- Idempotent: second call with same params is a no-op (0 rows updated)

## Changes
- `src/routes/internal.ts` — new route file for internal endpoints
- `src/schemas.ts` — Zod schemas + OpenAPI path registration for the endpoint
- `src/index.ts` + `tests/helpers/test-app.ts` — wired up the new route
- `openapi.json` — regenerated
- `tests/integration/transfer-brand.test.ts` — 8 integration tests covering: solo-brand transfer, co-brand skip, different brand skip, null brand_ids skip, idempotency, auth, multi-row transfer, and validation

## Test plan
- [x] All 147 tests pass (13 files), including 8 new transfer-brand tests
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)