### PR TITLE
feat: add trace event client for run-level billing events

### DIFF
--- a/src/lib/trace-client.ts
+++ b/src/lib/trace-client.ts
@@ -1,0 +1,43 @@
+/** Fire-and-forget client for posting trace events to runs-service. */
+
+interface TraceEventParams {
+  runId: string;
+  orgId: string;
+  userId: string;
+  event: string;
+  detail?: Record<string, unknown>;
+  workflowHeaders?: Record<string, string>;
+}
+
+function getRunsServiceConfig() {
+  const url = process.env.RUNS_SERVICE_URL;
+  const apiKey = process.env.RUNS_SERVICE_API_KEY;
+  if (!url || !apiKey) return null;
+  return { url, apiKey };
+}
+
+export function traceEvent(params: TraceEventParams): void {
+  if (!params.runId) return;
+
+  const config = getRunsServiceConfig();
+  if (!config) return;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "x-api-key": config.apiKey,
+    "x-org-id": params.orgId,
+    "x-user-id": params.userId,
+    ...params.workflowHeaders,
+  };
+
+  fetch(`${config.url}/v1/runs/${params.runId}/events`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      event: params.event,
+      detail: params.detail,
+    }),
+  }).catch((err) => {
+    console.error("[billing-service] Failed to trace event:", err);
+  });
+}

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -14,6 +14,7 @@ import { fireAndForgetBalanceTxn } from "../lib/ledger.js";
 import { sendEmail } from "../lib/email-client.js";
 import { resolveRequiredCents } from "../lib/costs-client.js";
 import { findOrCreateAccount } from "../lib/account.js";
+import { traceEvent } from "../lib/trace-client.js";
 
 const router = Router();
 
@@ -259,6 +260,16 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
 
     // Strip internal fields from response
     const { _customerId: _c, _ledgerEntryId: _l, ...response } = result as Record<string, unknown>;
+
+    traceEvent({
+      runId,
+      orgId,
+      userId,
+      event: "billing.credits.deducted",
+      detail: { amount_cents, balance_cents: result.balance_cents, depleted: result.depleted },
+      workflowHeaders: wfHeaders,
+    });
+
     res.json(response);
   } catch (err) {
     console.error("[billing-service] Error deducting credits:", err);
@@ -450,6 +461,16 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
 
     // Strip internal fields
     const { _emailEvent, _reloadLedgerEntryId, _customerId, ...response } = result as Record<string, unknown>;
+
+    traceEvent({
+      runId,
+      orgId,
+      userId,
+      event: "billing.credits.authorized",
+      detail: { sufficient: result.sufficient, balance_cents: result.balance_cents, required_cents: requiredCents },
+      workflowHeaders: wfHeaders,
+    });
+
     res.json(response);
   } catch (err) {
     console.error("[billing-service] Error authorizing credits:", err);

--- a/src/routes/provisions.ts
+++ b/src/routes/provisions.ts
@@ -11,6 +11,7 @@ import {
 import { fireAndForgetBalanceTxn } from "../lib/ledger.js";
 import { sendEmail } from "../lib/email-client.js";
 import { findOrCreateAccount } from "../lib/account.js";
+import { traceEvent } from "../lib/trace-client.js";
 
 const router = Router();
 
@@ -217,6 +218,16 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
 
     // Strip internal fields from response
     const { _creditLedgerEntryId: _, _reloadAmount: _r, _customerId: _c, _pmId: _p, _provisionLedgerEntryId: _pl, ...response } = result as Record<string, unknown>;
+
+    traceEvent({
+      runId,
+      orgId,
+      userId,
+      event: "billing.provision.created",
+      detail: { provision_id: result.provision_id, amount_cents, balance_cents: result.balance_cents },
+      workflowHeaders: fwdHeaders,
+    });
+
     res.json(response);
   } catch (err) {
     console.error("[billing-service] Error creating provision:", err);
@@ -376,6 +387,16 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
 
     // Strip internal fields
     const { _customerId: _c, _adjustmentCents: _a, ...response } = result as Record<string, unknown>;
+
+    traceEvent({
+      runId: req.headers["x-run-id"] as string,
+      orgId,
+      userId,
+      event: "billing.provision.confirmed",
+      detail: { provision_id: provisionId, adjustment_cents: adjustment },
+      workflowHeaders: wfHeaders,
+    });
+
     res.json(response);
   } catch (err) {
     console.error("[billing-service] Error confirming provision:", err);
@@ -503,6 +524,16 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
 
     // Strip internal fields
     const { _customerId: _c, _refundedCents: _r, ...response } = result as Record<string, unknown>;
+
+    traceEvent({
+      runId: req.headers["x-run-id"] as string,
+      orgId,
+      userId,
+      event: "billing.provision.cancelled",
+      detail: { provision_id: provisionId, refunded_cents: refundedCents },
+      workflowHeaders: wfHeaders,
+    });
+
     res.json(response);
   } catch (err) {
     console.error("[billing-service] Error cancelling provision:", err);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,6 +10,8 @@ process.env.STRIPE_SECRET_KEY = "sk_test_fake";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec_test_fake";
 process.env.COSTS_SERVICE_URL = "http://localhost:9998";
 process.env.COSTS_SERVICE_API_KEY = "test-costs-service-key";
+process.env.RUNS_SERVICE_URL = "http://localhost:9997";
+process.env.RUNS_SERVICE_API_KEY = "test-runs-service-key";
 process.env.NODE_ENV = "test";
 
 beforeAll(async () => {

--- a/tests/unit/trace-client.test.ts
+++ b/tests/unit/trace-client.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { traceEvent } from "../../src/lib/trace-client.js";
+
+describe("traceEvent", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    process.env.RUNS_SERVICE_URL = "http://localhost:9997";
+    process.env.RUNS_SERVICE_API_KEY = "test-runs-key";
+  });
+
+  it("POSTs to /v1/runs/{runId}/events with event and detail", () => {
+    mockFetch.mockResolvedValue({ ok: true });
+
+    traceEvent({
+      runId: "run-abc",
+      orgId: "org-1",
+      userId: "user-1",
+      event: "provision.created",
+      detail: { amount_cents: 500 },
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe("http://localhost:9997/v1/runs/run-abc/events");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body);
+    expect(body.event).toBe("provision.created");
+    expect(body.detail).toEqual({ amount_cents: 500 });
+  });
+
+  it("forwards identity and workflow headers", () => {
+    mockFetch.mockResolvedValue({ ok: true });
+
+    traceEvent({
+      runId: "run-abc",
+      orgId: "org-1",
+      userId: "user-1",
+      event: "provision.created",
+      workflowHeaders: {
+        "x-campaign-id": "camp-1",
+        "x-brand-id": "brand-1,brand-2",
+        "x-workflow-slug": "outreach",
+        "x-feature-slug": "email-gen",
+      },
+    });
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers["x-org-id"]).toBe("org-1");
+    expect(headers["x-user-id"]).toBe("user-1");
+    expect(headers["x-campaign-id"]).toBe("camp-1");
+    expect(headers["x-brand-id"]).toBe("brand-1,brand-2");
+    expect(headers["x-workflow-slug"]).toBe("outreach");
+    expect(headers["x-feature-slug"]).toBe("email-gen");
+  });
+
+  it("sends x-api-key from env", () => {
+    mockFetch.mockResolvedValue({ ok: true });
+
+    traceEvent({
+      runId: "run-abc",
+      orgId: "org-1",
+      userId: "user-1",
+      event: "test.event",
+    });
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers["x-api-key"]).toBe("test-runs-key");
+  });
+
+  it("no-ops when RUNS_SERVICE_URL not configured", () => {
+    delete process.env.RUNS_SERVICE_URL;
+
+    traceEvent({
+      runId: "run-abc",
+      orgId: "org-1",
+      userId: "user-1",
+      event: "test.event",
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when runId is missing", () => {
+    traceEvent({
+      runId: "",
+      orgId: "org-1",
+      userId: "user-1",
+      event: "test.event",
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("swallows fetch errors without throwing", async () => {
+    mockFetch.mockRejectedValue(new Error("network down"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    traceEvent({
+      runId: "run-abc",
+      orgId: "org-1",
+      userId: "user-1",
+      event: "test.event",
+    });
+
+    // Let the microtask (catch handler) run
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[billing-service]"),
+      expect.any(Error)
+    );
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/lib/trace-client.ts` — fire-and-forget client that POSTs structured events to `runs-service` at `POST /v1/runs/{runId}/events`
- Wires `traceEvent` into 5 billing flows: provision create/confirm/cancel, credits deduct, credits authorize
- Each event includes `event` name (e.g. `billing.provision.created`) and `detail` payload with relevant financial data
- No-ops gracefully when `RUNS_SERVICE_URL` is unconfigured or `runId` is missing

## Test plan
- [x] 6 unit tests for `traceEvent` covering URL construction, header forwarding, env-missing no-op, runId-missing no-op, error swallowing
- [x] All 155 existing tests pass

## Dependencies
- `runs-service` needs `POST /v1/runs/{runId}/events` endpoint (not yet implemented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)