### PR TITLE
fix: complete financial ledger + reconciliation

### DIFF
--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -544,7 +544,7 @@ describe("Credit provision endpoints", () => {
       expect(res.body.balance_cents).toBe(1150);
 
       // Wait for async rollback to complete
-      await new Promise((r) => setTimeout(r, 100));
+      await new Promise((r) => setTimeout(r, 500));
 
       // After async rollback, balance should be back to 150 (no credit)
       const [account] = await db


### PR DESCRIPTION
## Summary
- Rename `credit_provisions` → `credit_ledger` with new `source` column (provision, deduct, reload, welcome, promo)
- Rename `promo_codes` → `local_promo_codes`, remove `promo_redemptions` (replaced by ledger entries)
- Add `stripe_balance_txn_id` tracking for Stripe sync status
- Every operation now writes to `credit_ledger`: welcome, promo, deduct, reload, provision create/confirm/cancel
- Remove ALL reload logic from `/deduct` (authorize handles it)
- Add fire-and-forget Stripe balance txns on provisions (create/confirm/cancel)
- Add 3-check reconcile in authorize:
  1. Cache vs ledger (recompute balance from ledger)
  2. Stripe payments → DB (recover missing reload entries)
  3. DB → Stripe (sync unsynced ledger entries synchronously)
- Fix `findOrCreateAccount` race condition (idempotent upsert)
- `credit_balance_cents` is now a cache recalculable from `SUM(credit_ledger)`

## Test plan
- [ ] 149 tests pass (14 test files)
- [ ] Verify migration SQL on staging
- [ ] Run backfill script to populate historical ledger entries
- [ ] Verify reconcile corrects drift on staging accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)