### PR TITLE
refactor(billing): rename credit_ledger -> transactions, unify sources

### DIFF
--- a/drizzle/0012_transactions_rename.sql
+++ b/drizzle/0012_transactions_rename.sql
@@ -1,0 +1,113 @@
+-- Rename credit_ledger -> transactions and unify legacy sources into 'charge'.
+-- See migration plan in PR description (investor-page bug, ledger refactor 2026-05-06).
+-- This migration is idempotent: re-running on a fully-migrated DB is a no-op.
+
+-- Phase 1: rename table + indexes
+ALTER TABLE IF EXISTS "credit_ledger" RENAME TO "transactions";--> statement-breakpoint
+ALTER INDEX IF EXISTS "idx_credit_ledger_org_id" RENAME TO "idx_transactions_org_id";--> statement-breakpoint
+ALTER INDEX IF EXISTS "idx_credit_ledger_status" RENAME TO "idx_transactions_status";--> statement-breakpoint
+ALTER INDEX IF EXISTS "idx_credit_ledger_source" RENAME TO "idx_transactions_source";--> statement-breakpoint
+ALTER INDEX IF EXISTS "idx_credit_ledger_reload_pi" RENAME TO "idx_transactions_reload_pi";--> statement-breakpoint
+ALTER INDEX IF EXISTS "idx_credit_ledger_brand_ids" RENAME TO "idx_transactions_brand_ids";--> statement-breakpoint
+ALTER INDEX IF EXISTS "idx_credit_ledger_promo_org" RENAME TO "idx_transactions_promo_org";--> statement-breakpoint
+
+-- Phase 3: deduct -> charge (direct deductions are now charges in canonical schema)
+UPDATE "transactions" SET source = 'charge' WHERE source = 'deduct';--> statement-breakpoint
+
+-- Phase 4 (pre-check): every provision_cancel must pair with a cancelled-debit parent of the same amount.
+-- If the data does not match, abort — orphans need human investigation rather than silent drop.
+DO $$
+DECLARE orphan_count int;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM "transactions" pc
+  WHERE pc.source = 'provision_cancel'
+    AND NOT EXISTS (
+      SELECT 1 FROM "transactions" p
+      WHERE p.id::text = substring(pc.description from 'Provision ([0-9a-f-]+)')
+        AND p.status = 'cancelled'
+        AND p.amount_cents = pc.amount_cents
+        AND p.type = 'debit'
+    );
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'provision_cancel orphans: % rows. Aborting migration.', orphan_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- Phase 4: drop provision_cancel credit miroirs (the parent debit row is already 'cancelled' which neutralises the balance)
+DELETE FROM "transactions" WHERE source = 'provision_cancel';--> statement-breakpoint
+
+-- Phase 5 (pre-check): every provision_adjust must reference an existing parent provision row.
+DO $$
+DECLARE orphan_count int;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM "transactions" a
+  WHERE a.source = 'provision_adjust'
+    AND NOT EXISTS (
+      SELECT 1 FROM "transactions" p
+      WHERE p.id::text = substring(a.description from 'Provision ([0-9a-f-]+)')
+        AND p.source = 'provision'
+    );
+  IF orphan_count > 0 THEN
+    RAISE EXCEPTION 'provision_adjust orphans: % rows. Aborting migration.', orphan_count;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- Phase 5 step A: for each provision_adjust, insert a new confirmed debit row that represents the actual
+-- final amount $Y (= the parent's current amount_cents). This becomes the canonical 'charge' row after Phase 6.
+-- Carries org/user/run/workflow context from the parent so analytics keep working.
+INSERT INTO "transactions" (org_id, user_id, run_id, type, amount_cents, status, source, description, campaign_id, brand_ids, workflow_slug, feature_slug, created_at, updated_at)
+SELECT
+  p.org_id,
+  p.user_id,
+  p.run_id,
+  'debit',
+  p.amount_cents,
+  'confirmed',
+  'provision',
+  COALESCE(p.description, '') || ' (post-confirm $Y from collapsed adjust ' || a.id::text || ')',
+  p.campaign_id,
+  p.brand_ids,
+  p.workflow_slug,
+  p.feature_slug,
+  NOW(),
+  NOW()
+FROM "transactions" a
+JOIN "transactions" p
+  ON p.id::text = substring(a.description from 'Provision ([0-9a-f-]+)')
+WHERE a.source = 'provision_adjust'
+  AND p.source = 'provision';--> statement-breakpoint
+
+-- Phase 5 step B: restore parent provision back to its original amount $X and mark it cancelled.
+-- $X is recovered from $Y_current and the signed adjustment delta carried in the adjust row.
+UPDATE "transactions" p SET
+  amount_cents = CASE
+    WHEN a.type = 'credit' THEN p.amount_cents + a.amount_cents
+    ELSE p.amount_cents - a.amount_cents
+  END,
+  status = 'cancelled',
+  updated_at = NOW()
+FROM "transactions" a
+WHERE a.source = 'provision_adjust'
+  AND p.id::text = substring(a.description from 'Provision ([0-9a-f-]+)')
+  AND p.source = 'provision'
+  AND p.status = 'confirmed';--> statement-breakpoint
+
+-- Phase 5 step C: drop the now-redundant adjust rows.
+DELETE FROM "transactions" WHERE source = 'provision_adjust';--> statement-breakpoint
+
+-- Phase 6: collapse the remaining 'provision' rows into the unified 'charge' source.
+UPDATE "transactions" SET source = 'charge' WHERE source = 'provision';--> statement-breakpoint
+
+-- Phase 7: invariant — only canonical sources remain.
+DO $$
+DECLARE bad_count int;
+BEGIN
+  SELECT COUNT(*) INTO bad_count
+  FROM "transactions"
+  WHERE source NOT IN ('reload', 'welcome', 'promo', 'charge', 'refund');
+  IF bad_count > 0 THEN
+    RAISE EXCEPTION 'Migration left % rows with non-canonical source', bad_count;
+  END IF;
+END $$;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777161600000,
       "tag": "0011_reload_pi_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1778198400000,
+      "tag": "0012_transactions_rename",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -53,8 +53,8 @@ export const localPromoCodes = pgTable(
 export type LocalPromoCode = typeof localPromoCodes.$inferSelect;
 export type NewLocalPromoCode = typeof localPromoCodes.$inferInsert;
 
-export const creditLedger = pgTable(
-  "credit_ledger",
+export const transactions = pgTable(
+  "transactions",
   {
     id: uuid("id").primaryKey().defaultRandom(),
     orgId: uuid("org_id").notNull(),
@@ -63,7 +63,7 @@ export const creditLedger = pgTable(
     type: text("type").notNull().default("debit"),
     amountCents: integer("amount_cents").notNull(),
     status: text("status").notNull().default("pending"),
-    source: text("source").notNull().default("provision"),
+    source: text("source").notNull().default("charge"),
     stripePaymentIntentId: text("stripe_payment_intent_id"),
     stripeBalanceTxnId: text("stripe_balance_txn_id"),
     promoCodeId: uuid("promo_code_id").references(() => localPromoCodes.id),
@@ -80,14 +80,14 @@ export const creditLedger = pgTable(
       .defaultNow(),
   },
   (table) => [
-    index("idx_credit_ledger_org_id").on(table.orgId),
-    index("idx_credit_ledger_status").on(table.status),
-    index("idx_credit_ledger_source").on(table.source),
-    uniqueIndex("idx_credit_ledger_reload_pi")
+    index("idx_transactions_org_id").on(table.orgId),
+    index("idx_transactions_status").on(table.status),
+    index("idx_transactions_source").on(table.source),
+    uniqueIndex("idx_transactions_reload_pi")
       .on(table.orgId, table.stripePaymentIntentId)
       .where(sql`source = 'reload' AND stripe_payment_intent_id IS NOT NULL`),
   ]
 );
 
-export type CreditLedgerEntry = typeof creditLedger.$inferSelect;
-export type NewCreditLedgerEntry = typeof creditLedger.$inferInsert;
+export type Transaction = typeof transactions.$inferSelect;
+export type NewTransaction = typeof transactions.$inferInsert;

--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { billingAccounts, creditLedger } from "../db/schema.js";
+import { billingAccounts, transactions } from "../db/schema.js";
 import { createCustomer, createBalanceTransaction } from "./stripe.js";
 
 /**
@@ -52,7 +52,7 @@ export async function findOrCreateAccount(
 
   // Write welcome credit to ledger
   const [welcomeEntry] = await db
-    .insert(creditLedger)
+    .insert(transactions)
     .values({
       orgId,
       userId,
@@ -75,9 +75,9 @@ export async function findOrCreateAccount(
     wfHeaders
   )
     .then((txn) => {
-      db.update(creditLedger)
+      db.update(transactions)
         .set({ stripeBalanceTxnId: txn.id, updatedAt: new Date() })
-        .where(eq(creditLedger.id, welcomeEntry.id))
+        .where(eq(transactions.id, welcomeEntry.id))
         .then(() => {})
         .catch(() => {});
     })

--- a/src/lib/ledger.ts
+++ b/src/lib/ledger.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { creditLedger } from "../db/schema.js";
+import { transactions } from "../db/schema.js";
 import { createBalanceTransaction } from "./stripe.js";
 
 /**
@@ -30,9 +30,9 @@ export function fireAndForgetBalanceTxn(
     wfHeaders
   )
     .then((txn) => {
-      db.update(creditLedger)
+      db.update(transactions)
         .set({ stripeBalanceTxnId: txn.id, updatedAt: new Date() })
-        .where(eq(creditLedger.id, ledgerEntryId))
+        .where(eq(transactions.id, ledgerEntryId))
         .then(() => {})
         .catch(() => {});
     })

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { eq, and, isNull, gte, lte, desc, sql as rawSql } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { billingAccounts, creditLedger } from "../db/schema.js";
+import { billingAccounts, transactions } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { DeductRequestSchema, AuthorizeRequestSchema } from "../schemas.js";
 import {
@@ -81,7 +81,7 @@ async function reconcile(
         END
       ), 0)::int AS computed,
       COUNT(*)::int AS entry_count
-      FROM credit_ledger WHERE org_id = ${orgId}`
+      FROM transactions WHERE org_id = ${orgId}`
     )) as unknown as { computed: number; entry_count: number }[];
     const { computed, entry_count } = ledgerRows[0];
     if (entry_count > 0 && computed !== account.credit_balance_cents) {
@@ -108,7 +108,7 @@ async function reconcile(
           // Idempotent insert: relies on partial unique index
           // (org_id, stripe_payment_intent_id) WHERE source='reload' AND stripe_payment_intent_id IS NOT NULL.
           const insertedRows = (await tx.execute(
-            rawSql`INSERT INTO credit_ledger
+            rawSql`INSERT INTO transactions
               (org_id, user_id, type, amount_cents, status, source, stripe_payment_intent_id, description)
               VALUES (${orgId}, ${userId}, 'credit', ${pi.amount}, 'confirmed', 'reload', ${pi.id},
                 ${`Recovered reload from Stripe PI ${pi.id}`})
@@ -144,14 +144,14 @@ async function reconcile(
       const twoMinAgo = new Date(Date.now() - 2 * 60 * 1000);
       const unsyncedEntries = await tx
         .select()
-        .from(creditLedger)
+        .from(transactions)
         .where(
           and(
-            eq(creditLedger.orgId, orgId),
-            isNull(creditLedger.stripeBalanceTxnId),
-            eq(creditLedger.status, "confirmed"),
-            gte(creditLedger.createdAt, sevenDaysAgo),
-            lte(creditLedger.createdAt, twoMinAgo)
+            eq(transactions.orgId, orgId),
+            isNull(transactions.stripeBalanceTxnId),
+            eq(transactions.status, "confirmed"),
+            gte(transactions.createdAt, sevenDaysAgo),
+            lte(transactions.createdAt, twoMinAgo)
           )
         );
 
@@ -170,9 +170,9 @@ async function reconcile(
             entry.id
           );
           await tx
-            .update(creditLedger)
+            .update(transactions)
             .set({ stripeBalanceTxnId: txn.id, updatedAt: new Date() })
-            .where(eq(creditLedger.id, entry.id));
+            .where(eq(transactions.id, entry.id));
         } catch (err) {
           console.error(
             `[billing-service] Check 3: Failed to sync ledger entry ${entry.id} to Stripe:`,
@@ -228,7 +228,7 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
 
       // Insert debit ledger entry
       const [ledgerEntry] = await tx
-        .insert(creditLedger)
+        .insert(transactions)
         .values({
           orgId,
           userId,
@@ -236,7 +236,7 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
           type: "debit",
           amountCents: amount_cents,
           status: "confirmed",
-          source: "deduct",
+          source: "charge",
           description,
         })
         .returning();
@@ -362,15 +362,15 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
           // Cooldown: skip reload if the last reload entry is cancelled and < 15 min old
           const RELOAD_COOLDOWN_MS = 15 * 60 * 1000;
           const [lastReload] = await tx
-            .select({ status: creditLedger.status, createdAt: creditLedger.createdAt })
-            .from(creditLedger)
+            .select({ status: transactions.status, createdAt: transactions.createdAt })
+            .from(transactions)
             .where(
               and(
-                eq(creditLedger.orgId, orgId),
-                eq(creditLedger.source, "reload")
+                eq(transactions.orgId, orgId),
+                eq(transactions.source, "reload")
               )
             )
-            .orderBy(desc(creditLedger.createdAt))
+            .orderBy(desc(transactions.createdAt))
             .limit(1);
 
           const reloadOnCooldown =
@@ -395,7 +395,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
 
               // Insert reload ledger entry
               const [reloadEntry] = await tx
-                .insert(creditLedger)
+                .insert(transactions)
                 .values({
                   orgId,
                   userId,
@@ -421,7 +421,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
               console.error("[billing-service] Auto-reload failed during authorize:", reloadErr);
               // Record failed reload in ledger for cooldown tracking
               await tx
-                .insert(creditLedger)
+                .insert(transactions)
                 .values({
                   orgId,
                   userId,
@@ -465,8 +465,8 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
     if (result._reloadLedgerEntryId && result._customerId) {
       const entry = await db
         .select()
-        .from(creditLedger)
-        .where(eq(creditLedger.id, result._reloadLedgerEntryId))
+        .from(transactions)
+        .where(eq(transactions.id, result._reloadLedgerEntryId))
         .limit(1);
       if (entry[0]) {
         fireAndForgetBalanceTxn(

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -16,7 +16,7 @@ router.post("/internal/transfer-brand", async (req, res) => {
 
   // Step 1: Move org_id from sourceOrgId to targetOrgId for solo-brand rows
   const step1 = await db.execute(sql`
-    UPDATE credit_ledger
+    UPDATE transactions
     SET org_id = ${targetOrgId},
         updated_at = NOW()
     WHERE org_id = ${sourceOrgId}
@@ -24,27 +24,27 @@ router.post("/internal/transfer-brand", async (req, res) => {
       AND brand_ids[1] = ${sourceBrandId}
   `);
 
-  let creditLedgerCount = Number(step1.count ?? 0);
+  let transactionsCount = Number(step1.count ?? 0);
 
   // Step 2: Rewrite brand reference when targetBrandId is provided (conflict case)
   if (targetBrandId) {
     const step2 = await db.execute(sql`
-      UPDATE credit_ledger
+      UPDATE transactions
       SET brand_ids = ARRAY[${targetBrandId}],
           updated_at = NOW()
       WHERE array_length(brand_ids, 1) = 1
         AND brand_ids[1] = ${sourceBrandId}
     `);
-    creditLedgerCount = Math.max(creditLedgerCount, Number(step2.count ?? 0));
+    transactionsCount = Math.max(transactionsCount, Number(step2.count ?? 0));
   }
 
   console.log(
-    `[billing-service] transfer-brand: sourceBrandId=${sourceBrandId} targetBrandId=${targetBrandId ?? "none"} from=${sourceOrgId} to=${targetOrgId} credit_ledger=${creditLedgerCount}`
+    `[billing-service] transfer-brand: sourceBrandId=${sourceBrandId} targetBrandId=${targetBrandId ?? "none"} from=${sourceOrgId} to=${targetOrgId} transactions=${transactionsCount}`
   );
 
   res.json({
     updatedTables: [
-      { tableName: "credit_ledger", count: creditLedgerCount },
+      { tableName: "transactions", count: transactionsCount },
     ],
   });
 });

--- a/src/routes/promo.ts
+++ b/src/routes/promo.ts
@@ -4,7 +4,7 @@ import { db } from "../db/index.js";
 import {
   billingAccounts,
   localPromoCodes,
-  creditLedger,
+  transactions,
 } from "../db/schema.js";
 import {
   requireOrgHeaders,
@@ -54,15 +54,14 @@ router.post("/v1/promo/redeem", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    // Check max redemptions (count from credit_ledger where source='promo')
     if (promo.maxRedemptions !== null) {
       const [countResult] = await db
         .select({ count: rawSql<number>`count(*)::int` })
-        .from(creditLedger)
+        .from(transactions)
         .where(
           and(
-            eq(creditLedger.promoCodeId, promo.id),
-            eq(creditLedger.source, "promo")
+            eq(transactions.promoCodeId, promo.id),
+            eq(transactions.source, "promo")
           )
         );
       if (countResult.count >= promo.maxRedemptions) {
@@ -71,15 +70,14 @@ router.post("/v1/promo/redeem", requireOrgHeaders, async (req, res) => {
       }
     }
 
-    // Check if this org already redeemed this code (via credit_ledger)
     const [existing] = await db
       .select()
-      .from(creditLedger)
+      .from(transactions)
       .where(
         and(
-          eq(creditLedger.promoCodeId, promo.id),
-          eq(creditLedger.orgId, orgId),
-          eq(creditLedger.source, "promo")
+          eq(transactions.promoCodeId, promo.id),
+          eq(transactions.orgId, orgId),
+          eq(transactions.source, "promo")
         )
       )
       .limit(1);
@@ -94,9 +92,8 @@ router.post("/v1/promo/redeem", requireOrgHeaders, async (req, res) => {
 
     // Credit the promo amount inside a transaction
     const result = await db.transaction(async (tx) => {
-      // Record the redemption in credit_ledger (partial unique index prevents double-dip)
       const [ledgerEntry] = await tx
-        .insert(creditLedger)
+        .insert(transactions)
         .values({
           orgId,
           userId,
@@ -150,8 +147,7 @@ router.post("/v1/promo/redeem", requireOrgHeaders, async (req, res) => {
     // Handle unique constraint violation (race condition double-dip via partial index)
     if (
       err instanceof Error &&
-      (err.message.includes("idx_credit_ledger_promo_org") ||
-        err.message.includes("idx_promo_redemptions_org_code"))
+      err.message.includes("idx_transactions_promo_org")
     ) {
       res.status(409).json({ error: "Promo code already redeemed by this organization" });
       return;

--- a/src/routes/provisions.ts
+++ b/src/routes/provisions.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { eq, sql as rawSql } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { billingAccounts, creditLedger } from "../db/schema.js";
+import { billingAccounts, transactions } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { ProvisionRequestSchema, ConfirmProvisionRequestSchema } from "../schemas.js";
 import { isStripeAuthError } from "../lib/stripe.js";
@@ -21,7 +21,7 @@ interface AccountRow {
   stripe_payment_method_id: string | null;
 }
 
-// POST /v1/credits/provision — provision credits (deduct from balance immediately)
+// POST /v1/credits/provision — provision credits (deduct from balance immediately, status=pending)
 router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
@@ -38,7 +38,6 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
 
     const { amount_cents, description } = parsed.data;
 
-    // Ensure account exists (auto-create with $2 trial credit if new)
     await findOrCreateAccount(orgId, userId, fwdHeaders);
 
     const result = await db.transaction(async (tx) => {
@@ -51,7 +50,6 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
         return { error: "Billing account not found" as const, status: 404 as const };
       }
 
-      // Deduct from balance (allow negative)
       const newBalance = account.credit_balance_cents - amount_cents;
       await tx
         .update(billingAccounts)
@@ -62,7 +60,7 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
         .where(eq(billingAccounts.orgId, orgId));
 
       const [provision] = await tx
-        .insert(creditLedger)
+        .insert(transactions)
         .values({
           orgId,
           userId,
@@ -70,7 +68,7 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
           type: "debit",
           amountCents: amount_cents,
           status: "pending",
-          source: "provision",
+          source: "charge",
           description,
           campaignId: wfHeaders.campaignId,
           brandIds: wfHeaders.brandIds,
@@ -93,7 +91,6 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    // Fire-and-forget Stripe balance txn for the provision debit
     if (result._customerId && result._provisionLedgerEntryId) {
       fireAndForgetBalanceTxn(
         orgId,
@@ -106,7 +103,6 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
       );
     }
 
-    // Strip internal fields from response
     const { _customerId: _c, _provisionLedgerEntryId: _pl, ...response } = result as Record<string, unknown>;
 
     traceEvent({
@@ -129,12 +125,14 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
   }
 });
 
-// POST /v1/credits/provision/:id/confirm — confirm provision, optionally adjust for actual cost
+// POST /v1/credits/provision/:id/confirm — confirm provision; on amount mismatch, cancel original and write a fresh charge.
 router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
-    const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
+    const runId = req.headers["x-run-id"] as string;
+    const wfHeadersRaw = getWorkflowHeaders(req);
+    const wfHeaders = forwardWorkflowHeaders(wfHeadersRaw);
     const provisionId = req.params.id;
     const parsed = ConfirmProvisionRequestSchema.safeParse(req.body);
 
@@ -146,14 +144,18 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
     const { actual_amount_cents } = parsed.data;
 
     const result = await db.transaction(async (tx) => {
-      // Lock the provision row
       const provRows = await tx.execute<{
         id: string;
         org_id: string;
         amount_cents: number;
         status: string;
+        description: string | null;
+        campaign_id: string | null;
+        brand_ids: string[] | null;
+        workflow_slug: string | null;
+        feature_slug: string | null;
       }>(
-        rawSql`SELECT * FROM credit_ledger WHERE id = ${provisionId} AND org_id = ${orgId} FOR UPDATE`
+        rawSql`SELECT * FROM transactions WHERE id = ${provisionId} AND org_id = ${orgId} FOR UPDATE`
       );
 
       const provision = (provRows as unknown as Array<{
@@ -161,14 +163,28 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
         org_id: string;
         amount_cents: number;
         status: string;
+        description: string | null;
+        campaign_id: string | null;
+        brand_ids: string[] | null;
+        workflow_slug: string | null;
+        feature_slug: string | null;
       }>)[0];
 
       if (!provision) {
         return { error: "Provision not found" as const, status: 404 as const };
       }
 
+      // Idempotent: confirm with same amount on already-confirmed row is a no-op.
       if (provision.status === "confirmed") {
-        // Idempotent: already confirmed — return current state as no-op
+        const sameAmount =
+          actual_amount_cents === undefined ||
+          actual_amount_cents === provision.amount_cents;
+        if (!sameAmount) {
+          return {
+            error: `Provision already confirmed at ${provision.amount_cents} cents` as const,
+            status: 409 as const,
+          };
+        }
         const [account] = await tx
           .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
           .from(billingAccounts)
@@ -189,48 +205,71 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
         return { error: `Provision already ${provision.status}` as const, status: 409 as const };
       }
 
-      // If actual cost differs, adjust balance
-      const adjustmentCents = actual_amount_cents !== undefined
-        ? provision.amount_cents - actual_amount_cents
-        : 0;
+      const finalAmount = actual_amount_cents ?? provision.amount_cents;
+      const adjustmentCents = provision.amount_cents - finalAmount;
 
-      if (adjustmentCents !== 0) {
-        // Positive adjustment = we over-provisioned, credit back
-        // Negative adjustment = we under-provisioned, deduct more
+      // Same amount → flip status only; no balance change, no new row.
+      if (adjustmentCents === 0) {
         await tx
-          .update(billingAccounts)
-          .set({
-            creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${adjustmentCents}`,
-            updatedAt: new Date(),
+          .update(transactions)
+          .set({ status: "confirmed", updatedAt: new Date() })
+          .where(eq(transactions.id, provisionId));
+
+        const [account] = await tx
+          .select({
+            creditBalanceCents: billingAccounts.creditBalanceCents,
+            stripeCustomerId: billingAccounts.stripeCustomerId,
           })
-          .where(eq(billingAccounts.orgId, orgId));
+          .from(billingAccounts)
+          .where(eq(billingAccounts.orgId, orgId))
+          .limit(1);
 
-        // Insert adjustment ledger entry
-        await tx
-          .insert(creditLedger)
-          .values({
-            orgId,
-            userId,
-            type: adjustmentCents > 0 ? "credit" : "debit",
-            amountCents: Math.abs(adjustmentCents),
-            status: "confirmed",
-            source: "provision_adjust",
-            description: `Provision ${provisionId} adjustment: ${adjustmentCents > 0 ? "+" : ""}${adjustmentCents} cents`,
-          });
+        return {
+          provision_id: provisionId,
+          status: "confirmed" as const,
+          original_amount_cents: provision.amount_cents,
+          final_amount_cents: finalAmount,
+          adjustment_cents: 0,
+          balance_cents: account?.creditBalanceCents ?? null,
+          _customerId: account?.stripeCustomerId ?? null,
+          _adjustmentCents: 0,
+          _newChargeId: null as string | null,
+        };
       }
 
-      const finalAmount = actual_amount_cents ?? provision.amount_cents;
-
+      // Amount differs: cancel original hold (refund $X) and write a fresh confirmed charge ($Y).
+      // Net balance change = (X - Y) = adjustmentCents.
       await tx
-        .update(creditLedger)
+        .update(billingAccounts)
         .set({
-          status: "confirmed",
-          amountCents: finalAmount,
+          creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${adjustmentCents}`,
           updatedAt: new Date(),
         })
-        .where(eq(creditLedger.id, provisionId));
+        .where(eq(billingAccounts.orgId, orgId));
 
-      // Get updated balance and customer ID for Stripe balance txn
+      await tx
+        .update(transactions)
+        .set({ status: "cancelled", updatedAt: new Date() })
+        .where(eq(transactions.id, provisionId));
+
+      const [newCharge] = await tx
+        .insert(transactions)
+        .values({
+          orgId,
+          userId,
+          runId,
+          type: "debit",
+          amountCents: finalAmount,
+          status: "confirmed",
+          source: "charge",
+          description: provision.description,
+          campaignId: provision.campaign_id ?? undefined,
+          brandIds: provision.brand_ids ?? undefined,
+          workflowSlug: provision.workflow_slug ?? undefined,
+          featureSlug: provision.feature_slug ?? undefined,
+        })
+        .returning();
+
       const [account] = await tx
         .select({
           creditBalanceCents: billingAccounts.creditBalanceCents,
@@ -249,6 +288,7 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
         balance_cents: account?.creditBalanceCents ?? null,
         _customerId: account?.stripeCustomerId ?? null,
         _adjustmentCents: adjustmentCents,
+        _newChargeId: newCharge.id,
       };
     });
 
@@ -257,29 +297,40 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
       return;
     }
 
-    // Fire-and-forget Stripe balance txn for the adjustment (if any)
-    const customerId = "_customerId" in result ? result._customerId as string | null : null;
-    const adjustment = "_adjustmentCents" in result ? result._adjustmentCents as number : 0;
-    if (customerId && adjustment !== 0) {
-      // adjustment > 0 means credit back → negative Stripe amount
-      // adjustment < 0 means deduct more → positive Stripe amount
-      const stripeAmount = -adjustment;
+    // Stripe sync: when amount changes, post a refund of the original hold AND a charge for the new amount.
+    // Each fires against its own ledger row id (refund → original provision row, charge → newly inserted row).
+    const customerId = "_customerId" in result ? (result._customerId as string | null) : null;
+    const adjustment = "_adjustmentCents" in result ? (result._adjustmentCents as number) : 0;
+    const newChargeId = "_newChargeId" in result ? (result._newChargeId as string | null) : null;
+    if (customerId && adjustment !== 0 && newChargeId) {
+      // Refund the original $X to the customer's Stripe balance (negative amount for credit).
       fireAndForgetBalanceTxn(
         orgId,
         userId,
         customerId,
-        stripeAmount,
-        `Provision ${provisionId} adjustment`,
+        -result.original_amount_cents,
+        `Provision ${provisionId} cancelled (replaced by confirm at ${result.final_amount_cents} cents)`,
         provisionId,
+        wfHeaders
+      );
+      // Charge the new $Y on Stripe balance (positive amount for debit).
+      fireAndForgetBalanceTxn(
+        orgId,
+        userId,
+        customerId,
+        result.final_amount_cents,
+        result.original_amount_cents !== result.final_amount_cents
+          ? `Confirmed charge (replacing provision ${provisionId})`
+          : `Provision ${provisionId} confirmed`,
+        newChargeId,
         wfHeaders
       );
     }
 
-    // Strip internal fields
-    const { _customerId: _c, _adjustmentCents: _a, ...response } = result as Record<string, unknown>;
+    const { _customerId: _c, _adjustmentCents: _a, _newChargeId: _n, ...response } = result as Record<string, unknown>;
 
     traceEvent({
-      runId: req.headers["x-run-id"] as string,
+      runId,
       orgId,
       userId,
       event: "billing.provision.confirmed",
@@ -294,7 +345,7 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
   }
 });
 
-// POST /v1/credits/provision/:id/cancel — cancel provision, re-credit balance
+// POST /v1/credits/provision/:id/cancel — cancel provision, re-credit balance. No miroir row.
 router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
@@ -309,7 +360,7 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
         amount_cents: number;
         status: string;
       }>(
-        rawSql`SELECT * FROM credit_ledger WHERE id = ${provisionId} AND org_id = ${orgId} FOR UPDATE`
+        rawSql`SELECT * FROM transactions WHERE id = ${provisionId} AND org_id = ${orgId} FOR UPDATE`
       );
 
       const provision = (provRows as unknown as Array<{
@@ -324,7 +375,6 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
       }
 
       if (provision.status === "cancelled") {
-        // Idempotent: already cancelled — return current state as no-op
         const [account] = await tx
           .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
           .from(billingAccounts)
@@ -343,7 +393,6 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
         return { error: `Provision already ${provision.status}` as const, status: 409 as const };
       }
 
-      // Re-credit the provisioned amount
       await tx
         .update(billingAccounts)
         .set({
@@ -353,25 +402,12 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
         .where(eq(billingAccounts.orgId, orgId));
 
       await tx
-        .update(creditLedger)
+        .update(transactions)
         .set({
           status: "cancelled",
           updatedAt: new Date(),
         })
-        .where(eq(creditLedger.id, provisionId));
-
-      // Insert cancel refund ledger entry
-      await tx
-        .insert(creditLedger)
-        .values({
-          orgId,
-          userId,
-          type: "credit",
-          amountCents: provision.amount_cents,
-          status: "confirmed",
-          source: "provision_cancel",
-          description: `Provision ${provisionId} cancelled — refund`,
-        });
+        .where(eq(transactions.id, provisionId));
 
       const [account] = await tx
         .select({
@@ -397,7 +433,6 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
       return;
     }
 
-    // Fire-and-forget Stripe balance txn for the refund
     const customerId = "_customerId" in result ? result._customerId as string | null : null;
     const refundedCents = "_refundedCents" in result ? result._refundedCents as number : 0;
     if (customerId && refundedCents > 0) {
@@ -412,7 +447,6 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
       );
     }
 
-    // Strip internal fields
     const { _customerId: _c, _refundedCents: _r, ...response } = result as Record<string, unknown>;
 
     traceEvent({

--- a/src/routes/public-stats.ts
+++ b/src/routes/public-stats.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { sql as rawSql } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { billingAccounts, creditLedger } from "../db/schema.js";
+import { billingAccounts, transactions } from "../db/schema.js";
 
 const router = Router();
 
@@ -15,18 +15,18 @@ interface GrowthRow {
 async function queryGrowth(truncTo: "month" | "week"): Promise<GrowthRow[]> {
   const rows = await db.execute(
     rawSql`SELECT
-      to_char(date_trunc(${truncTo}, ${creditLedger.createdAt}), 'YYYY-MM-DD') AS period,
-      COALESCE(SUM(${creditLedger.amountCents}) FILTER (
-        WHERE ${creditLedger.type} = 'credit' AND ${creditLedger.status} = 'confirmed'
+      to_char(date_trunc(${truncTo}, ${transactions.createdAt}), 'YYYY-MM-DD') AS period,
+      COALESCE(SUM(${transactions.amountCents}) FILTER (
+        WHERE ${transactions.type} = 'credit' AND ${transactions.status} = 'confirmed'
       ), 0)::int AS credited_cents,
-      COALESCE(SUM(${creditLedger.amountCents}) FILTER (
-        WHERE ${creditLedger.type} = 'debit' AND ${creditLedger.status} IN ('confirmed', 'pending')
+      COALESCE(SUM(${transactions.amountCents}) FILTER (
+        WHERE ${transactions.type} = 'debit' AND ${transactions.status} IN ('confirmed', 'pending')
       ), 0)::int AS consumed_cents,
-      COALESCE(SUM(${creditLedger.amountCents}) FILTER (
-        WHERE ${creditLedger.type} = 'credit' AND ${creditLedger.status} = 'confirmed'
-          AND ${creditLedger.source} = 'reload'
+      COALESCE(SUM(${transactions.amountCents}) FILTER (
+        WHERE ${transactions.type} = 'credit' AND ${transactions.status} = 'confirmed'
+          AND ${transactions.source} = 'reload'
       ), 0)::int AS revenue_cents
-    FROM ${creditLedger}
+    FROM ${transactions}
     GROUP BY 1
     ORDER BY 1`
   );
@@ -45,20 +45,20 @@ router.get("/public/stats/billing", async (_req, res) => {
 
     const [creditStats] = await db
       .select({
-        totalCreditedCents: rawSql<number>`COALESCE(SUM(${creditLedger.amountCents}), 0)::int`,
+        totalCreditedCents: rawSql<number>`COALESCE(SUM(${transactions.amountCents}), 0)::int`,
       })
-      .from(creditLedger)
+      .from(transactions)
       .where(
-        rawSql`${creditLedger.type} = 'credit' AND ${creditLedger.status} = 'confirmed'`
+        rawSql`${transactions.type} = 'credit' AND ${transactions.status} = 'confirmed'`
       );
 
     const [debitStats] = await db
       .select({
-        totalConsumedCents: rawSql<number>`COALESCE(SUM(${creditLedger.amountCents}), 0)::int`,
+        totalConsumedCents: rawSql<number>`COALESCE(SUM(${transactions.amountCents}), 0)::int`,
       })
-      .from(creditLedger)
+      .from(transactions)
       .where(
-        rawSql`${creditLedger.type} = 'debit' AND ${creditLedger.status} IN ('confirmed', 'pending')`
+        rawSql`${transactions.type} = 'debit' AND ${transactions.status} IN ('confirmed', 'pending')`
       );
 
     const [monthlyGrowth, weeklyGrowth] = await Promise.all([

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { billingAccounts, creditLedger } from "../db/schema.js";
+import { billingAccounts, transactions } from "../db/schema.js";
 import {
   constructWebhookEvent,
   retrievePaymentIntent,
@@ -104,7 +104,7 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
 
     // Insert reload ledger entry
     const [ledgerEntry] = await db
-      .insert(creditLedger)
+      .insert(transactions)
       .values({
         orgId: account.orgId,
         userId: "00000000-0000-0000-0000-000000000000",

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,12 +1,12 @@
 import { db, sql } from "../../src/db/index.js";
 import {
   billingAccounts,
-  creditLedger,
+  transactions,
   localPromoCodes,
 } from "../../src/db/schema.js";
 
 export async function cleanTestData() {
-  await db.delete(creditLedger);
+  await db.delete(transactions);
   await db.delete(billingAccounts);
   await db.delete(localPromoCodes);
 }

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import request from "supertest";
 import { eq, and } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
-import { creditLedger, billingAccounts } from "../../src/db/schema.js";
+import { transactions, billingAccounts } from "../../src/db/schema.js";
 import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
 import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
 import { setupStripeMocks } from "../helpers/mock-stripe.js";
@@ -48,11 +48,11 @@ describe("Credits deduction endpoint", () => {
     // Verify ledger entry was created
     const entries = await db
       .select()
-      .from(creditLedger)
+      .from(transactions)
       .where(
         and(
-          eq(creditLedger.orgId, orgId),
-          eq(creditLedger.source, "deduct")
+          eq(transactions.orgId, orgId),
+          eq(transactions.source, "charge")
         )
       );
     expect(entries).toHaveLength(1);
@@ -125,11 +125,11 @@ describe("Credits deduction endpoint", () => {
     // Welcome ledger entry should exist
     const welcomeEntries = await db
       .select()
-      .from(creditLedger)
+      .from(transactions)
       .where(
         and(
-          eq(creditLedger.orgId, "00000000-0000-0000-0000-999999999999"),
-          eq(creditLedger.source, "welcome")
+          eq(transactions.orgId, "00000000-0000-0000-0000-999999999999"),
+          eq(transactions.source, "welcome")
         )
       );
     expect(welcomeEntries).toHaveLength(1);
@@ -302,11 +302,11 @@ describe("Credits authorize endpoint", () => {
     // Reload ledger entry should exist
     const reloadEntries = await db
       .select()
-      .from(creditLedger)
+      .from(transactions)
       .where(
         and(
-          eq(creditLedger.orgId, orgId),
-          eq(creditLedger.source, "reload")
+          eq(transactions.orgId, orgId),
+          eq(transactions.source, "reload")
         )
       );
     expect(reloadEntries).toHaveLength(1);
@@ -380,11 +380,11 @@ describe("Credits authorize endpoint", () => {
     // Verify cancelled reload entry was written
     const reloadEntries = await db
       .select()
-      .from(creditLedger)
+      .from(transactions)
       .where(
         and(
-          eq(creditLedger.orgId, orgId),
-          eq(creditLedger.source, "reload")
+          eq(transactions.orgId, orgId),
+          eq(transactions.source, "reload")
         )
       );
     expect(reloadEntries).toHaveLength(1);
@@ -403,7 +403,7 @@ describe("Credits authorize endpoint", () => {
     });
 
     // Insert a recent cancelled reload entry (5 min ago)
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId,
       userId,
       type: "credit",
@@ -435,7 +435,7 @@ describe("Credits authorize endpoint", () => {
     });
 
     // Back up the 50 cents with a confirmed ledger entry (so reconcile doesn't zero it)
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId,
       userId,
       type: "credit",
@@ -446,7 +446,7 @@ describe("Credits authorize endpoint", () => {
     });
 
     // Insert an old cancelled reload entry (20 min ago)
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId,
       userId,
       type: "credit",
@@ -479,7 +479,7 @@ describe("Credits authorize endpoint", () => {
     });
 
     // Back up the 50 cents
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId,
       userId,
       type: "credit",
@@ -490,7 +490,7 @@ describe("Credits authorize endpoint", () => {
     });
 
     // Insert a cancelled reload entry (3 min ago)
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId,
       userId,
       type: "credit",
@@ -502,7 +502,7 @@ describe("Credits authorize endpoint", () => {
     });
 
     // Insert a small confirmed reload entry (1 min ago) — resets cooldown
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId,
       userId,
       type: "credit",
@@ -592,7 +592,7 @@ describe("Credits authorize endpoint", () => {
     });
 
     // Insert a ledger entry that should compute to 300
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId,
       userId,
       type: "credit",
@@ -645,7 +645,7 @@ describe("Credits authorize — reconcile race conditions", () => {
       stripeCustomerId: "cus_race",
       creditBalanceCents: 999, // wrong cache
     });
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId,
       userId,
       type: "credit",
@@ -671,8 +671,8 @@ describe("Credits authorize — reconcile race conditions", () => {
     // Only one welcome ledger row should exist — no duplicates from concurrent reconciles
     const entries = await db
       .select()
-      .from(creditLedger)
-      .where(eq(creditLedger.orgId, orgId));
+      .from(transactions)
+      .where(eq(transactions.orgId, orgId));
     expect(entries).toHaveLength(1);
     expect(entries[0].source).toBe("welcome");
   });
@@ -707,11 +707,11 @@ describe("Credits authorize — reconcile race conditions", () => {
     // Exactly one recovered reload entry — no duplicates from concurrent reconciles
     const reloadEntries = await db
       .select()
-      .from(creditLedger)
+      .from(transactions)
       .where(
         and(
-          eq(creditLedger.orgId, orgId),
-          eq(creditLedger.source, "reload")
+          eq(transactions.orgId, orgId),
+          eq(transactions.source, "reload")
         )
       );
     expect(reloadEntries).toHaveLength(1);
@@ -720,7 +720,7 @@ describe("Credits authorize — reconcile race conditions", () => {
   });
 
   it("rejects duplicate (org_id, stripe_payment_intent_id) reload rows at the DB level", async () => {
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId,
       userId,
       type: "credit",
@@ -732,7 +732,7 @@ describe("Credits authorize — reconcile race conditions", () => {
     });
 
     await expect(
-      db.insert(creditLedger).values({
+      db.insert(transactions).values({
         orgId,
         userId,
         type: "credit",
@@ -753,7 +753,7 @@ describe("Credits authorize — reconcile race conditions", () => {
     });
 
     const [entry] = await db
-      .insert(creditLedger)
+      .insert(transactions)
       .values({
         orgId,
         userId,
@@ -797,7 +797,7 @@ describe("Credits authorize — reconcile race conditions", () => {
     });
 
     // Fresh entry — within grace window — should be skipped by Check 3
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId,
       userId,
       type: "credit",

--- a/tests/integration/migration-0012.test.ts
+++ b/tests/integration/migration-0012.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { eq, and, sql as rawSql } from "drizzle-orm";
+import { db, sql } from "../../src/db/index.js";
+import { transactions } from "../../src/db/schema.js";
+import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
+
+// Verifies the 0012 SQL migration on a synthetic snapshot of legacy rows:
+//   - 'deduct'   debit confirmed         -> renamed to 'charge'
+//   - 'provision' debit confirmed/cancelled/pending -> renamed to 'charge'
+//   - 'provision_cancel' credit confirmed (paired with cancelled debit parent)  -> deleted
+//   - 'provision_adjust' credit confirmed (paired with confirmed debit parent)  -> collapsed into a fresh 'charge' row at $Y, parent reverted to $X cancelled
+// After running the migration, we re-check totals from the public-stats query semantics
+// and the per-row invariants required by AC-A* / AC-B*.
+
+const MIGRATION_PATH = resolve(__dirname, "..", "..", "drizzle", "0012_transactions_rename.sql");
+
+async function runMigrationFresh() {
+  // Drizzle's migrator splits the file on `--> statement-breakpoint` and runs each chunk
+  // as one statement. Postgres treats lines starting with `--` as comments inside the chunk.
+  const raw = readFileSync(MIGRATION_PATH, "utf-8");
+  const statements = raw
+    .split("--> statement-breakpoint")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  for (const statement of statements) {
+    await db.execute(rawSql.raw(statement));
+  }
+}
+
+describe("Migration 0012: transactions rename + source unification", () => {
+  const orgId = "00000000-0000-0000-0000-0000000aabb1";
+  const userId = "00000000-0000-0000-0000-000000000099";
+
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("is a no-op when run on already-canonical data", async () => {
+    await insertTestAccount({ orgId, creditBalanceCents: 1000 });
+
+    await db.insert(transactions).values([
+      {
+        orgId,
+        userId,
+        type: "debit",
+        status: "confirmed",
+        amountCents: 100,
+        source: "charge",
+        description: "already canonical",
+      },
+      {
+        orgId,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: 1000,
+        source: "reload",
+        description: "already canonical",
+      },
+    ]);
+
+    await runMigrationFresh();
+
+    const all = await db.select().from(transactions).where(eq(transactions.orgId, orgId));
+    expect(all).toHaveLength(2);
+    for (const row of all) {
+      expect(["charge", "reload", "welcome", "promo", "refund"]).toContain(row.source);
+    }
+  });
+
+  it("renames source 'deduct' -> 'charge'", async () => {
+    await insertTestAccount({ orgId, creditBalanceCents: 0 });
+
+    await db.insert(transactions).values({
+      orgId,
+      userId,
+      type: "debit",
+      status: "confirmed",
+      amountCents: 50,
+      source: "deduct",
+      description: "legacy deduct",
+    });
+
+    await runMigrationFresh();
+
+    const rows = await db.select().from(transactions).where(eq(transactions.orgId, orgId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source).toBe("charge");
+    expect(rows[0].amountCents).toBe(50);
+  });
+
+  it("renames source 'provision' -> 'charge' for all statuses", async () => {
+    await insertTestAccount({ orgId, creditBalanceCents: 0 });
+
+    await db.insert(transactions).values([
+      {
+        orgId,
+        userId,
+        type: "debit",
+        status: "confirmed",
+        amountCents: 100,
+        source: "provision",
+        description: "confirmed provision",
+      },
+      {
+        orgId,
+        userId,
+        type: "debit",
+        status: "pending",
+        amountCents: 200,
+        source: "provision",
+        description: "pending provision",
+      },
+      {
+        orgId,
+        userId,
+        type: "debit",
+        status: "cancelled",
+        amountCents: 300,
+        source: "provision",
+        description: "cancelled provision",
+      },
+    ]);
+
+    await runMigrationFresh();
+
+    const rows = await db.select().from(transactions).where(eq(transactions.orgId, orgId));
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.source).toBe("charge");
+    }
+  });
+
+  it("deletes provision_cancel rows and keeps the cancelled-debit parent intact", async () => {
+    await insertTestAccount({ orgId, creditBalanceCents: 0 });
+
+    const [parent] = await db
+      .insert(transactions)
+      .values({
+        orgId,
+        userId,
+        type: "debit",
+        status: "cancelled",
+        amountCents: 100,
+        source: "provision",
+        description: "original hold",
+      })
+      .returning();
+
+    await db.insert(transactions).values({
+      orgId,
+      userId,
+      type: "credit",
+      status: "confirmed",
+      amountCents: 100,
+      source: "provision_cancel",
+      description: `Provision ${parent.id} cancelled — refund`,
+    });
+
+    await runMigrationFresh();
+
+    const rows = await db.select().from(transactions).where(eq(transactions.orgId, orgId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(parent.id);
+    expect(rows[0].status).toBe("cancelled");
+    expect(rows[0].source).toBe("charge");
+  });
+
+  it("collapses provision_adjust (over-provisioned) into a fresh charge at $Y; parent reverts to $X cancelled", async () => {
+    await insertTestAccount({ orgId, creditBalanceCents: 0 });
+
+    // Original $X = 100, actual $Y = 60. Over-provisioned, adjust is a credit of 40.
+    const [parent] = await db
+      .insert(transactions)
+      .values({
+        orgId,
+        userId,
+        type: "debit",
+        status: "confirmed",
+        amountCents: 60, // current $Y — confirm() updated it
+        source: "provision",
+        description: "over-provisioned hold",
+      })
+      .returning();
+
+    await db.insert(transactions).values({
+      orgId,
+      userId,
+      type: "credit",
+      status: "confirmed",
+      amountCents: 40, // |delta|
+      source: "provision_adjust",
+      description: `Provision ${parent.id} adjustment: +40 cents`,
+    });
+
+    await runMigrationFresh();
+
+    // Parent reverted to $X = 100, status cancelled.
+    const [parentAfter] = await db.select().from(transactions).where(eq(transactions.id, parent.id));
+    expect(parentAfter.status).toBe("cancelled");
+    expect(parentAfter.amountCents).toBe(100);
+    expect(parentAfter.source).toBe("charge");
+
+    // Adjust row deleted.
+    const adjusts = await db
+      .select()
+      .from(transactions)
+      .where(and(eq(transactions.orgId, orgId), eq(transactions.source, "provision_adjust")));
+    expect(adjusts).toHaveLength(0);
+
+    // New charge row at $Y = 60.
+    const charges = await db
+      .select()
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.orgId, orgId),
+          eq(transactions.source, "charge"),
+          eq(transactions.status, "confirmed")
+        )
+      );
+    expect(charges).toHaveLength(1);
+    expect(charges[0].amountCents).toBe(60);
+
+    // Net balance contribution preserved: pre = -60 (parent) + 40 (adjust) = -20.
+    // post = 0 (cancelled parent) - 60 (new charge) = -60.
+    // Mismatch is expected and intentional: pre-migration the cache reflected -60 (the actual
+    // money owed), but the ledger summed to -20 due to the adjust bug. Post-migration, the
+    // ledger correctly sums to -60 = cache. This test asserts the post-state, not pre-equality.
+    const [{ ledgerSum }] = (await db.execute(rawSql`
+      SELECT COALESCE(SUM(
+        CASE
+          WHEN type = 'credit' AND status = 'confirmed' THEN amount_cents
+          WHEN type = 'debit' AND status IN ('confirmed','pending') THEN -amount_cents
+          ELSE 0
+        END
+      ), 0)::int AS "ledgerSum"
+      FROM transactions WHERE org_id = ${orgId}
+    `)) as unknown as { ledgerSum: number }[];
+    expect(ledgerSum).toBe(-60);
+  });
+
+  it("collapses provision_adjust (under-provisioned) into a fresh charge at $Y; parent reverts to $X cancelled", async () => {
+    await insertTestAccount({ orgId, creditBalanceCents: 0 });
+
+    // Original $X = 100, actual $Y = 150. Under-provisioned, adjust is a debit of 50.
+    const [parent] = await db
+      .insert(transactions)
+      .values({
+        orgId,
+        userId,
+        type: "debit",
+        status: "confirmed",
+        amountCents: 150,
+        source: "provision",
+        description: "under-provisioned hold",
+      })
+      .returning();
+
+    await db.insert(transactions).values({
+      orgId,
+      userId,
+      type: "debit",
+      status: "confirmed",
+      amountCents: 50,
+      source: "provision_adjust",
+      description: `Provision ${parent.id} adjustment: -50 cents`,
+    });
+
+    await runMigrationFresh();
+
+    const [parentAfter] = await db.select().from(transactions).where(eq(transactions.id, parent.id));
+    expect(parentAfter.status).toBe("cancelled");
+    expect(parentAfter.amountCents).toBe(100);
+
+    const charges = await db
+      .select()
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.orgId, orgId),
+          eq(transactions.source, "charge"),
+          eq(transactions.status, "confirmed")
+        )
+      );
+    expect(charges).toHaveLength(1);
+    expect(charges[0].amountCents).toBe(150);
+  });
+
+  it("aborts when a provision_cancel row has no matching parent", async () => {
+    await insertTestAccount({ orgId, creditBalanceCents: 0 });
+
+    await db.insert(transactions).values({
+      orgId,
+      userId,
+      type: "credit",
+      status: "confirmed",
+      amountCents: 100,
+      source: "provision_cancel",
+      description: "Provision 00000000-0000-0000-0000-000000abcdef cancelled — refund",
+    });
+
+    await expect(runMigrationFresh()).rejects.toThrow(/provision_cancel orphans/);
+
+    // Row still present after failed migration.
+    const rows = await db.select().from(transactions).where(eq(transactions.orgId, orgId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source).toBe("provision_cancel");
+  });
+
+  it("leaves only canonical sources after running on a mixed-state dataset", async () => {
+    await insertTestAccount({ orgId, creditBalanceCents: 0 });
+
+    const [parentForCancel] = await db
+      .insert(transactions)
+      .values({
+        orgId,
+        userId,
+        type: "debit",
+        status: "cancelled",
+        amountCents: 25,
+        source: "provision",
+        description: "for cancel pairing",
+      })
+      .returning();
+
+    const [parentForAdjust] = await db
+      .insert(transactions)
+      .values({
+        orgId,
+        userId,
+        type: "debit",
+        status: "confirmed",
+        amountCents: 80,
+        source: "provision",
+        description: "for adjust pairing",
+      })
+      .returning();
+
+    await db.insert(transactions).values([
+      {
+        orgId,
+        userId,
+        type: "debit",
+        status: "confirmed",
+        amountCents: 5,
+        source: "deduct",
+        description: "legacy deduct",
+      },
+      {
+        orgId,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: 1000,
+        source: "reload",
+        description: "real reload",
+      },
+      {
+        orgId,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: 200,
+        source: "welcome",
+        description: "welcome credit",
+      },
+      {
+        orgId,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: 25,
+        source: "provision_cancel",
+        description: `Provision ${parentForCancel.id} cancelled — refund`,
+      },
+      {
+        orgId,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: 20,
+        source: "provision_adjust",
+        description: `Provision ${parentForAdjust.id} adjustment: +20 cents`,
+      },
+    ]);
+
+    await runMigrationFresh();
+
+    const rows = await db.select().from(transactions).where(eq(transactions.orgId, orgId));
+    for (const row of rows) {
+      expect(["charge", "reload", "welcome", "promo", "refund"]).toContain(row.source);
+    }
+    // Originals: parentForCancel (charge cancelled), parentForAdjust (charge cancelled), deduct→charge,
+    // reload, welcome. Plus one new charge from adjust. Total 6.
+    expect(rows).toHaveLength(6);
+  });
+});

--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import request from "supertest";
 import { eq, and } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
-import { creditLedger, billingAccounts } from "../../src/db/schema.js";
+import { transactions, billingAccounts } from "../../src/db/schema.js";
 import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
 import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
 import { setupStripeMocks } from "../helpers/mock-stripe.js";
@@ -41,13 +41,12 @@ describe("Credit provision endpoints", () => {
       expect(res.body.balance_cents).toBe(400);
       expect(res.body.depleted).toBe(false);
 
-      // Verify ledger entry
       const entries = await db
         .select()
-        .from(creditLedger)
-        .where(eq(creditLedger.id, res.body.provision_id));
+        .from(transactions)
+        .where(eq(transactions.id, res.body.provision_id));
       expect(entries).toHaveLength(1);
-      expect(entries[0].source).toBe("provision");
+      expect(entries[0].source).toBe("charge");
       expect(entries[0].type).toBe("debit");
       expect(entries[0].status).toBe("pending");
     });
@@ -104,8 +103,8 @@ describe("Credit provision endpoints", () => {
 
       const [row] = await db
         .select()
-        .from(creditLedger)
-        .where(eq(creditLedger.id, res.body.provision_id))
+        .from(transactions)
+        .where(eq(transactions.id, res.body.provision_id))
         .limit(1);
 
       expect(row.campaignId).toBe("camp_42");
@@ -133,8 +132,8 @@ describe("Credit provision endpoints", () => {
 
       const [row] = await db
         .select()
-        .from(creditLedger)
-        .where(eq(creditLedger.id, res.body.provision_id))
+        .from(transactions)
+        .where(eq(transactions.id, res.body.provision_id))
         .limit(1);
 
       expect(row.brandIds).toEqual(["brand_1", "brand_2", "brand_3"]);
@@ -206,7 +205,7 @@ describe("Credit provision endpoints", () => {
       expect(res.body.balance_cents).toBe(400);
     });
 
-    it("adjusts balance when actual cost is lower", async () => {
+    it("on lower actual cost: cancels original hold, writes new charge at $Y, refunds delta", async () => {
       await insertTestAccount({
         orgId,
         stripeCustomerId: "cus_123",
@@ -218,9 +217,10 @@ describe("Credit provision endpoints", () => {
         .set(getAuthHeaders(orgId))
         .send({ amount_cents: 100, description: "test" });
 
-      // Balance is now 400. Confirm with actual 60 → credit back 40 → balance 440
+      const provisionId = provRes.body.provision_id;
+
       const res = await request(app)
-        .post(`/v1/credits/provision/${provRes.body.provision_id}/confirm`)
+        .post(`/v1/credits/provision/${provisionId}/confirm`)
         .set(getAuthHeaders(orgId))
         .send({ actual_amount_cents: 60 });
 
@@ -229,22 +229,45 @@ describe("Credit provision endpoints", () => {
       expect(res.body.final_amount_cents).toBe(60);
       expect(res.body.balance_cents).toBe(440);
 
-      // Adjustment ledger entry should exist
-      const adjEntries = await db
+      // Original row mutates to cancelled at $X, no miroir credit row.
+      const original = await db
         .select()
-        .from(creditLedger)
+        .from(transactions)
+        .where(eq(transactions.id, provisionId));
+      expect(original).toHaveLength(1);
+      expect(original[0].status).toBe("cancelled");
+      expect(original[0].amountCents).toBe(100);
+      expect(original[0].source).toBe("charge");
+
+      // Exactly one fresh confirmed charge row at $Y.
+      const confirmed = await db
+        .select()
+        .from(transactions)
         .where(
           and(
-            eq(creditLedger.orgId, orgId),
-            eq(creditLedger.source, "provision_adjust")
+            eq(transactions.orgId, orgId),
+            eq(transactions.source, "charge"),
+            eq(transactions.status, "confirmed")
           )
         );
-      expect(adjEntries).toHaveLength(1);
-      expect(adjEntries[0].type).toBe("credit");
-      expect(adjEntries[0].amountCents).toBe(40);
+      expect(confirmed).toHaveLength(1);
+      expect(confirmed[0].type).toBe("debit");
+      expect(confirmed[0].amountCents).toBe(60);
+
+      // No legacy miroir sources written
+      const legacy = await db
+        .select()
+        .from(transactions)
+        .where(
+          and(
+            eq(transactions.orgId, orgId),
+            eq(transactions.source, "provision_adjust")
+          )
+        );
+      expect(legacy).toHaveLength(0);
     });
 
-    it("adjusts balance when actual cost is higher", async () => {
+    it("on higher actual cost: cancels original hold, writes new charge at $Y, deducts delta", async () => {
       await insertTestAccount({
         orgId,
         stripeCustomerId: "cus_123",
@@ -256,9 +279,10 @@ describe("Credit provision endpoints", () => {
         .set(getAuthHeaders(orgId))
         .send({ amount_cents: 100, description: "test" });
 
-      // Balance is now 400. Confirm with actual 150 → deduct 50 more → balance 350
+      const provisionId = provRes.body.provision_id;
+
       const res = await request(app)
-        .post(`/v1/credits/provision/${provRes.body.provision_id}/confirm`)
+        .post(`/v1/credits/provision/${provisionId}/confirm`)
         .set(getAuthHeaders(orgId))
         .send({ actual_amount_cents: 150 });
 
@@ -266,6 +290,58 @@ describe("Credit provision endpoints", () => {
       expect(res.body.adjustment_cents).toBe(-50);
       expect(res.body.final_amount_cents).toBe(150);
       expect(res.body.balance_cents).toBe(350);
+
+      const original = await db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, provisionId));
+      expect(original[0].status).toBe("cancelled");
+      expect(original[0].amountCents).toBe(100);
+
+      const confirmed = await db
+        .select()
+        .from(transactions)
+        .where(
+          and(
+            eq(transactions.orgId, orgId),
+            eq(transactions.source, "charge"),
+            eq(transactions.status, "confirmed")
+          )
+        );
+      expect(confirmed).toHaveLength(1);
+      expect(confirmed[0].amountCents).toBe(150);
+    });
+
+    it("on same amount: mutates row pending→confirmed, no new row", async () => {
+      await insertTestAccount({
+        orgId,
+        stripeCustomerId: "cus_123",
+        creditBalanceCents: 500,
+      });
+
+      const provRes = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "test" });
+
+      const provisionId = provRes.body.provision_id;
+
+      const res = await request(app)
+        .post(`/v1/credits/provision/${provisionId}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({ actual_amount_cents: 100 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.balance_cents).toBe(400);
+
+      const all = await db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.orgId, orgId));
+      expect(all).toHaveLength(1);
+      expect(all[0].id).toBe(provisionId);
+      expect(all[0].status).toBe("confirmed");
+      expect(all[0].amountCents).toBe(100);
     });
 
     it("returns 200 idempotently for already confirmed provision", async () => {
@@ -311,7 +387,7 @@ describe("Credit provision endpoints", () => {
   });
 
   describe("POST /v1/credits/provision/:id/cancel", () => {
-    it("cancels a pending provision, re-credits balance, and writes cancel ledger entry", async () => {
+    it("cancels a pending provision, re-credits balance, mutates row, no miroir credit", async () => {
       await insertTestAccount({
         orgId,
         stripeCustomerId: "cus_123",
@@ -323,9 +399,10 @@ describe("Credit provision endpoints", () => {
         .set(getAuthHeaders(orgId))
         .send({ amount_cents: 100, description: "test" });
 
-      // Balance is now 400. Cancel → re-credit 100 → balance 500
+      const provisionId = provRes.body.provision_id;
+
       const res = await request(app)
-        .post(`/v1/credits/provision/${provRes.body.provision_id}/cancel`)
+        .post(`/v1/credits/provision/${provisionId}/cancel`)
         .set(getAuthHeaders(orgId))
         .send();
 
@@ -334,19 +411,26 @@ describe("Credit provision endpoints", () => {
       expect(res.body.refunded_cents).toBe(100);
       expect(res.body.balance_cents).toBe(500);
 
-      // Cancel ledger entry should exist
-      const cancelEntries = await db
+      // Original row mutates to cancelled — no new miroir credit row.
+      const all = await db
         .select()
-        .from(creditLedger)
+        .from(transactions)
+        .where(eq(transactions.orgId, orgId));
+      expect(all).toHaveLength(1);
+      expect(all[0].id).toBe(provisionId);
+      expect(all[0].status).toBe("cancelled");
+      expect(all[0].type).toBe("debit");
+
+      const legacy = await db
+        .select()
+        .from(transactions)
         .where(
           and(
-            eq(creditLedger.orgId, orgId),
-            eq(creditLedger.source, "provision_cancel")
+            eq(transactions.orgId, orgId),
+            eq(transactions.source, "provision_cancel")
           )
         );
-      expect(cancelEntries).toHaveLength(1);
-      expect(cancelEntries[0].type).toBe("credit");
-      expect(cancelEntries[0].amountCents).toBe(100);
+      expect(legacy).toHaveLength(0);
     });
 
     it("returns 200 idempotently for already cancelled provision", async () => {
@@ -427,12 +511,12 @@ describe("Credit provision endpoints", () => {
 
       const creditEntries = await db
         .select()
-        .from(creditLedger)
+        .from(transactions)
         .where(
           and(
-            eq(creditLedger.orgId, orgId),
-            eq(creditLedger.type, "credit"),
-            eq(creditLedger.source, "reload")
+            eq(transactions.orgId, orgId),
+            eq(transactions.type, "credit"),
+            eq(transactions.source, "reload")
           )
         );
 

--- a/tests/integration/public-stats.test.ts
+++ b/tests/integration/public-stats.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import { createTestApp } from "../helpers/test-app.js";
 import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
 import { db } from "../../src/db/index.js";
-import { creditLedger } from "../../src/db/schema.js";
+import { transactions } from "../../src/db/schema.js";
 
 describe("GET /public/stats/billing", () => {
   const app = createTestApp();
@@ -52,7 +52,7 @@ describe("GET /public/stats/billing", () => {
       stripePaymentMethodId: null,
     });
 
-    await db.insert(creditLedger).values([
+    await db.insert(transactions).values([
       {
         orgId: orgA,
         userId,
@@ -77,7 +77,7 @@ describe("GET /public/stats/billing", () => {
         type: "debit",
         status: "confirmed",
         amountCents: 2000,
-        source: "deduct",
+        source: "charge",
         description: "usage",
       },
       {
@@ -86,8 +86,8 @@ describe("GET /public/stats/billing", () => {
         type: "debit",
         status: "pending",
         amountCents: 9999,
-        source: "provision",
-        description: "pending provision — included in consumed",
+        source: "charge",
+        description: "pending charge — included in consumed",
       },
       {
         orgId: orgB,
@@ -113,7 +113,7 @@ describe("GET /public/stats/billing", () => {
   it("returns monthly and weekly growth with credited, consumed, and revenue", async () => {
     await insertTestAccount({ orgId: orgA, creditBalanceCents: 1000 });
 
-    await db.insert(creditLedger).values([
+    await db.insert(transactions).values([
       {
         orgId: orgA,
         userId,
@@ -138,7 +138,7 @@ describe("GET /public/stats/billing", () => {
         type: "debit",
         status: "confirmed",
         amountCents: 300,
-        source: "deduct",
+        source: "charge",
         description: "usage",
       },
     ]);
@@ -178,5 +178,95 @@ describe("GET /public/stats/billing", () => {
       expect(row).toHaveProperty("consumed_cents");
       expect(row).toHaveProperty("revenue_cents");
     }
+  });
+
+  // Regression: investor page was showing $1418 credited vs $870 real Stripe revenue because
+  // provision_cancel and provision_adjust credit miroirs were summed into totalCreditedCents.
+  // After the refactor, those sources no longer exist; only canonical credit sources count.
+  it("totalCreditedCents only sums canonical credit sources (no accounting noise)", async () => {
+    await insertTestAccount({ orgId: orgA, creditBalanceCents: 1000 });
+
+    await db.insert(transactions).values([
+      // Canonical credits — all counted.
+      {
+        orgId: orgA,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: 1000,
+        source: "reload",
+        description: "real Stripe top-up",
+      },
+      {
+        orgId: orgA,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: 200,
+        source: "welcome",
+        description: "trial credit",
+      },
+      {
+        orgId: orgA,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: 50,
+        source: "promo",
+        description: "promo redemption",
+      },
+      // Cancelled credit — excluded by status filter.
+      {
+        orgId: orgA,
+        userId,
+        type: "credit",
+        status: "cancelled",
+        amountCents: 9999,
+        source: "reload",
+        description: "failed reload — must not count",
+      },
+    ]);
+
+    const res = await request(app).get("/public/stats/billing");
+    expect(res.status).toBe(200);
+    expect(res.body.totalCreditedCents).toBe(1250); // 1000 + 200 + 50
+  });
+
+  it("totalConsumedCents excludes cancelled charges", async () => {
+    await insertTestAccount({ orgId: orgA, creditBalanceCents: 1000 });
+
+    await db.insert(transactions).values([
+      {
+        orgId: orgA,
+        userId,
+        type: "debit",
+        status: "confirmed",
+        amountCents: 100,
+        source: "charge",
+        description: "confirmed usage",
+      },
+      {
+        orgId: orgA,
+        userId,
+        type: "debit",
+        status: "pending",
+        amountCents: 50,
+        source: "charge",
+        description: "active hold",
+      },
+      {
+        orgId: orgA,
+        userId,
+        type: "debit",
+        status: "cancelled",
+        amountCents: 999,
+        source: "charge",
+        description: "cancelled hold — must not count",
+      },
+    ]);
+
+    const res = await request(app).get("/public/stats/billing");
+    expect(res.status).toBe(200);
+    expect(res.body.totalConsumedCents).toBe(150);
   });
 });

--- a/tests/integration/transfer-brand.test.ts
+++ b/tests/integration/transfer-brand.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import request from "supertest";
 import { eq } from "drizzle-orm";
 import { db } from "../../src/db/index.js";
-import { creditLedger } from "../../src/db/schema.js";
+import { transactions } from "../../src/db/schema.js";
 import { createTestApp } from "../helpers/test-app.js";
 import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
 
@@ -32,7 +32,7 @@ describe("POST /internal/transfer-brand", () => {
   });
 
   it("transfers solo-brand ledger entries from source to target org", async () => {
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId: sourceOrgId,
       userId,
       amountCents: 100,
@@ -47,12 +47,12 @@ describe("POST /internal/transfer-brand", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
-      { tableName: "credit_ledger", count: 1 },
+      { tableName: "transactions", count: 1 },
     ]);
   });
 
   it("rewrites brand_ids when targetBrandId is provided", async () => {
-    const [provision] = await db.insert(creditLedger).values({
+    const [provision] = await db.insert(transactions).values({
       orgId: sourceOrgId,
       userId,
       amountCents: 100,
@@ -67,21 +67,21 @@ describe("POST /internal/transfer-brand", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
-      { tableName: "credit_ledger", count: 1 },
+      { tableName: "transactions", count: 1 },
     ]);
 
     // Verify the brand_ids was rewritten to targetBrandId
     const [updated] = await db
       .select()
-      .from(creditLedger)
-      .where(eq(creditLedger.id, provision.id));
+      .from(transactions)
+      .where(eq(transactions.id, provision.id));
 
     expect(updated.orgId).toBe(targetOrgId);
     expect(updated.brandIds).toEqual([targetBrandId]);
   });
 
   it("skips co-branding entries (multiple brand IDs)", async () => {
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId: sourceOrgId,
       userId,
       amountCents: 200,
@@ -96,12 +96,12 @@ describe("POST /internal/transfer-brand", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
-      { tableName: "credit_ledger", count: 0 },
+      { tableName: "transactions", count: 0 },
     ]);
   });
 
   it("skips entries for a different brand", async () => {
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId: sourceOrgId,
       userId,
       amountCents: 100,
@@ -116,12 +116,12 @@ describe("POST /internal/transfer-brand", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
-      { tableName: "credit_ledger", count: 0 },
+      { tableName: "transactions", count: 0 },
     ]);
   });
 
   it("skips entries with null brand_ids", async () => {
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId: sourceOrgId,
       userId,
       amountCents: 100,
@@ -136,12 +136,12 @@ describe("POST /internal/transfer-brand", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
-      { tableName: "credit_ledger", count: 0 },
+      { tableName: "transactions", count: 0 },
     ]);
   });
 
   it("is idempotent — second call is a no-op", async () => {
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId: sourceOrgId,
       userId,
       amountCents: 100,
@@ -156,7 +156,7 @@ describe("POST /internal/transfer-brand", () => {
 
     expect(res1.status).toBe(200);
     expect(res1.body.updatedTables).toEqual([
-      { tableName: "credit_ledger", count: 1 },
+      { tableName: "transactions", count: 1 },
     ]);
 
     const res2 = await request(app)
@@ -166,12 +166,12 @@ describe("POST /internal/transfer-brand", () => {
 
     expect(res2.status).toBe(200);
     expect(res2.body.updatedTables).toEqual([
-      { tableName: "credit_ledger", count: 0 },
+      { tableName: "transactions", count: 0 },
     ]);
   });
 
   it("is idempotent with targetBrandId — second call is a no-op", async () => {
-    await db.insert(creditLedger).values({
+    await db.insert(transactions).values({
       orgId: sourceOrgId,
       userId,
       amountCents: 100,
@@ -186,7 +186,7 @@ describe("POST /internal/transfer-brand", () => {
 
     expect(res1.status).toBe(200);
     expect(res1.body.updatedTables).toEqual([
-      { tableName: "credit_ledger", count: 1 },
+      { tableName: "transactions", count: 1 },
     ]);
 
     // Second call — brand_ids is now [targetBrandId], org_id is targetOrgId, so WHERE won't match
@@ -197,7 +197,7 @@ describe("POST /internal/transfer-brand", () => {
 
     expect(res2.status).toBe(200);
     expect(res2.body.updatedTables).toEqual([
-      { tableName: "credit_ledger", count: 0 },
+      { tableName: "transactions", count: 0 },
     ]);
   });
 
@@ -221,7 +221,7 @@ describe("POST /internal/transfer-brand", () => {
   });
 
   it("transfers multiple solo-brand entries at once", async () => {
-    await db.insert(creditLedger).values([
+    await db.insert(transactions).values([
       {
         orgId: sourceOrgId,
         userId,
@@ -252,7 +252,7 @@ describe("POST /internal/transfer-brand", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.updatedTables).toEqual([
-      { tableName: "credit_ledger", count: 2 },
+      { tableName: "transactions", count: 2 },
     ]);
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
 
   const { sql } = await import("../src/db/index.js");
 
-  // Drop billing_mode column if it still exists
+  // billing_accounts cleanup from earlier schemas
   await sql`
     DO $$ BEGIN
       ALTER TABLE billing_accounts DROP COLUMN IF EXISTS billing_mode;
@@ -28,7 +28,7 @@ beforeAll(async () => {
     END $$
   `;
 
-  // Rename promo_codes -> local_promo_codes (if old table exists)
+  // local_promo_codes (renamed from promo_codes in 0010)
   await sql`
     DO $$ BEGIN
       ALTER TABLE promo_codes RENAME TO local_promo_codes;
@@ -48,7 +48,7 @@ beforeAll(async () => {
   `;
   await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_local_promo_codes_code" ON "local_promo_codes" USING btree ("code")`;
 
-  // Rename credit_provisions -> credit_ledger (if old table exists)
+  // Walk the table-rename history: credit_provisions -> credit_ledger -> transactions.
   await sql`
     DO $$ BEGIN
       ALTER TABLE credit_provisions RENAME TO credit_ledger;
@@ -57,7 +57,15 @@ beforeAll(async () => {
     END $$
   `;
   await sql`
-    CREATE TABLE IF NOT EXISTS "credit_ledger" (
+    DO $$ BEGIN
+      ALTER TABLE credit_ledger RENAME TO transactions;
+    EXCEPTION WHEN undefined_table THEN NULL;
+              WHEN duplicate_table THEN NULL;
+    END $$
+  `;
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS "transactions" (
       "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
       "org_id" uuid NOT NULL,
       "user_id" uuid NOT NULL,
@@ -65,7 +73,7 @@ beforeAll(async () => {
       "type" text DEFAULT 'debit' NOT NULL,
       "amount_cents" integer NOT NULL,
       "status" text DEFAULT 'pending' NOT NULL,
-      "source" text DEFAULT 'provision' NOT NULL,
+      "source" text DEFAULT 'charge' NOT NULL,
       "stripe_payment_intent_id" text,
       "stripe_balance_txn_id" text,
       "promo_code_id" uuid,
@@ -79,46 +87,45 @@ beforeAll(async () => {
     )
   `;
 
-  // Add new columns if they don't exist (for rename path)
-  await sql`ALTER TABLE "credit_ledger" ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'provision' NOT NULL`;
-  await sql`ALTER TABLE "credit_ledger" ADD COLUMN IF NOT EXISTS "stripe_balance_txn_id" text`;
-  await sql`ALTER TABLE "credit_ledger" ADD COLUMN IF NOT EXISTS "promo_code_id" uuid`;
-  await sql`ALTER TABLE "credit_ledger" ADD COLUMN IF NOT EXISTS "feature_slug" text`;
-  await sql`ALTER TABLE "credit_ledger" ADD COLUMN IF NOT EXISTS "brand_ids" text[]`;
-  await sql`ALTER TABLE "credit_ledger" ADD COLUMN IF NOT EXISTS "stripe_payment_intent_id" text`;
-  await sql`ALTER TABLE "credit_ledger" ADD COLUMN IF NOT EXISTS "type" text DEFAULT 'debit' NOT NULL`;
+  // Add columns if missing (rename path keeps existing columns; this fills gaps).
+  await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'charge' NOT NULL`;
+  await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "stripe_balance_txn_id" text`;
+  await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "promo_code_id" uuid`;
+  await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "feature_slug" text`;
+  await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "brand_ids" text[]`;
+  await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "stripe_payment_intent_id" text`;
+  await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "type" text DEFAULT 'debit' NOT NULL`;
 
-  // Indexes
-  await sql`CREATE INDEX IF NOT EXISTS "idx_credit_ledger_org_id" ON "credit_ledger" USING btree ("org_id")`;
-  await sql`CREATE INDEX IF NOT EXISTS "idx_credit_ledger_status" ON "credit_ledger" USING btree ("status")`;
-  await sql`CREATE INDEX IF NOT EXISTS "idx_credit_ledger_source" ON "credit_ledger" USING btree ("source")`;
+  // Renamed indexes (rename path) + create-if-missing (fresh DB path).
+  await sql`ALTER INDEX IF EXISTS "idx_credit_ledger_org_id" RENAME TO "idx_transactions_org_id"`;
+  await sql`ALTER INDEX IF EXISTS "idx_credit_ledger_status" RENAME TO "idx_transactions_status"`;
+  await sql`ALTER INDEX IF EXISTS "idx_credit_ledger_source" RENAME TO "idx_transactions_source"`;
+  await sql`ALTER INDEX IF EXISTS "idx_credit_ledger_promo_org" RENAME TO "idx_transactions_promo_org"`;
+  await sql`ALTER INDEX IF EXISTS "idx_credit_ledger_reload_pi" RENAME TO "idx_transactions_reload_pi"`;
 
-  // Partial unique index for promo anti-double-redemption
-  await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_credit_ledger_promo_org" ON "credit_ledger" ("promo_code_id", "org_id") WHERE source = 'promo'`;
+  await sql`CREATE INDEX IF NOT EXISTS "idx_transactions_org_id" ON "transactions" USING btree ("org_id")`;
+  await sql`CREATE INDEX IF NOT EXISTS "idx_transactions_status" ON "transactions" USING btree ("status")`;
+  await sql`CREATE INDEX IF NOT EXISTS "idx_transactions_source" ON "transactions" USING btree ("source")`;
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_transactions_promo_org" ON "transactions" ("promo_code_id", "org_id") WHERE source = 'promo'`;
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_transactions_reload_pi" ON "transactions" ("org_id", "stripe_payment_intent_id") WHERE source = 'reload' AND stripe_payment_intent_id IS NOT NULL`;
 
-  // Partial unique index to prevent duplicate reload entries for the same Stripe PI
-  await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_credit_ledger_reload_pi" ON "credit_ledger" ("org_id", "stripe_payment_intent_id") WHERE source = 'reload' AND stripe_payment_intent_id IS NOT NULL`;
-
-  // Migrate brand_id -> brand_ids if old column exists
+  // Old column migrations (idempotent on a fresh schema).
   await sql`
     DO $$ BEGIN
-      UPDATE credit_ledger SET brand_ids = ARRAY[brand_id] WHERE brand_id IS NOT NULL AND brand_ids IS NULL;
-      ALTER TABLE credit_ledger DROP COLUMN IF EXISTS brand_id;
+      UPDATE transactions SET brand_ids = ARRAY[brand_id] WHERE brand_id IS NOT NULL AND brand_ids IS NULL;
+      ALTER TABLE transactions DROP COLUMN IF EXISTS brand_id;
+    EXCEPTION WHEN undefined_column THEN
+      NULL;
+    END $$
+  `;
+  await sql`
+    DO $$ BEGIN
+      ALTER TABLE transactions RENAME COLUMN workflow_name TO workflow_slug;
     EXCEPTION WHEN undefined_column THEN
       NULL;
     END $$
   `;
 
-  // Rename workflow_name -> workflow_slug if old column exists
-  await sql`
-    DO $$ BEGIN
-      ALTER TABLE credit_ledger RENAME COLUMN workflow_name TO workflow_slug;
-    EXCEPTION WHEN undefined_column THEN
-      NULL;
-    END $$
-  `;
-
-  // Drop promo_redemptions table (data migrated to credit_ledger)
   await sql`DROP TABLE IF EXISTS "promo_redemptions"`;
 });
 afterAll(() => console.log("Test suite complete."));


### PR DESCRIPTION
## Why

Production investor page (distribute.you/investors) showed `$1,418` credits-loaded vs `$870` real Stripe revenue. Root cause: `/public/stats/billing.totalCreditedCents` sums `type='credit' AND status='confirmed'`, which included `provision_cancel` and `provision_adjust` credit miroirs — those are accounting movements (refund-of-hold, delta), not real top-ups.

Fixing that surface query alone wasn't enough — the underlying schema had four sources (`provision`, `deduct`, `provision_cancel`, `provision_adjust`) representing one concept (a charge with lifecycle). Collapsing them into one source kept by status makes the ledger truthful by construction.

## What

### Schema
- `credit_ledger` -> `transactions` (table + 4 indexes renamed; partial indexes for `promo` and `reload_pi` carried over).
- Drizzle schema export `creditLedger` -> `transactions`.
- All callers updated.

### Sources (canonical: `reload`, `welcome`, `promo`, `charge`, `refund`)
- `deduct` -> `charge` (direct deductions are charges).
- `provision` + `provision_cancel` + `provision_adjust` collapsed to `charge` with status driving the lifecycle:
  - **Provision**: insert `charge / pending`, debit balance.
  - **Confirm same amount**: mutate row `pending -> confirmed`. No new row.
  - **Confirm different amount $Y != $X**: cancel original (`pending -> cancelled`, refund $X to balance) + insert fresh `charge / confirmed / amount=$Y` (debit $Y from balance). Net balance change = $X - $Y.
  - **Cancel**: mutate row `pending -> cancelled`, refund balance. No miroir credit row.
- Side-effect: also fixes the existing under-provision drift (current code mutated the parent's `amount_cents` to $Y while leaving an adjust debit in the ledger — reconcile saw -$Y - delta and would over-deduct).

### Public-stats query
Unchanged shape (`type/status` filters). The fix is in the data: with no more `provision_cancel` / `provision_adjust` rows, `totalCreditedCents` only sums real credit sources. `totalConsumedCents` still counts confirmed + pending debits (active holds = balance reserved).

### Migration (\`drizzle/0012_transactions_rename.sql\`)
Auto-runs on container boot via the existing \`migrate()\` call in \`src/index.ts\`. Idempotent (re-running on a fully-migrated DB is a no-op).

| Phase | Action |
|-------|--------|
| 1 | Rename table + indexes (`ALTER ... IF EXISTS`) |
| 3 | `deduct` -> `charge` |
| 4 | Verify every `provision_cancel` pairs with a cancelled-debit-same-amount parent; abort otherwise. DELETE rows. |
| 5 | Verify every `provision_adjust` references an existing parent; abort otherwise. Insert fresh `provision/confirmed/$Y` rows carrying parent context, restore parent to `$X / cancelled`, DELETE adjust rows. |
| 6 | `provision` -> `charge` |
| 7 | Invariant check: only canonical sources remain; raise otherwise. |

**Phase 2 (Math.ceil reconcile) is intentionally deferred** — it depends on runs-service exposing `GET /v1/runs/:id/billable-cost`. Will be a follow-up PR. See companion runs-service workspace.

### Tests
- All 173 tests green.
- New `tests/integration/migration-0012.test.ts` covers: deduct rename, provision rename, provision_cancel deletion, provision_adjust over/under collapse, orphan-aborts, mixed-state dataset.
- Provision flow tests rewritten for new semantics (mutate-row, cancel+new-charge on amount mismatch, no miroir rows on cancel).
- Public-stats tests get two regression tests asserting the bug fix (cancelled credits excluded from credited; cancelled charges excluded from consumed).

## Verification on prod (after deploy)

The migration is auto-run on Railway boot. Drizzle records the migration in `__drizzle_migrations` so it runs exactly once per env. After deploy, run on the prod DB:

```sql
-- AC-A1/A2: schema renamed
SELECT 1 FROM information_schema.tables WHERE table_name = 'transactions';
SELECT indexname FROM pg_indexes WHERE tablename = 'transactions';

-- AC-B1: only canonical sources remain
SELECT source, COUNT(*) FROM transactions GROUP BY source;
-- Expect: reload, welcome, promo, charge (refund: 0)

-- AC-D: per-org balance matches ledger
SELECT b.org_id, b.credit_balance_cents, COALESCE(SUM(
  CASE
    WHEN t.type='credit' AND t.status='confirmed' THEN t.amount_cents
    WHEN t.type='debit' AND t.status IN ('confirmed','pending') THEN -t.amount_cents
    ELSE 0
  END
), 0)::int AS computed
FROM billing_accounts b
LEFT JOIN transactions t ON t.org_id = b.org_id
GROUP BY b.org_id, b.credit_balance_cents
HAVING b.credit_balance_cents != COALESCE(SUM(
  CASE
    WHEN t.type='credit' AND t.status='confirmed' THEN t.amount_cents
    WHEN t.type='debit' AND t.status IN ('confirmed','pending') THEN -t.amount_cents
    ELSE 0
  END
), 0)::int;
-- Expect: 0 rows.
```

Pre-migration row counts (snapshot 2026-05-06) and expected post-state are documented in the spec; total balance per org is preserved.

## Triage
**Hotfix** — investor page surfaces wrong revenue numbers and the underlying ledger semantics confuse downstream consumers. Branched from `origin/main`, targets `main`. Promote with \`release.sh hotfix\` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)