### PR TITLE
hotfix: Stop reusing ledger row id as Stripe idempotency key on async sync paths

### DIFF
--- a/src/lib/ledger.ts
+++ b/src/lib/ledger.ts
@@ -16,6 +16,10 @@ export function fireAndForgetBalanceTxn(
   ledgerEntryId: string,
   wfHeaders?: Record<string, string>
 ): void {
+  // Note: do NOT pass `ledgerEntryId` as `idempotencyKey` here. Multiple distinct
+  // Stripe operations (initial debit, provision adjustment, cancel refund) target the
+  // same ledger row id with different params; reusing the key would trigger
+  // StripeIdempotencyError. Recovery via reconcile() Check 3 owns idempotency keying.
   createBalanceTransaction(
     orgId,
     userId,
@@ -23,8 +27,7 @@ export function fireAndForgetBalanceTxn(
     amountCents,
     description,
     undefined,
-    wfHeaders,
-    ledgerEntryId
+    wfHeaders
   )
     .then((txn) => {
       db.update(creditLedger)

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { eq, and, isNull, gte, desc, sql as rawSql } from "drizzle-orm";
+import { eq, and, isNull, gte, lte, desc, sql as rawSql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { billingAccounts, creditLedger } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
@@ -135,9 +135,13 @@ async function reconcile(
       }
     }
 
-    // Check 3: DB -> Stripe (synchronous — must succeed on reconcile path)
+    // Check 3: DB -> Stripe (recovery path)
+    // Grace filter (2 min): fire-and-forget Stripe sync runs async after the originating
+    // request returns; without a grace window we'd race that in-flight call and create
+    // duplicate Stripe balance transactions. 7-day upper bound keeps recovery cheap.
     if (account.stripe_customer_id) {
       const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      const twoMinAgo = new Date(Date.now() - 2 * 60 * 1000);
       const unsyncedEntries = await tx
         .select()
         .from(creditLedger)
@@ -146,7 +150,8 @@ async function reconcile(
             eq(creditLedger.orgId, orgId),
             isNull(creditLedger.stripeBalanceTxnId),
             eq(creditLedger.status, "confirmed"),
-            gte(creditLedger.createdAt, sevenDaysAgo)
+            gte(creditLedger.createdAt, sevenDaysAgo),
+            lte(creditLedger.createdAt, twoMinAgo)
           )
         );
 

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -172,8 +172,7 @@ describe("Credits deduction endpoint", () => {
       5,
       "test deduction",
       undefined,
-      {},
-      expect.any(String) // idempotencyKey = ledger entry id
+      {}
     );
   });
 
@@ -764,6 +763,8 @@ describe("Credits authorize — reconcile race conditions", () => {
         source: "welcome",
         description: "Welcome credit",
         // stripeBalanceTxnId left null → Check 3 will sync this entry
+        // Backdate beyond the 2-minute grace window so Check 3 doesn't skip it
+        createdAt: new Date(Date.now() - 5 * 60 * 1000),
       })
       .returning();
 
@@ -786,5 +787,57 @@ describe("Credits authorize — reconcile race conditions", () => {
     const calls = stripeMocks.createBalanceTransaction.mock.calls;
     const matched = calls.find((args) => args[7] === entry.id);
     expect(matched).toBeDefined();
+  });
+
+  it("Check 3 skips entries newer than 2 minutes (grace window for fire-and-forget)", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_race",
+      creditBalanceCents: 500,
+    });
+
+    // Fresh entry — within grace window — should be skipped by Check 3
+    await db.insert(creditLedger).values({
+      orgId,
+      userId,
+      type: "credit",
+      amountCents: 500,
+      status: "confirmed",
+      source: "welcome",
+      description: "Welcome credit",
+      // createdAt defaults to NOW() — well within the 2-minute grace window
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    // Stripe should NOT be called for a fresh unsynced entry
+    expect(stripeMocks.createBalanceTransaction).not.toHaveBeenCalled();
+  });
+
+  it("fireAndForgetBalanceTxn does NOT pass an idempotency key (multiple Stripe ops share a ledger row id)", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_race",
+      creditBalanceCents: 200,
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: 5, description: "race-no-idem" });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(stripeMocks.createBalanceTransaction).toHaveBeenCalled();
+    const calls = stripeMocks.createBalanceTransaction.mock.calls;
+    // No call from fire-and-forget should pass an 8th positional arg (idempotencyKey)
+    for (const args of calls) {
+      expect(args[7]).toBeUndefined();
+    }
   });
 });

--- a/tests/integration/promo.test.ts
+++ b/tests/integration/promo.test.ts
@@ -55,8 +55,7 @@ describe("Promo endpoints", () => {
         -800,
         "Promo credit: qr10 ($8.00)",
         undefined,
-        {},
-        expect.any(String)
+        {}
       );
     });
 

--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -173,8 +173,7 @@ describe("Credit provision endpoints", () => {
         100,
         "test provision",
         undefined,
-        {},
-        expect.any(String)
+        {}
       );
     });
   });


### PR DESCRIPTION
Automated by release.sh