### PR TITLE
fix: include pending provisions in consumed credits stats

### DIFF
--- a/src/routes/public-stats.ts
+++ b/src/routes/public-stats.ts
@@ -20,7 +20,7 @@ async function queryGrowth(truncTo: "month" | "week"): Promise<GrowthRow[]> {
         WHERE ${creditLedger.type} = 'credit' AND ${creditLedger.status} = 'confirmed'
       ), 0)::int AS credited_cents,
       COALESCE(SUM(${creditLedger.amountCents}) FILTER (
-        WHERE ${creditLedger.type} = 'debit' AND ${creditLedger.status} = 'confirmed'
+        WHERE ${creditLedger.type} = 'debit' AND ${creditLedger.status} IN ('confirmed', 'pending')
       ), 0)::int AS consumed_cents,
       COALESCE(SUM(${creditLedger.amountCents}) FILTER (
         WHERE ${creditLedger.type} = 'credit' AND ${creditLedger.status} = 'confirmed'
@@ -58,7 +58,7 @@ router.get("/public/stats/billing", async (_req, res) => {
       })
       .from(creditLedger)
       .where(
-        rawSql`${creditLedger.type} = 'debit' AND ${creditLedger.status} = 'confirmed'`
+        rawSql`${creditLedger.type} = 'debit' AND ${creditLedger.status} IN ('confirmed', 'pending')`
       );
 
     const [monthlyGrowth, weeklyGrowth] = await Promise.all([

--- a/tests/integration/public-stats.test.ts
+++ b/tests/integration/public-stats.test.ts
@@ -87,7 +87,7 @@ describe("GET /public/stats/billing", () => {
         status: "pending",
         amountCents: 9999,
         source: "provision",
-        description: "should be excluded — pending",
+        description: "pending provision — included in consumed",
       },
       {
         orgId: orgB,
@@ -107,7 +107,7 @@ describe("GET /public/stats/billing", () => {
     expect(res.body.accountsWithPaymentMethod).toBe(1);
     expect(res.body.totalCreditBalanceCents).toBe(8000);
     expect(res.body.totalCreditedCents).toBe(15000);
-    expect(res.body.totalConsumedCents).toBe(2000);
+    expect(res.body.totalConsumedCents).toBe(11999); // 2000 confirmed + 9999 pending
   });
 
   it("returns monthly and weekly growth with credited, consumed, and revenue", async () => {


### PR DESCRIPTION
## Summary
- Dashboard showed mismatched balance: `$733.33 - $233.31 ≠ $435.41`
- Root cause: `totalConsumedCents` excluded `pending` debits (active provisions), but `creditBalanceCents` already reflects those deductions
- Fixed SQL filter from `status = 'confirmed'` to `status IN ('confirmed', 'pending')` in both summary and growth queries

## Test plan
- [x] Updated integration test to expect pending debits in consumed total
- [x] All 4 public-stats tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)