### PR TITLE
feat: add GET /public/stats/billing endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -12,6 +12,33 @@
   ],
   "components": {
     "schemas": {
+      "PublicBillingStats": {
+        "type": "object",
+        "properties": {
+          "totalAccounts": {
+            "type": "integer"
+          },
+          "accountsWithPaymentMethod": {
+            "type": "integer"
+          },
+          "totalCreditBalanceCents": {
+            "type": "integer"
+          },
+          "totalCreditedCents": {
+            "type": "integer"
+          },
+          "totalConsumedCents": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "totalAccounts",
+          "accountsWithPaymentMethod",
+          "totalCreditBalanceCents",
+          "totalCreditedCents",
+          "totalConsumedCents"
+        ]
+      },
       "BillingAccount": {
         "type": "object",
         "properties": {
@@ -530,6 +557,24 @@
                     "status",
                     "service"
                   ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/public/stats/billing": {
+      "get": {
+        "summary": "Aggregate billing stats (no auth)",
+        "description": "Cross-tenant aggregate billing statistics. No authentication required.",
+        "responses": {
+          "200": {
+            "description": "Billing stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicBillingStats"
                 }
               }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import { db } from "./db/index.js";
 import healthRoutes from "./routes/health.js";
+import publicStatsRoutes from "./routes/public-stats.js";
 import accountsRoutes from "./routes/accounts.js";
 import creditsRoutes from "./routes/credits.js";
 import provisionsRoutes from "./routes/provisions.js";
@@ -32,6 +33,7 @@ app.use(express.json());
 
 // Public routes
 app.use(healthRoutes);
+app.use(publicStatsRoutes);
 
 // Serve OpenAPI spec (resolve relative to dist/ → ../openapi.json in Docker)
 const openapiPath = resolve(__dirname, "..", "openapi.json");

--- a/src/routes/public-stats.ts
+++ b/src/routes/public-stats.ts
@@ -1,0 +1,49 @@
+import { Router } from "express";
+import { sql as rawSql } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { billingAccounts, creditProvisions } from "../db/schema.js";
+
+const router = Router();
+
+router.get("/public/stats/billing", async (_req, res) => {
+  try {
+    const [accountStats] = await db
+      .select({
+        totalAccounts: rawSql<number>`COUNT(*)::int`,
+        accountsWithPaymentMethod: rawSql<number>`COUNT(*) FILTER (WHERE ${billingAccounts.stripePaymentMethodId} IS NOT NULL)::int`,
+        totalCreditBalanceCents: rawSql<number>`COALESCE(SUM(${billingAccounts.creditBalanceCents}), 0)::int`,
+      })
+      .from(billingAccounts);
+
+    const [creditStats] = await db
+      .select({
+        totalCreditedCents: rawSql<number>`COALESCE(SUM(${creditProvisions.amountCents}), 0)::int`,
+      })
+      .from(creditProvisions)
+      .where(
+        rawSql`${creditProvisions.type} = 'credit' AND ${creditProvisions.status} = 'confirmed'`
+      );
+
+    const [debitStats] = await db
+      .select({
+        totalConsumedCents: rawSql<number>`COALESCE(SUM(${creditProvisions.amountCents}), 0)::int`,
+      })
+      .from(creditProvisions)
+      .where(
+        rawSql`${creditProvisions.type} = 'debit' AND ${creditProvisions.status} = 'confirmed'`
+      );
+
+    res.json({
+      totalAccounts: accountStats.totalAccounts,
+      accountsWithPaymentMethod: accountStats.accountsWithPaymentMethod,
+      totalCreditBalanceCents: accountStats.totalCreditBalanceCents,
+      totalCreditedCents: creditStats.totalCreditedCents,
+      totalConsumedCents: debitStats.totalConsumedCents,
+    });
+  } catch (err) {
+    console.error("[billing-service] GET /public/stats/billing failed:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -221,6 +221,18 @@ export const TransferBrandResponseSchema = z
   })
   .openapi("TransferBrandResponse");
 
+// --- Public Stats ---
+
+export const PublicBillingStatsSchema = z
+  .object({
+    totalAccounts: z.number().int(),
+    accountsWithPaymentMethod: z.number().int(),
+    totalCreditBalanceCents: z.number().int(),
+    totalCreditedCents: z.number().int(),
+    totalConsumedCents: z.number().int(),
+  })
+  .openapi("PublicBillingStats");
+
 // --- OpenAPI Path Registrations ---
 
 const protectedHeaders = z.object({
@@ -248,6 +260,22 @@ registry.registerPath({
             service: z.string(),
           }),
         },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/public/stats/billing",
+  summary: "Aggregate billing stats (no auth)",
+  description:
+    "Cross-tenant aggregate billing statistics. No authentication required.",
+  responses: {
+    200: {
+      description: "Billing stats",
+      content: {
+        "application/json": { schema: PublicBillingStatsSchema },
       },
     },
   },

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import healthRoutes from "../../src/routes/health.js";
+import publicStatsRoutes from "../../src/routes/public-stats.js";
 import accountsRoutes from "../../src/routes/accounts.js";
 import creditsRoutes from "../../src/routes/credits.js";
 import provisionsRoutes from "../../src/routes/provisions.js";
@@ -24,6 +25,7 @@ export function createTestApp() {
 
   // Public routes
   app.use(healthRoutes);
+  app.use(publicStatsRoutes);
 
   // Protected routes
   app.use(requireApiKey);

--- a/tests/integration/public-stats.test.ts
+++ b/tests/integration/public-stats.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import { createTestApp } from "../helpers/test-app.js";
+import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
+import { db } from "../../src/db/index.js";
+import { creditProvisions } from "../../src/db/schema.js";
+
+describe("GET /public/stats/billing", () => {
+  const app = createTestApp();
+  const orgA = "00000000-0000-0000-0000-000000000001";
+  const orgB = "00000000-0000-0000-0000-000000000002";
+  const userId = "00000000-0000-0000-0000-000000000099";
+
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("returns zeros when no data exists", async () => {
+    const res = await request(app).get("/public/stats/billing");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalAccounts: 0,
+      accountsWithPaymentMethod: 0,
+      totalCreditBalanceCents: 0,
+      totalCreditedCents: 0,
+      totalConsumedCents: 0,
+    });
+  });
+
+  it("does not require authentication", async () => {
+    const res = await request(app).get("/public/stats/billing");
+    expect(res.status).toBe(200);
+  });
+
+  it("aggregates across multiple orgs", async () => {
+    await insertTestAccount({
+      orgId: orgA,
+      creditBalanceCents: 5000,
+      stripePaymentMethodId: "pm_123",
+    });
+    await insertTestAccount({
+      orgId: orgB,
+      creditBalanceCents: 3000,
+      stripePaymentMethodId: null,
+    });
+
+    await db.insert(creditProvisions).values([
+      {
+        orgId: orgA,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: 10000,
+        description: "reload",
+      },
+      {
+        orgId: orgB,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: 5000,
+        description: "reload",
+      },
+      {
+        orgId: orgA,
+        userId,
+        type: "debit",
+        status: "confirmed",
+        amountCents: 2000,
+        description: "usage",
+      },
+      {
+        orgId: orgA,
+        userId,
+        type: "debit",
+        status: "pending",
+        amountCents: 9999,
+        description: "should be excluded — pending",
+      },
+      {
+        orgId: orgB,
+        userId,
+        type: "credit",
+        status: "cancelled",
+        amountCents: 9999,
+        description: "should be excluded — cancelled",
+      },
+    ]);
+
+    const res = await request(app).get("/public/stats/billing");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      totalAccounts: 2,
+      accountsWithPaymentMethod: 1,
+      totalCreditBalanceCents: 8000,
+      totalCreditedCents: 15000,
+      totalConsumedCents: 2000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /public/stats/billing` — unauthenticated, cross-tenant aggregate billing stats
- Returns: `totalAccounts`, `accountsWithPaymentMethod`, `totalCreditBalanceCents`, `totalCreditedCents`, `totalConsumedCents`
- Only counts `confirmed` provisions (pending/cancelled excluded)

## Test plan
- [x] Returns zeros when no data exists
- [x] No auth required (no `x-api-key` header needed)
- [x] Aggregates correctly across multiple orgs with mixed provision statuses
- [x] All 152 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)