### PR TITLE
feat: transfer-brand — rename brandId, add targetBrandId

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -481,7 +481,7 @@
       "TransferBrandRequest": {
         "type": "object",
         "properties": {
-          "brandId": {
+          "sourceBrandId": {
             "type": "string",
             "format": "uuid"
           },
@@ -492,10 +492,14 @@
           "targetOrgId": {
             "type": "string",
             "format": "uuid"
+          },
+          "targetBrandId": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "required": [
-          "brandId",
+          "sourceBrandId",
           "sourceOrgId",
           "targetOrgId"
         ]
@@ -2016,7 +2020,7 @@
     "/internal/transfer-brand": {
       "post": {
         "summary": "Transfer all solo-brand rows from one org to another",
-        "description": "For every table that stores brand references alongside org_id, re-assigns rows where org_id = sourceOrgId and the row references only the given brandId. Skips co-branding rows (multiple brand IDs). Idempotent.",
+        "description": "For every table that stores brand references alongside org_id, re-assigns rows where org_id = sourceOrgId and the row references only sourceBrandId. When targetBrandId is provided, also rewrites the brand reference to targetBrandId. Skips co-branding rows (multiple brand IDs). Idempotent.",
         "parameters": [
           {
             "schema": {

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,7 +1,6 @@
 import { Router } from "express";
-import { eq, and, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { creditProvisions } from "../db/schema.js";
 import { TransferBrandRequestSchema } from "../schemas.js";
 
 const router = Router();
@@ -13,22 +12,25 @@ router.post("/internal/transfer-brand", async (req, res) => {
     return;
   }
 
-  const { brandId, sourceOrgId, targetOrgId } = parsed.data;
+  const { sourceBrandId, sourceOrgId, targetOrgId, targetBrandId } = parsed.data;
 
-  // Update credit_provisions where org_id = sourceOrgId AND brand_ids has exactly one element AND that element is brandId
+  // When targetBrandId is present, rewrite the brand reference too (conflict case)
+  const newBrandId = targetBrandId ?? sourceBrandId;
+
   const result = await db.execute(sql`
     UPDATE credit_provisions
     SET org_id = ${targetOrgId},
+        brand_ids = ARRAY[${newBrandId}],
         updated_at = NOW()
     WHERE org_id = ${sourceOrgId}
       AND array_length(brand_ids, 1) = 1
-      AND brand_ids[1] = ${brandId}
+      AND brand_ids[1] = ${sourceBrandId}
   `);
 
   const creditProvisionsCount = Number(result.count ?? 0);
 
   console.log(
-    `[billing-service] transfer-brand: brandId=${brandId} from=${sourceOrgId} to=${targetOrgId} credit_provisions=${creditProvisionsCount}`
+    `[billing-service] transfer-brand: sourceBrandId=${sourceBrandId} targetBrandId=${targetBrandId ?? "none"} from=${sourceOrgId} to=${targetOrgId} credit_provisions=${creditProvisionsCount}`
   );
 
   res.json({

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -201,9 +201,10 @@ export const RedeemPromoResponseSchema = z
 
 export const TransferBrandRequestSchema = z
   .object({
-    brandId: z.string().uuid(),
+    sourceBrandId: z.string().uuid(),
     sourceOrgId: z.string().uuid(),
     targetOrgId: z.string().uuid(),
+    targetBrandId: z.string().uuid().optional(),
   })
   .openapi("TransferBrandRequest");
 
@@ -594,7 +595,8 @@ registry.registerPath({
   summary: "Transfer all solo-brand rows from one org to another",
   description:
     "For every table that stores brand references alongside org_id, " +
-    "re-assigns rows where org_id = sourceOrgId and the row references only the given brandId. " +
+    "re-assigns rows where org_id = sourceOrgId and the row references only sourceBrandId. " +
+    "When targetBrandId is provided, also rewrites the brand reference to targetBrandId. " +
     "Skips co-branding rows (multiple brand IDs). Idempotent.",
   request: {
     headers: internalHeaders,

--- a/tests/integration/transfer-brand.test.ts
+++ b/tests/integration/transfer-brand.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import request from "supertest";
+import { eq } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
 import { creditProvisions } from "../../src/db/schema.js";
 import { createTestApp } from "../helpers/test-app.js";
@@ -9,7 +10,8 @@ describe("POST /internal/transfer-brand", () => {
   const app = createTestApp();
   const sourceOrgId = "00000000-0000-0000-0000-000000000001";
   const targetOrgId = "00000000-0000-0000-0000-000000000002";
-  const brandId = "00000000-0000-0000-0000-00000000b001";
+  const sourceBrandId = "00000000-0000-0000-0000-00000000b001";
+  const targetBrandId = "00000000-0000-0000-0000-00000000b003";
   const otherBrandId = "00000000-0000-0000-0000-00000000b002";
   const userId = "00000000-0000-0000-0000-000000000099";
 
@@ -30,19 +32,18 @@ describe("POST /internal/transfer-brand", () => {
   });
 
   it("transfers solo-brand provisions from source to target org", async () => {
-    // Insert a solo-brand provision for the source org
     await db.insert(creditProvisions).values({
       orgId: sourceOrgId,
       userId,
       amountCents: 100,
-      brandIds: [brandId],
+      brandIds: [sourceBrandId],
       description: "solo brand provision",
     });
 
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set(internalHeaders)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
@@ -50,20 +51,48 @@ describe("POST /internal/transfer-brand", () => {
     ]);
   });
 
+  it("rewrites brand_ids when targetBrandId is provided", async () => {
+    const [provision] = await db.insert(creditProvisions).values({
+      orgId: sourceOrgId,
+      userId,
+      amountCents: 100,
+      brandIds: [sourceBrandId],
+      description: "will be rewritten",
+    }).returning();
+
+    const res = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ sourceBrandId, sourceOrgId, targetOrgId, targetBrandId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.updatedTables).toEqual([
+      { tableName: "credit_provisions", count: 1 },
+    ]);
+
+    // Verify the brand_ids was rewritten to targetBrandId
+    const [updated] = await db
+      .select()
+      .from(creditProvisions)
+      .where(eq(creditProvisions.id, provision.id));
+
+    expect(updated.orgId).toBe(targetOrgId);
+    expect(updated.brandIds).toEqual([targetBrandId]);
+  });
+
   it("skips co-branding provisions (multiple brand IDs)", async () => {
-    // Insert a co-branding provision (two brands)
     await db.insert(creditProvisions).values({
       orgId: sourceOrgId,
       userId,
       amountCents: 200,
-      brandIds: [brandId, otherBrandId],
+      brandIds: [sourceBrandId, otherBrandId],
       description: "co-brand provision",
     });
 
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set(internalHeaders)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
@@ -83,7 +112,7 @@ describe("POST /internal/transfer-brand", () => {
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set(internalHeaders)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
@@ -103,7 +132,7 @@ describe("POST /internal/transfer-brand", () => {
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set(internalHeaders)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
@@ -116,26 +145,55 @@ describe("POST /internal/transfer-brand", () => {
       orgId: sourceOrgId,
       userId,
       amountCents: 100,
-      brandIds: [brandId],
+      brandIds: [sourceBrandId],
       description: "solo brand",
     });
 
-    // First call
     const res1 = await request(app)
       .post("/internal/transfer-brand")
       .set(internalHeaders)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res1.status).toBe(200);
     expect(res1.body.updatedTables).toEqual([
       { tableName: "credit_provisions", count: 1 },
     ]);
 
-    // Second call — rows already moved, nothing to update
     const res2 = await request(app)
       .post("/internal/transfer-brand")
       .set(internalHeaders)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.updatedTables).toEqual([
+      { tableName: "credit_provisions", count: 0 },
+    ]);
+  });
+
+  it("is idempotent with targetBrandId — second call is a no-op", async () => {
+    await db.insert(creditProvisions).values({
+      orgId: sourceOrgId,
+      userId,
+      amountCents: 100,
+      brandIds: [sourceBrandId],
+      description: "solo brand",
+    });
+
+    const res1 = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ sourceBrandId, sourceOrgId, targetOrgId, targetBrandId });
+
+    expect(res1.status).toBe(200);
+    expect(res1.body.updatedTables).toEqual([
+      { tableName: "credit_provisions", count: 1 },
+    ]);
+
+    // Second call — brand_ids is now [targetBrandId], org_id is targetOrgId, so WHERE won't match
+    const res2 = await request(app)
+      .post("/internal/transfer-brand")
+      .set(internalHeaders)
+      .send({ sourceBrandId, sourceOrgId, targetOrgId, targetBrandId });
 
     expect(res2.status).toBe(200);
     expect(res2.body.updatedTables).toEqual([
@@ -147,7 +205,7 @@ describe("POST /internal/transfer-brand", () => {
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set(internalHeaders)
-      .send({ brandId: "not-a-uuid" });
+      .send({ sourceBrandId: "not-a-uuid" });
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBeDefined();
@@ -157,7 +215,7 @@ describe("POST /internal/transfer-brand", () => {
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set({ "Content-Type": "application/json" })
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(401);
   });
@@ -168,21 +226,21 @@ describe("POST /internal/transfer-brand", () => {
         orgId: sourceOrgId,
         userId,
         amountCents: 100,
-        brandIds: [brandId],
+        brandIds: [sourceBrandId],
         description: "provision 1",
       },
       {
         orgId: sourceOrgId,
         userId,
         amountCents: 200,
-        brandIds: [brandId],
+        brandIds: [sourceBrandId],
         description: "provision 2",
       },
       {
         orgId: sourceOrgId,
         userId,
         amountCents: 300,
-        brandIds: [brandId, otherBrandId],
+        brandIds: [sourceBrandId, otherBrandId],
         description: "co-brand — should skip",
       },
     ]);
@@ -190,7 +248,7 @@ describe("POST /internal/transfer-brand", () => {
     const res = await request(app)
       .post("/internal/transfer-brand")
       .set(internalHeaders)
-      .send({ brandId, sourceOrgId, targetOrgId });
+      .send({ sourceBrandId, sourceOrgId, targetOrgId });
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([


### PR DESCRIPTION
## Summary
- Renames `brandId` → `sourceBrandId` in the transfer-brand request schema (breaking change, big bang deploy)
- Adds optional `targetBrandId` field — when present, rewrites `brand_ids` to the target brand (conflict case where target org already has a brand for the same domain)
- Without `targetBrandId`, behavior is unchanged: only `org_id` moves, `brand_ids` stays the same

## Changes
- `src/schemas.ts` — updated Zod schema + OpenAPI description
- `src/routes/internal.ts` — updated SQL to SET `brand_ids = ARRAY[newBrandId]` (uses targetBrandId when present, sourceBrandId otherwise)
- `openapi.json` — regenerated
- `tests/integration/transfer-brand.test.ts` — 10 tests (added: brand rewrite test, idempotency with targetBrandId)

## Test plan
- [x] All 149 tests pass (13 files), including 10 transfer-brand tests
- [x] OpenAPI spec regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)