### PR TITLE
refactor(billing): fractional cents ledger with ceil-delta Stripe sync

### DIFF
--- a/drizzle/0013_fractional_cents.sql
+++ b/drizzle/0013_fractional_cents.sql
@@ -1,0 +1,61 @@
+-- Convert integer-cent columns to numeric(16,10) for sub-cent precision.
+-- Idempotent: re-running on a migrated DB is a no-op (column types are checked).
+--
+-- Why:
+--   Upstream services (notably runs-service) need to bill fractional costs without
+--   per-call rounding. We move the rounding boundary from "every batch" to
+--   "human-facing display only", and let Stripe (integer-only) lag the ledger
+--   by ≤1¢ via ceil-boundary delta sync.
+--
+-- Bit-for-bit preservation:
+--   integer N maps to numeric(16,10) value N exactly. PostgreSQL casts
+--   `int → numeric` losslessly.
+
+-- transactions.amount_cents
+DO $$ BEGIN
+  IF (SELECT data_type FROM information_schema.columns
+      WHERE table_name = 'transactions' AND column_name = 'amount_cents') = 'integer'
+  THEN
+    ALTER TABLE "transactions" ALTER COLUMN "amount_cents" TYPE numeric(16,10) USING "amount_cents"::numeric(16,10);
+  END IF;
+END $$;--> statement-breakpoint
+
+-- billing_accounts.credit_balance_cents
+DO $$ BEGIN
+  IF (SELECT data_type FROM information_schema.columns
+      WHERE table_name = 'billing_accounts' AND column_name = 'credit_balance_cents') = 'integer'
+  THEN
+    ALTER TABLE "billing_accounts" ALTER COLUMN "credit_balance_cents" TYPE numeric(16,10) USING "credit_balance_cents"::numeric(16,10);
+    ALTER TABLE "billing_accounts" ALTER COLUMN "credit_balance_cents" SET DEFAULT 200;
+  END IF;
+END $$;--> statement-breakpoint
+
+-- Per-org balance invariant check (post-migration).
+-- If integer cast preserved every value, this should never fire.
+DO $$
+DECLARE bad_count int;
+BEGIN
+  SELECT COUNT(*) INTO bad_count FROM (
+    SELECT
+      ba.org_id,
+      ba.credit_balance_cents AS cached,
+      COALESCE(SUM(
+        CASE
+          WHEN t.type = 'credit' AND t.status = 'confirmed' THEN t.amount_cents
+          WHEN t.type = 'debit' AND t.status IN ('confirmed', 'pending') THEN -t.amount_cents
+          ELSE 0
+        END
+      ), 0) AS computed,
+      COUNT(t.id) AS entry_count
+    FROM billing_accounts ba
+    LEFT JOIN transactions t ON t.org_id = ba.org_id
+    GROUP BY ba.org_id, ba.credit_balance_cents
+  ) AS s
+  WHERE s.entry_count > 0 AND s.cached <> s.computed;
+  -- Note: drift is reconciled at runtime in /authorize, not blocking here.
+  -- We only RAISE if invariant was broken BY this migration, which is impossible
+  -- under int → numeric cast. Counting for telemetry.
+  IF bad_count > 0 THEN
+    RAISE NOTICE 'Pre-existing balance drift detected: % orgs (reconcile() will heal at runtime)', bad_count;
+  END IF;
+END $$;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1778198400000,
       "tag": "0012_transactions_rename",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1778803200000,
+      "tag": "0013_fractional_cents",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -19,13 +19,13 @@
             "type": "string"
           },
           "credited_cents": {
-            "type": "integer"
+            "type": "string"
           },
           "consumed_cents": {
-            "type": "integer"
+            "type": "string"
           },
           "revenue_cents": {
-            "type": "integer"
+            "type": "string"
           }
         },
         "required": [
@@ -45,13 +45,13 @@
             "type": "integer"
           },
           "totalCreditBalanceCents": {
-            "type": "integer"
+            "type": "string"
           },
           "totalCreditedCents": {
-            "type": "integer"
+            "type": "string"
           },
           "totalConsumedCents": {
-            "type": "integer"
+            "type": "string"
           },
           "monthlyGrowth": {
             "type": "array",
@@ -88,7 +88,7 @@
             "format": "uuid"
           },
           "creditBalanceCents": {
-            "type": "integer"
+            "type": "string"
           },
           "reloadAmountCents": {
             "type": "integer",
@@ -138,7 +138,7 @@
         "type": "object",
         "properties": {
           "balance_cents": {
-            "type": "integer"
+            "type": "string"
           },
           "depleted": {
             "type": "boolean"
@@ -247,7 +247,7 @@
             "type": "boolean"
           },
           "balance_cents": {
-            "type": "integer"
+            "type": "string"
           },
           "depleted": {
             "type": "boolean"
@@ -263,9 +263,14 @@
         "type": "object",
         "properties": {
           "amount_cents": {
-            "type": "integer",
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "description": {
             "type": "string",
@@ -322,10 +327,10 @@
             "type": "boolean"
           },
           "balance_cents": {
-            "type": "integer"
+            "type": "string"
           },
           "required_cents": {
-            "type": "integer"
+            "type": "string"
           }
         },
         "required": [
@@ -378,7 +383,7 @@
             "format": "uuid"
           },
           "balance_cents": {
-            "type": "integer"
+            "type": "string"
           },
           "depleted": {
             "type": "boolean"
@@ -394,9 +399,14 @@
         "type": "object",
         "properties": {
           "amount_cents": {
-            "type": "integer",
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           },
           "description": {
             "type": "string",
@@ -422,16 +432,16 @@
             ]
           },
           "original_amount_cents": {
-            "type": "integer"
+            "type": "string"
           },
           "final_amount_cents": {
-            "type": "integer"
+            "type": "string"
           },
           "adjustment_cents": {
-            "type": "integer"
+            "type": "string"
           },
           "balance_cents": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           }
         },
@@ -448,9 +458,14 @@
         "type": "object",
         "properties": {
           "actual_amount_cents": {
-            "type": "integer",
-            "minimum": 0,
-            "exclusiveMinimum": true
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           }
         }
       },
@@ -468,10 +483,10 @@
             ]
           },
           "refunded_cents": {
-            "type": "integer"
+            "type": "string"
           },
           "balance_cents": {
-            "type": "integer",
+            "type": "string",
             "nullable": true
           }
         },
@@ -492,7 +507,7 @@
             "type": "integer"
           },
           "balance_cents": {
-            "type": "integer"
+            "type": "string"
           }
         },
         "required": [

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^7.0.0",
     "cors": "^2.8.5",
+    "decimal.js": "^10.6.0",
     "drizzle-orm": "^0.36.0",
     "express": "^4.21.0",
     "p-queue": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.6
+      decimal.js:
+        specifier: ^10.6.0
+        version: 10.6.0
       drizzle-orm:
         specifier: ^0.36.0
         version: 0.36.4(postgres@3.4.8)
@@ -549,66 +552,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -821,6 +837,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1939,6 +1958,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   delayed-stream@1.0.0: {}
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,10 +4,16 @@ import {
   uuid,
   text,
   integer,
+  numeric,
   timestamp,
   uniqueIndex,
   index,
 } from "drizzle-orm/pg-core";
+
+// Sub-cent fractional cents — see migration 0013.
+// Drizzle returns numeric columns as JS strings to preserve precision.
+const FRACTIONAL_PRECISION = 16;
+const FRACTIONAL_SCALE = 10;
 
 export const billingAccounts = pgTable(
   "billing_accounts",
@@ -15,7 +21,12 @@ export const billingAccounts = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     orgId: uuid("org_id").notNull(),
     stripeCustomerId: text("stripe_customer_id"),
-    creditBalanceCents: integer("credit_balance_cents").notNull().default(200),
+    creditBalanceCents: numeric("credit_balance_cents", {
+      precision: FRACTIONAL_PRECISION,
+      scale: FRACTIONAL_SCALE,
+    })
+      .notNull()
+      .default("200"),
     reloadAmountCents: integer("reload_amount_cents"),
     reloadThresholdCents: integer("reload_threshold_cents").default(200),
     stripePaymentMethodId: text("stripe_payment_method_id"),
@@ -61,7 +72,10 @@ export const transactions = pgTable(
     userId: uuid("user_id").notNull(),
     runId: uuid("run_id"),
     type: text("type").notNull().default("debit"),
-    amountCents: integer("amount_cents").notNull(),
+    amountCents: numeric("amount_cents", {
+      precision: FRACTIONAL_PRECISION,
+      scale: FRACTIONAL_SCALE,
+    }).notNull(),
     status: text("status").notNull().default("pending"),
     source: text("source").notNull().default("charge"),
     stripePaymentIntentId: text("stripe_payment_intent_id"),

--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -3,6 +3,8 @@ import { db } from "../db/index.js";
 import { billingAccounts, transactions } from "../db/schema.js";
 import { createCustomer, createBalanceTransaction } from "./stripe.js";
 
+const WELCOME_CREDIT_CENTS = "200";
+
 /**
  * Find or auto-create a billing account for an org.
  * Uses INSERT ON CONFLICT to prevent duplicate Stripe customers
@@ -26,7 +28,7 @@ export async function findOrCreateAccount(
     .insert(billingAccounts)
     .values({
       orgId,
-      creditBalanceCents: 200,
+      creditBalanceCents: WELCOME_CREDIT_CENTS,
     })
     .onConflictDoNothing()
     .returning();
@@ -57,7 +59,7 @@ export async function findOrCreateAccount(
       orgId,
       userId,
       type: "credit",
-      amountCents: 200,
+      amountCents: WELCOME_CREDIT_CENTS,
       status: "confirmed",
       source: "welcome",
       description: "Trial credit: $2.00",

--- a/src/lib/cents.ts
+++ b/src/lib/cents.ts
@@ -1,0 +1,129 @@
+import { Decimal } from "decimal.js";
+
+// Match DB column scale: numeric(16,10).
+// Decimal.js precision counts total significant digits — set high enough that
+// 16+10 digit operands plus a few digits of headroom never round.
+Decimal.set({ precision: 50, rounding: Decimal.ROUND_HALF_EVEN });
+
+const SCALE = 10;
+const MAX_INT_DIGITS = 16;
+
+/**
+ * Validate + normalize a fractional-cents input.
+ * Accepts string or number, rejects:
+ *   - non-finite (NaN, ±Infinity)
+ *   - negative
+ *   - zero
+ *   - integer part > 16 digits
+ *   - non-numeric strings
+ *
+ * Returns canonical string with fixed scale (10 fractional digits).
+ */
+export function parsePositiveCents(input: unknown): string {
+  if (typeof input !== "string" && typeof input !== "number") {
+    throw new Error("amount_cents must be a number or decimal string");
+  }
+  if (typeof input === "number" && !Number.isFinite(input)) {
+    throw new Error("amount_cents must be a finite number");
+  }
+  let dec: Decimal;
+  try {
+    dec = new Decimal(input);
+  } catch {
+    throw new Error(`amount_cents is not a valid decimal: ${String(input)}`);
+  }
+  if (dec.isNaN() || !dec.isFinite()) {
+    throw new Error("amount_cents must be a finite number");
+  }
+  if (dec.lessThanOrEqualTo(0)) {
+    throw new Error("amount_cents must be positive");
+  }
+  const intDigits = dec.truncated().abs().toFixed(0);
+  if (intDigits.length > MAX_INT_DIGITS) {
+    throw new Error(`amount_cents integer part exceeds ${MAX_INT_DIGITS} digits`);
+  }
+  return dec.toFixed(SCALE);
+}
+
+/**
+ * Validate + normalize a non-negative cents input (allows 0). For optional
+ * fields like reload_threshold_cents that historically allowed integer 0.
+ */
+export function parseNonNegativeCents(input: unknown): string {
+  if (typeof input !== "string" && typeof input !== "number") {
+    throw new Error("value must be a number or decimal string");
+  }
+  if (typeof input === "number" && !Number.isFinite(input)) {
+    throw new Error("value must be a finite number");
+  }
+  let dec: Decimal;
+  try {
+    dec = new Decimal(input);
+  } catch {
+    throw new Error(`value is not a valid decimal: ${String(input)}`);
+  }
+  if (dec.isNaN() || !dec.isFinite()) {
+    throw new Error("value must be a finite number");
+  }
+  if (dec.lessThan(0)) {
+    throw new Error("value must be non-negative");
+  }
+  const intDigits = dec.truncated().abs().toFixed(0);
+  if (intDigits.length > MAX_INT_DIGITS) {
+    throw new Error(`value integer part exceeds ${MAX_INT_DIGITS} digits`);
+  }
+  return dec.toFixed(SCALE);
+}
+
+/** Add two cent strings — returns canonical fixed-scale string. */
+export function addCents(a: string, b: string): string {
+  return new Decimal(a).plus(b).toFixed(SCALE);
+}
+
+/** Subtract `b` from `a`. */
+export function subCents(a: string, b: string): string {
+  return new Decimal(a).minus(b).toFixed(SCALE);
+}
+
+/** Compare: -1, 0, 1. */
+export function cmpCents(a: string, b: string): -1 | 0 | 1 {
+  return new Decimal(a).comparedTo(b) as -1 | 0 | 1;
+}
+
+/** True if value <= 0 (depleted check). */
+export function isDepleted(a: string): boolean {
+  return new Decimal(a).lessThanOrEqualTo(0);
+}
+
+/** True if a >= b. */
+export function gte(a: string, b: string): boolean {
+  return new Decimal(a).greaterThanOrEqualTo(b);
+}
+
+/**
+ * Ceil to integer cents — used for Stripe sync.
+ * Stripe accepts only integer cents, so we ceil so Stripe is always >= ledger floor.
+ * Negative balances ceil toward zero (e.g. -0.5 → 0), positive balances ceil up
+ * (e.g. 1.4 → 2). This matches Decimal.ROUND_CEIL.
+ */
+export function ceilToInt(a: string): number {
+  return new Decimal(a).toDecimalPlaces(0, Decimal.ROUND_CEIL).toNumber();
+}
+
+/**
+ * Compute Stripe ceil-cent delta between two balances.
+ * Returns the integer delta to send to Stripe so its customer balance tracks
+ * `ceil(newBalance)`. Sign convention matches `createBalanceTransaction`:
+ *   - balance dropped (debit) → returns positive int
+ *   - balance rose (credit)   → returns negative int
+ *   - no ceil-boundary crossed → 0 (caller skips the Stripe API call)
+ *
+ * Stripe customer balance semantics: positive amount = customer owes,
+ * negative = customer has credit. Our ledger's `creditBalanceCents` is the
+ * inverse (positive = customer has credit), hence the sign flip.
+ */
+export function stripeCeilDelta(oldBalance: string, newBalance: string): number {
+  const oldCeil = ceilToInt(oldBalance);
+  const newCeil = ceilToInt(newBalance);
+  return oldCeil - newCeil;
+}

--- a/src/lib/costs-client.ts
+++ b/src/lib/costs-client.ts
@@ -47,20 +47,25 @@ export async function resolvePlatformPrice(
   return (await res.json()) as ResolvedPrice;
 }
 
-/** Resolve all items and compute total required cents. */
+/**
+ * Resolve all items and compute total required cents as a fractional-cents
+ * decimal string. Rounding is deferred to the presentation layer; the ledger
+ * works in full precision.
+ */
 export async function resolveRequiredCents(
   items: CostItem[],
   headers: Record<string, string>
-): Promise<number> {
+): Promise<string> {
+  const { Decimal } = await import("decimal.js");
   const prices = await Promise.all(
     items.map((item) => resolvePlatformPrice(item.costName, headers))
   );
 
-  let totalCents = 0;
+  let total = new Decimal(0);
   for (let i = 0; i < items.length; i++) {
-    const unitCost = parseFloat(prices[i].pricePerUnitInUsdCents);
-    totalCents += items[i].quantity * unitCost;
+    const unitCost = new Decimal(prices[i].pricePerUnitInUsdCents);
+    total = total.plus(unitCost.times(items[i].quantity));
   }
 
-  return Math.ceil(totalCents);
+  return total.toFixed(10);
 }

--- a/src/lib/ledger.ts
+++ b/src/lib/ledger.ts
@@ -2,43 +2,58 @@ import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { transactions } from "../db/schema.js";
 import { createBalanceTransaction } from "./stripe.js";
+import { stripeCeilDelta } from "./cents.js";
 
 /**
- * Fire-and-forget a Stripe customer balance transaction, then update the ledger
- * entry with the resulting transaction ID. Errors are logged but never thrown.
+ * Fire-and-forget a Stripe customer balance transaction sized to keep Stripe
+ * within ≤1¢ of `ceil(ledger_balance)`. Returns synchronously; errors are
+ * logged but never thrown. No-ops when the ceil-cent delta is 0 (the ledger
+ * moved sub-cent and Stripe doesn't need a touch).
+ *
+ * Why ceil-delta:
+ *   Stripe's `createBalanceTransaction` only accepts integer cents. We round
+ *   our fractional ledger up to integer cents on the Stripe side, so Stripe
+ *   always shows ≥ ledger floor. Skipping zero-delta ops avoids spamming
+ *   Stripe with no-op calls under fractional batching.
+ *
+ * The ledger row's `stripeBalanceTxnId` is set ONLY when the API call fires,
+ * so audits can tell which rows triggered Stripe state changes.
  */
-export function fireAndForgetBalanceTxn(
-  orgId: string,
-  userId: string,
-  customerId: string,
-  amountCents: number,
-  description: string,
-  ledgerEntryId: string,
-  wfHeaders?: Record<string, string>
-): void {
+export function syncStripeCeilDelta(args: {
+  orgId: string;
+  userId: string;
+  customerId: string;
+  oldBalance: string;
+  newBalance: string;
+  description: string;
+  ledgerEntryId: string;
+  wfHeaders?: Record<string, string>;
+}): void {
+  const delta = stripeCeilDelta(args.oldBalance, args.newBalance);
+  if (delta === 0) return;
   // Note: do NOT pass `ledgerEntryId` as `idempotencyKey` here. Multiple distinct
   // Stripe operations (initial debit, provision adjustment, cancel refund) target the
   // same ledger row id with different params; reusing the key would trigger
   // StripeIdempotencyError. Recovery via reconcile() Check 3 owns idempotency keying.
   createBalanceTransaction(
-    orgId,
-    userId,
-    customerId,
-    amountCents,
-    description,
+    args.orgId,
+    args.userId,
+    args.customerId,
+    delta,
+    args.description,
     undefined,
-    wfHeaders
+    args.wfHeaders
   )
     .then((txn) => {
       db.update(transactions)
         .set({ stripeBalanceTxnId: txn.id, updatedAt: new Date() })
-        .where(eq(transactions.id, ledgerEntryId))
+        .where(eq(transactions.id, args.ledgerEntryId))
         .then(() => {})
         .catch(() => {});
     })
     .catch((err) => {
       console.error(
-        `[billing-service] Stripe balance txn failed (async) for ledger ${ledgerEntryId}:`,
+        `[billing-service] Stripe balance txn failed (async) for ledger ${args.ledgerEntryId}:`,
         err
       );
     });

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -11,6 +11,7 @@ import {
   isStripeAuthError,
 } from "../lib/stripe.js";
 import { findOrCreateAccount } from "../lib/account.js";
+import { isDepleted } from "../lib/cents.js";
 
 const router = Router();
 
@@ -65,7 +66,7 @@ router.get("/v1/accounts/balance", requireOrgHeaders, async (req, res) => {
 
     res.json({
       balance_cents: account.creditBalanceCents,
-      depleted: account.creditBalanceCents <= 0,
+      depleted: isDepleted(account.creditBalanceCents),
     });
   } catch (err) {
     console.error("Error checking balance:", err);

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { eq, and, isNull, gte, lte, desc, sql as rawSql } from "drizzle-orm";
+import { Decimal } from "decimal.js";
 import { db } from "../db/index.js";
 import { billingAccounts, transactions } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
@@ -10,22 +11,25 @@ import {
   listPaymentIntents,
   isStripeAuthError,
 } from "../lib/stripe.js";
-import { fireAndForgetBalanceTxn } from "../lib/ledger.js";
+import { syncStripeCeilDelta } from "../lib/ledger.js";
 import { sendEmail } from "../lib/email-client.js";
 import { resolveRequiredCents } from "../lib/costs-client.js";
 import { findOrCreateAccount } from "../lib/account.js";
 import { traceEvent } from "../lib/trace-event.js";
+import { addCents, subCents, gte as gteCents, isDepleted, cmpCents } from "../lib/cents.js";
 
 const router = Router();
 
 /**
  * Compute the reload charge needed to cover `requiredCents` given `currentBalance`.
  * Returns the smallest multiple of `reloadUnit` such that balance + charge >= required.
+ * Reload units are integer cents (configured by the user in whole-dollar amounts);
+ * required and balance can be fractional.
  */
-function computeReloadCharge(currentBalance: number, requiredCents: number, reloadUnit: number): number {
-  const deficit = requiredCents - currentBalance;
-  if (deficit <= 0) return 0;
-  const multiples = Math.ceil(deficit / reloadUnit);
+function computeReloadCharge(currentBalance: string, requiredCents: string, reloadUnit: number): number {
+  const deficit = new Decimal(requiredCents).minus(currentBalance);
+  if (deficit.lessThanOrEqualTo(0)) return 0;
+  const multiples = deficit.dividedBy(reloadUnit).toDecimalPlaces(0, Decimal.ROUND_CEIL).toNumber();
   return multiples * reloadUnit;
 }
 
@@ -33,7 +37,7 @@ interface AccountRow {
   id: string;
   org_id: string;
   stripe_customer_id: string | null;
-  credit_balance_cents: number;
+  credit_balance_cents: string;
   reload_amount_cents: number | null;
   reload_threshold_cents: number | null;
   stripe_payment_method_id: string | null;
@@ -79,12 +83,12 @@ async function reconcile(
           WHEN type = 'debit' AND status IN ('confirmed', 'pending') THEN -amount_cents
           ELSE 0
         END
-      ), 0)::int AS computed,
+      ), 0)::numeric(16,10)::text AS computed,
       COUNT(*)::int AS entry_count
       FROM transactions WHERE org_id = ${orgId}`
-    )) as unknown as { computed: number; entry_count: number }[];
+    )) as unknown as { computed: string; entry_count: number }[];
     const { computed, entry_count } = ledgerRows[0];
-    if (entry_count > 0 && computed !== account.credit_balance_cents) {
+    if (entry_count > 0 && cmpCents(computed, account.credit_balance_cents) !== 0) {
       console.warn(
         `[billing-service] Cache drift detected for org ${orgId}: cache=${account.credit_balance_cents}, ledger=${computed}. Fixing.`
       );
@@ -110,7 +114,7 @@ async function reconcile(
           const insertedRows = (await tx.execute(
             rawSql`INSERT INTO transactions
               (org_id, user_id, type, amount_cents, status, source, stripe_payment_intent_id, description)
-              VALUES (${orgId}, ${userId}, 'credit', ${pi.amount}, 'confirmed', 'reload', ${pi.id},
+              VALUES (${orgId}, ${userId}, 'credit', ${pi.amount}::numeric, 'confirmed', 'reload', ${pi.id},
                 ${`Recovered reload from Stripe PI ${pi.id}`})
               ON CONFLICT (org_id, stripe_payment_intent_id)
                 WHERE source = 'reload' AND stripe_payment_intent_id IS NOT NULL
@@ -124,7 +128,7 @@ async function reconcile(
             await tx
               .update(billingAccounts)
               .set({
-                creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${pi.amount}`,
+                creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${pi.amount}::numeric`,
                 updatedAt: new Date(),
               })
               .where(eq(billingAccounts.orgId, orgId));
@@ -157,8 +161,15 @@ async function reconcile(
 
       for (const entry of unsyncedEntries) {
         try {
-          const stripeAmount =
-            entry.type === "credit" ? -entry.amountCents : entry.amountCents;
+          // Recovery sync: send the row's amount rounded up to integer cents.
+          // Bound: each recovered fractional row may overshoot Stripe by <1¢.
+          // The forward path's ceil-delta strategy (syncStripeCeilDelta) maintains
+          // ≤1¢ in steady state; this branch only fires when forward sync failed.
+          const ceilAmount = new Decimal(entry.amountCents)
+            .toDecimalPlaces(0, Decimal.ROUND_CEIL)
+            .toNumber();
+          const stripeAmount = entry.type === "credit" ? -ceilAmount : ceilAmount;
+          if (stripeAmount === 0) continue;
           const txn = await createBalanceTransaction(
             orgId,
             userId,
@@ -217,7 +228,8 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
       }
 
       // Always deduct, even if it results in a negative balance
-      const newBalance = account.credit_balance_cents - amount_cents;
+      const oldBalance = account.credit_balance_cents;
+      const newBalance = subCents(oldBalance, amount_cents);
       await tx
         .update(billingAccounts)
         .set({
@@ -244,7 +256,8 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
       return {
         success: true as const,
         balance_cents: newBalance,
-        depleted: newBalance <= 0,
+        depleted: isDepleted(newBalance),
+        _oldBalance: oldBalance,
         _customerId: account.stripe_customer_id,
         _ledgerEntryId: ledgerEntry.id,
       };
@@ -255,17 +268,18 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    // Fire-and-forget Stripe balance transaction
+    // Fire-and-forget Stripe balance sync — only when ceil-cent boundary crossed
     if (result._customerId && result._ledgerEntryId) {
-      fireAndForgetBalanceTxn(
+      syncStripeCeilDelta({
         orgId,
         userId,
-        result._customerId,
-        amount_cents,
+        customerId: result._customerId,
+        oldBalance: result._oldBalance,
+        newBalance: result.balance_cents,
         description,
-        result._ledgerEntryId,
-        wfHeaders
-      );
+        ledgerEntryId: result._ledgerEntryId,
+        wfHeaders,
+      });
     }
 
     // Send depleted email if needed
@@ -282,7 +296,7 @@ router.post("/v1/credits/deduct", requireOrgHeaders, async (req, res) => {
     traceEvent(runId, { service: "billing-service", event: "credits.deduct.done", data: { balance_cents: result.balance_cents, depleted: result.depleted } }, req.headers);
 
     // Strip internal fields from response
-    const { _customerId: _c, _ledgerEntryId: _l, ...response } = result as Record<string, unknown>;
+    const { _customerId: _c, _ledgerEntryId: _l, _oldBalance: _ob, ...response } = result as Record<string, unknown>;
     res.json(response);
   } catch (err) {
     console.error("[billing-service] Error deducting credits:", err);
@@ -314,7 +328,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
     traceEvent(runId, { service: "billing-service", event: "credits.authorize.start", data: { item_count: items.length } }, req.headers);
 
     // Resolve prices from costs-service (outside transaction — read-only, no lock needed)
-    let requiredCents: number;
+    let requiredCents: string;
     try {
       requiredCents = await resolveRequiredCents(items, {
         "x-org-id": orgId,
@@ -350,10 +364,11 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
       }
 
       let currentBalance = account.credit_balance_cents;
+      const balanceBeforeReload = currentBalance;
 
       // If insufficient, try synchronous auto-reload (charge enough multiples to cover)
       let reloadLedgerEntryId: string | null = null;
-      if (currentBalance < requiredCents) {
+      if (cmpCents(currentBalance, requiredCents) < 0) {
         if (
           account.stripe_payment_method_id &&
           account.stripe_customer_id &&
@@ -400,7 +415,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
                   orgId,
                   userId,
                   type: "credit",
-                  amountCents: chargeAmount,
+                  amountCents: String(chargeAmount),
                   status: "confirmed",
                   source: "reload",
                   stripePaymentIntentId: pi.id,
@@ -409,7 +424,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
                 .returning();
               reloadLedgerEntryId = reloadEntry.id;
 
-              currentBalance += chargeAmount;
+              currentBalance = addCents(currentBalance, String(chargeAmount));
               await tx
                 .update(billingAccounts)
                 .set({
@@ -426,7 +441,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
                   orgId,
                   userId,
                   type: "credit",
-                  amountCents: computeReloadCharge(currentBalance, requiredCents, account.reload_amount_cents),
+                  amountCents: String(computeReloadCharge(currentBalance, requiredCents, account.reload_amount_cents)),
                   status: "cancelled",
                   source: "reload",
                   description: `Auto-reload failed: ${reloadErr instanceof Error ? reloadErr.message : "unknown error"}`,
@@ -437,6 +452,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
                 required_cents: requiredCents,
                 _emailEvent: "credits-reload-failed" as const,
                 _reloadLedgerEntryId: null as string | null,
+                _balanceBefore: balanceBeforeReload,
                 _customerId: account.stripe_customer_id,
               };
             }
@@ -444,7 +460,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
         }
       }
 
-      const sufficient = currentBalance >= requiredCents;
+      const sufficient = gteCents(currentBalance, requiredCents);
 
       return {
         sufficient: sufficient as boolean,
@@ -452,6 +468,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
         required_cents: requiredCents,
         _emailEvent: sufficient ? null : ("credits-depleted" as const),
         _reloadLedgerEntryId: reloadLedgerEntryId,
+        _balanceBefore: balanceBeforeReload,
         _customerId: account.stripe_customer_id,
       };
     });
@@ -461,7 +478,8 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    // Fire-and-forget Stripe balance txn for the reload (if one happened)
+    // Fire-and-forget Stripe balance txn for the reload (if one happened) — uses
+    // ceil-delta sized to keep Stripe within ≤1¢ of `ceil(ledger_balance)`.
     if (result._reloadLedgerEntryId && result._customerId) {
       const entry = await db
         .select()
@@ -469,15 +487,16 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
         .where(eq(transactions.id, result._reloadLedgerEntryId))
         .limit(1);
       if (entry[0]) {
-        fireAndForgetBalanceTxn(
+        syncStripeCeilDelta({
           orgId,
           userId,
-          result._customerId,
-          -entry[0].amountCents,
-          entry[0].description ?? "Auto-reload credit",
-          result._reloadLedgerEntryId,
-          wfHeaders
-        );
+          customerId: result._customerId,
+          oldBalance: result._balanceBefore,
+          newBalance: result.balance_cents,
+          description: entry[0].description ?? "Auto-reload credit",
+          ledgerEntryId: result._reloadLedgerEntryId,
+          wfHeaders,
+        });
       }
     }
 
@@ -496,7 +515,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
     traceEvent(runId, { service: "billing-service", event: "credits.authorize.done", data: { sufficient: result.sufficient, balance_cents: result.balance_cents, required_cents: result.required_cents } }, req.headers);
 
     // Strip internal fields
-    const { _emailEvent, _reloadLedgerEntryId, _customerId, ...response } = result as Record<string, unknown>;
+    const { _emailEvent, _reloadLedgerEntryId, _balanceBefore, _customerId, ...response } = result as Record<string, unknown>;
     res.json(response);
   } catch (err) {
     console.error("[billing-service] Error authorizing credits:", err);

--- a/src/routes/promo.ts
+++ b/src/routes/promo.ts
@@ -13,7 +13,7 @@ import {
 } from "../middleware/auth.js";
 import { RedeemPromoRequestSchema } from "../schemas.js";
 import { findOrCreateAccount } from "../lib/account.js";
-import { fireAndForgetBalanceTxn } from "../lib/ledger.js";
+import { syncStripeCeilDelta } from "../lib/ledger.js";
 import { traceEvent } from "../lib/trace-event.js";
 
 const router = Router();
@@ -92,13 +92,20 @@ router.post("/v1/promo/redeem", requireOrgHeaders, async (req, res) => {
 
     // Credit the promo amount inside a transaction
     const result = await db.transaction(async (tx) => {
+      const [accountBefore] = await tx
+        .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId))
+        .limit(1);
+      const oldBalance = accountBefore?.creditBalanceCents ?? "0.0000000000";
+
       const [ledgerEntry] = await tx
         .insert(transactions)
         .values({
           orgId,
           userId,
           type: "credit",
-          amountCents: promo.amountCents,
+          amountCents: String(promo.amountCents),
           status: "confirmed",
           source: "promo",
           promoCodeId: promo.id,
@@ -110,26 +117,27 @@ router.post("/v1/promo/redeem", requireOrgHeaders, async (req, res) => {
       const [updated] = await tx
         .update(billingAccounts)
         .set({
-          creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${promo.amountCents}`,
+          creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${promo.amountCents}::numeric`,
           updatedAt: new Date(),
         })
         .where(eq(billingAccounts.orgId, orgId))
         .returning();
 
-      return { updated, ledgerEntryId: ledgerEntry.id };
+      return { updated, ledgerEntryId: ledgerEntry.id, oldBalance };
     });
 
-    // Fire-and-forget Stripe balance txn for promo credit
+    // Fire-and-forget Stripe balance sync for promo credit
     if (account.stripeCustomerId) {
-      fireAndForgetBalanceTxn(
+      syncStripeCeilDelta({
         orgId,
         userId,
-        account.stripeCustomerId,
-        -promo.amountCents,
-        `Promo credit: ${code} ($${(promo.amountCents / 100).toFixed(2)})`,
-        result.ledgerEntryId,
-        wfHeaders
-      );
+        customerId: account.stripeCustomerId,
+        oldBalance: result.oldBalance,
+        newBalance: result.updated.creditBalanceCents,
+        description: `Promo credit: ${code} ($${(promo.amountCents / 100).toFixed(2)})`,
+        ledgerEntryId: result.ledgerEntryId,
+        wfHeaders,
+      });
     }
 
     traceEvent(runId, { service: "billing-service", event: "promo.redeem.done", data: { code, amount_cents: promo.amountCents, balance_cents: result.updated.creditBalanceCents } }, req.headers);

--- a/src/routes/provisions.ts
+++ b/src/routes/provisions.ts
@@ -5,9 +5,10 @@ import { billingAccounts, transactions } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { ProvisionRequestSchema, ConfirmProvisionRequestSchema } from "../schemas.js";
 import { isStripeAuthError } from "../lib/stripe.js";
-import { fireAndForgetBalanceTxn } from "../lib/ledger.js";
+import { syncStripeCeilDelta } from "../lib/ledger.js";
 import { findOrCreateAccount } from "../lib/account.js";
 import { traceEvent } from "../lib/trace-client.js";
+import { addCents, subCents, isDepleted, cmpCents } from "../lib/cents.js";
 
 const router = Router();
 
@@ -15,7 +16,7 @@ interface AccountRow {
   id: string;
   org_id: string;
   stripe_customer_id: string | null;
-  credit_balance_cents: number;
+  credit_balance_cents: string;
   reload_amount_cents: number | null;
   reload_threshold_cents: number | null;
   stripe_payment_method_id: string | null;
@@ -50,7 +51,8 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
         return { error: "Billing account not found" as const, status: 404 as const };
       }
 
-      const newBalance = account.credit_balance_cents - amount_cents;
+      const oldBalance = account.credit_balance_cents;
+      const newBalance = subCents(oldBalance, amount_cents);
       await tx
         .update(billingAccounts)
         .set({
@@ -80,7 +82,8 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
       return {
         provision_id: provision.id,
         balance_cents: newBalance,
-        depleted: newBalance <= 0,
+        depleted: isDepleted(newBalance),
+        _oldBalance: oldBalance,
         _customerId: account.stripe_customer_id,
         _provisionLedgerEntryId: provision.id,
       };
@@ -92,18 +95,19 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
     }
 
     if (result._customerId && result._provisionLedgerEntryId) {
-      fireAndForgetBalanceTxn(
+      syncStripeCeilDelta({
         orgId,
         userId,
-        result._customerId,
-        amount_cents,
+        customerId: result._customerId,
+        oldBalance: result._oldBalance,
+        newBalance: result.balance_cents,
         description,
-        result._provisionLedgerEntryId,
-        fwdHeaders
-      );
+        ledgerEntryId: result._provisionLedgerEntryId,
+        wfHeaders: fwdHeaders,
+      });
     }
 
-    const { _customerId: _c, _provisionLedgerEntryId: _pl, ...response } = result as Record<string, unknown>;
+    const { _customerId: _c, _provisionLedgerEntryId: _pl, _oldBalance: _ob, ...response } = result as Record<string, unknown>;
 
     traceEvent({
       runId,
@@ -147,7 +151,7 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
       const provRows = await tx.execute<{
         id: string;
         org_id: string;
-        amount_cents: number;
+        amount_cents: string;
         status: string;
         description: string | null;
         campaign_id: string | null;
@@ -161,7 +165,7 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
       const provision = (provRows as unknown as Array<{
         id: string;
         org_id: string;
-        amount_cents: number;
+        amount_cents: string;
         status: string;
         description: string | null;
         campaign_id: string | null;
@@ -178,7 +182,7 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
       if (provision.status === "confirmed") {
         const sameAmount =
           actual_amount_cents === undefined ||
-          actual_amount_cents === provision.amount_cents;
+          cmpCents(actual_amount_cents, provision.amount_cents) === 0;
         if (!sameAmount) {
           return {
             error: `Provision already confirmed at ${provision.amount_cents} cents` as const,
@@ -196,7 +200,7 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
           status: "confirmed" as const,
           original_amount_cents: provision.amount_cents,
           final_amount_cents: provision.amount_cents,
-          adjustment_cents: 0,
+          adjustment_cents: "0.0000000000",
           balance_cents: account?.creditBalanceCents ?? null,
         };
       }
@@ -206,10 +210,10 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
       }
 
       const finalAmount = actual_amount_cents ?? provision.amount_cents;
-      const adjustmentCents = provision.amount_cents - finalAmount;
+      const adjustmentCents = subCents(provision.amount_cents, finalAmount);
 
       // Same amount → flip status only; no balance change, no new row.
-      if (adjustmentCents === 0) {
+      if (cmpCents(adjustmentCents, "0") === 0) {
         await tx
           .update(transactions)
           .set({ status: "confirmed", updatedAt: new Date() })
@@ -229,20 +233,28 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
           status: "confirmed" as const,
           original_amount_cents: provision.amount_cents,
           final_amount_cents: finalAmount,
-          adjustment_cents: 0,
+          adjustment_cents: "0.0000000000",
           balance_cents: account?.creditBalanceCents ?? null,
           _customerId: account?.stripeCustomerId ?? null,
-          _adjustmentCents: 0,
+          _oldBalance: account?.creditBalanceCents ?? null,
+          _adjustmentCents: "0.0000000000",
           _newChargeId: null as string | null,
         };
       }
 
       // Amount differs: cancel original hold (refund $X) and write a fresh confirmed charge ($Y).
       // Net balance change = (X - Y) = adjustmentCents.
+      const [accountBefore] = await tx
+        .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId))
+        .limit(1);
+      const oldBalance = accountBefore?.creditBalanceCents ?? null;
+
       await tx
         .update(billingAccounts)
         .set({
-          creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${adjustmentCents}`,
+          creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${adjustmentCents}::numeric`,
           updatedAt: new Date(),
         })
         .where(eq(billingAccounts.orgId, orgId));
@@ -287,6 +299,7 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
         adjustment_cents: adjustmentCents,
         balance_cents: account?.creditBalanceCents ?? null,
         _customerId: account?.stripeCustomerId ?? null,
+        _oldBalance: oldBalance,
         _adjustmentCents: adjustmentCents,
         _newChargeId: newCharge.id,
       };
@@ -297,44 +310,36 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
       return;
     }
 
-    // Stripe sync: when amount changes, post a refund of the original hold AND a charge for the new amount.
-    // Each fires against its own ledger row id (refund → original provision row, charge → newly inserted row).
+    // Stripe sync: post ONE ceil-delta sized to the net balance change.
+    // The new charge row owns the stripeBalanceTxnId; the cancelled provision row stays null.
     const customerId = "_customerId" in result ? (result._customerId as string | null) : null;
-    const adjustment = "_adjustmentCents" in result ? (result._adjustmentCents as number) : 0;
+    const oldBal = "_oldBalance" in result ? (result._oldBalance as string | null) : null;
     const newChargeId = "_newChargeId" in result ? (result._newChargeId as string | null) : null;
-    if (customerId && adjustment !== 0 && newChargeId) {
-      // Refund the original $X to the customer's Stripe balance (negative amount for credit).
-      fireAndForgetBalanceTxn(
+    if (customerId && oldBal !== null && newChargeId) {
+      syncStripeCeilDelta({
         orgId,
         userId,
         customerId,
-        -result.original_amount_cents,
-        `Provision ${provisionId} cancelled (replaced by confirm at ${result.final_amount_cents} cents)`,
-        provisionId,
-        wfHeaders
-      );
-      // Charge the new $Y on Stripe balance (positive amount for debit).
-      fireAndForgetBalanceTxn(
-        orgId,
-        userId,
-        customerId,
-        result.final_amount_cents,
-        result.original_amount_cents !== result.final_amount_cents
-          ? `Confirmed charge (replacing provision ${provisionId})`
-          : `Provision ${provisionId} confirmed`,
-        newChargeId,
-        wfHeaders
-      );
+        oldBalance: oldBal,
+        newBalance: result.balance_cents as string,
+        description:
+          cmpCents(result.original_amount_cents as string, result.final_amount_cents as string) !== 0
+            ? `Confirmed charge (replacing provision ${provisionId})`
+            : `Provision ${provisionId} confirmed`,
+        ledgerEntryId: newChargeId,
+        wfHeaders,
+      });
     }
 
-    const { _customerId: _c, _adjustmentCents: _a, _newChargeId: _n, ...response } = result as Record<string, unknown>;
+    const adjustment = "_adjustmentCents" in result ? (result._adjustmentCents as string) : "0";
+    const { _customerId: _c, _adjustmentCents: _a, _newChargeId: _n, _oldBalance: _ob, ...response } = result as Record<string, unknown>;
 
     traceEvent({
       runId,
       orgId,
       userId,
       event: "billing.provision.confirmed",
-      detail: { provision_id: provisionId, adjustment_cents: adjustment },
+      detail: { provision_id: provisionId, adjustment_cents: adjustment as unknown as string },
       workflowHeaders: wfHeaders,
     });
 
@@ -357,7 +362,7 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
       const provRows = await tx.execute<{
         id: string;
         org_id: string;
-        amount_cents: number;
+        amount_cents: string;
         status: string;
       }>(
         rawSql`SELECT * FROM transactions WHERE id = ${provisionId} AND org_id = ${orgId} FOR UPDATE`
@@ -366,7 +371,7 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
       const provision = (provRows as unknown as Array<{
         id: string;
         org_id: string;
-        amount_cents: number;
+        amount_cents: string;
         status: string;
       }>)[0];
 
@@ -384,7 +389,7 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
         return {
           provision_id: provisionId,
           status: "cancelled" as const,
-          refunded_cents: 0,
+          refunded_cents: "0.0000000000",
           balance_cents: account?.creditBalanceCents ?? null,
         };
       }
@@ -393,10 +398,17 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
         return { error: `Provision already ${provision.status}` as const, status: 409 as const };
       }
 
+      const [accountBefore] = await tx
+        .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId))
+        .limit(1);
+      const oldBalance = accountBefore?.creditBalanceCents ?? null;
+
       await tx
         .update(billingAccounts)
         .set({
-          creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${provision.amount_cents}`,
+          creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${provision.amount_cents}::numeric`,
           updatedAt: new Date(),
         })
         .where(eq(billingAccounts.orgId, orgId));
@@ -425,6 +437,7 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
         balance_cents: account?.creditBalanceCents ?? null,
         _customerId: account?.stripeCustomerId ?? null,
         _refundedCents: provision.amount_cents,
+        _oldBalance: oldBalance,
       };
     });
 
@@ -434,20 +447,22 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
     }
 
     const customerId = "_customerId" in result ? result._customerId as string | null : null;
-    const refundedCents = "_refundedCents" in result ? result._refundedCents as number : 0;
-    if (customerId && refundedCents > 0) {
-      fireAndForgetBalanceTxn(
+    const refundedCents = "_refundedCents" in result ? result._refundedCents as string : "0";
+    const oldBal = "_oldBalance" in result ? result._oldBalance as string | null : null;
+    if (customerId && oldBal !== null && cmpCents(refundedCents, "0") > 0) {
+      syncStripeCeilDelta({
         orgId,
         userId,
         customerId,
-        -refundedCents,
-        `Provision ${provisionId} cancel refund`,
-        provisionId,
-        wfHeaders
-      );
+        oldBalance: oldBal,
+        newBalance: result.balance_cents as string,
+        description: `Provision ${provisionId} cancel refund`,
+        ledgerEntryId: provisionId,
+        wfHeaders,
+      });
     }
 
-    const { _customerId: _c, _refundedCents: _r, ...response } = result as Record<string, unknown>;
+    const { _customerId: _c, _refundedCents: _r, _oldBalance: _ob, ...response } = result as Record<string, unknown>;
 
     traceEvent({
       runId: req.headers["x-run-id"] as string,

--- a/src/routes/public-stats.ts
+++ b/src/routes/public-stats.ts
@@ -5,11 +5,15 @@ import { billingAccounts, transactions } from "../db/schema.js";
 
 const router = Router();
 
+// Public-stats sums are returned as full-precision decimal strings (numeric(16,10)::text).
+// Investor/dashboard consumers wanting a display-rounded integer should
+// `Math.ceil(parseFloat(...))` at the presentation layer.
+
 interface GrowthRow {
   period: string;
-  credited_cents: number;
-  consumed_cents: number;
-  revenue_cents: number;
+  credited_cents: string;
+  consumed_cents: string;
+  revenue_cents: string;
 }
 
 async function queryGrowth(truncTo: "month" | "week"): Promise<GrowthRow[]> {
@@ -18,14 +22,14 @@ async function queryGrowth(truncTo: "month" | "week"): Promise<GrowthRow[]> {
       to_char(date_trunc(${truncTo}, ${transactions.createdAt}), 'YYYY-MM-DD') AS period,
       COALESCE(SUM(${transactions.amountCents}) FILTER (
         WHERE ${transactions.type} = 'credit' AND ${transactions.status} = 'confirmed'
-      ), 0)::int AS credited_cents,
+      ), 0)::numeric(16,10)::text AS credited_cents,
       COALESCE(SUM(${transactions.amountCents}) FILTER (
         WHERE ${transactions.type} = 'debit' AND ${transactions.status} IN ('confirmed', 'pending')
-      ), 0)::int AS consumed_cents,
+      ), 0)::numeric(16,10)::text AS consumed_cents,
       COALESCE(SUM(${transactions.amountCents}) FILTER (
         WHERE ${transactions.type} = 'credit' AND ${transactions.status} = 'confirmed'
           AND ${transactions.source} = 'reload'
-      ), 0)::int AS revenue_cents
+      ), 0)::numeric(16,10)::text AS revenue_cents
     FROM ${transactions}
     GROUP BY 1
     ORDER BY 1`
@@ -39,13 +43,13 @@ router.get("/public/stats/billing", async (_req, res) => {
       .select({
         totalAccounts: rawSql<number>`COUNT(*)::int`,
         accountsWithPaymentMethod: rawSql<number>`COUNT(*) FILTER (WHERE ${billingAccounts.stripePaymentMethodId} IS NOT NULL)::int`,
-        totalCreditBalanceCents: rawSql<number>`COALESCE(SUM(${billingAccounts.creditBalanceCents}), 0)::int`,
+        totalCreditBalanceCents: rawSql<string>`COALESCE(SUM(${billingAccounts.creditBalanceCents}), 0)::numeric(16,10)::text`,
       })
       .from(billingAccounts);
 
     const [creditStats] = await db
       .select({
-        totalCreditedCents: rawSql<number>`COALESCE(SUM(${transactions.amountCents}), 0)::int`,
+        totalCreditedCents: rawSql<string>`COALESCE(SUM(${transactions.amountCents}), 0)::numeric(16,10)::text`,
       })
       .from(transactions)
       .where(
@@ -54,7 +58,7 @@ router.get("/public/stats/billing", async (_req, res) => {
 
     const [debitStats] = await db
       .select({
-        totalConsumedCents: rawSql<number>`COALESCE(SUM(${transactions.amountCents}), 0)::int`,
+        totalConsumedCents: rawSql<string>`COALESCE(SUM(${transactions.amountCents}), 0)::numeric(16,10)::text`,
       })
       .from(transactions)
       .where(

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -6,7 +6,8 @@ import {
   constructWebhookEvent,
   retrievePaymentIntent,
 } from "../lib/stripe.js";
-import { fireAndForgetBalanceTxn } from "../lib/ledger.js";
+import { syncStripeCeilDelta } from "../lib/ledger.js";
+import { addCents } from "../lib/cents.js";
 import type Stripe from "stripe";
 
 const router = Router();
@@ -100,7 +101,8 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
 
   // Credit the balance with the reload amount and write to ledger
   if (reloadAmountCents) {
-    const newBalance = account.creditBalanceCents + reloadAmountCents;
+    const oldBalance = account.creditBalanceCents;
+    const newBalance = addCents(oldBalance, String(reloadAmountCents));
 
     // Insert reload ledger entry
     const [ledgerEntry] = await db
@@ -109,7 +111,7 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
         orgId: account.orgId,
         userId: "00000000-0000-0000-0000-000000000000",
         type: "credit",
-        amountCents: reloadAmountCents,
+        amountCents: String(reloadAmountCents),
         status: "confirmed",
         source: "reload",
         stripePaymentIntentId: piId ?? null,
@@ -128,16 +130,18 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
       })
       .where(eq(billingAccounts.stripeCustomerId, customerId));
 
-    // Fire-and-forget Stripe balance txn
+    // Fire-and-forget Stripe balance sync (ceil-delta — for whole-cent reload this
+    // always fires with delta = -reloadAmountCents, but the helper handles both cases).
     if (account.stripeCustomerId) {
-      fireAndForgetBalanceTxn(
-        account.orgId,
-        "system",
-        account.stripeCustomerId,
-        -reloadAmountCents,
-        "Initial reload credit",
-        ledgerEntry.id
-      );
+      syncStripeCeilDelta({
+        orgId: account.orgId,
+        userId: "system",
+        customerId: account.stripeCustomerId,
+        oldBalance,
+        newBalance,
+        description: "Initial reload credit",
+        ledgerEntryId: ledgerEntry.id,
+      });
     }
   } else {
     // No reload amount — just update payment method

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3,6 +3,7 @@ import {
   OpenAPIRegistry,
   extendZodWithOpenApi,
 } from "@asteasolutions/zod-to-openapi";
+import { parsePositiveCents } from "./lib/cents.js";
 
 extendZodWithOpenApi(z);
 export const registry = new OpenAPIRegistry();
@@ -13,13 +14,38 @@ export const ErrorResponseSchema = z
   .object({ error: z.string() })
   .openapi("ErrorResponse");
 
+/**
+ * Inbound fractional-cents amount. Accepts decimal string or finite number.
+ * Rejects negative, zero, NaN, non-numeric, or integer part > 16 digits.
+ * Output is the canonical fixed-scale string (10 fractional digits).
+ */
+const PositiveCentsSchema = z
+  .union([z.string(), z.number()])
+  .transform((v, ctx) => {
+    try {
+      return parsePositiveCents(v);
+    } catch (err) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: err instanceof Error ? err.message : "invalid amount_cents",
+      });
+      return z.NEVER;
+    }
+  });
+
+/**
+ * Outbound balance/amount string with full numeric(16,10) precision.
+ * Drizzle returns numeric columns as strings — we pass them through unchanged.
+ */
+const CentsStringSchema = z.string();
+
 // --- Account ---
 
 export const BillingAccountSchema = z
   .object({
     id: z.string().uuid(),
     orgId: z.string().uuid(),
-    creditBalanceCents: z.number().int(),
+    creditBalanceCents: CentsStringSchema,
     reloadAmountCents: z.number().int().nullable(),
     reloadThresholdCents: z.number().int().nullable(),
     hasPaymentMethod: z.boolean(),
@@ -33,7 +59,7 @@ export const BillingAccountSchema = z
 
 export const DeductRequestSchema = z
   .object({
-    amount_cents: z.number().int().positive(),
+    amount_cents: PositiveCentsSchema,
     description: z.string().min(1),
   })
   .openapi("DeductRequest");
@@ -41,7 +67,7 @@ export const DeductRequestSchema = z
 export const DeductResponseSchema = z
   .object({
     success: z.boolean(),
-    balance_cents: z.number().int(),
+    balance_cents: CentsStringSchema,
     depleted: z.boolean(),
   })
   .openapi("DeductResponse");
@@ -50,7 +76,7 @@ export const DeductResponseSchema = z
 
 export const ProvisionRequestSchema = z
   .object({
-    amount_cents: z.number().int().positive(),
+    amount_cents: PositiveCentsSchema,
     description: z.string().min(1),
   })
   .openapi("ProvisionRequest");
@@ -58,14 +84,14 @@ export const ProvisionRequestSchema = z
 export const ProvisionResponseSchema = z
   .object({
     provision_id: z.string().uuid(),
-    balance_cents: z.number().int(),
+    balance_cents: CentsStringSchema,
     depleted: z.boolean(),
   })
   .openapi("ProvisionResponse");
 
 export const ConfirmProvisionRequestSchema = z
   .object({
-    actual_amount_cents: z.number().int().positive().optional(),
+    actual_amount_cents: PositiveCentsSchema.optional(),
   })
   .openapi("ConfirmProvisionRequest");
 
@@ -73,10 +99,10 @@ export const ConfirmProvisionResponseSchema = z
   .object({
     provision_id: z.string().uuid(),
     status: z.literal("confirmed"),
-    original_amount_cents: z.number().int(),
-    final_amount_cents: z.number().int(),
-    adjustment_cents: z.number().int(),
-    balance_cents: z.number().int().nullable(),
+    original_amount_cents: CentsStringSchema,
+    final_amount_cents: CentsStringSchema,
+    adjustment_cents: CentsStringSchema,
+    balance_cents: CentsStringSchema.nullable(),
   })
   .openapi("ConfirmProvisionResponse");
 
@@ -84,8 +110,8 @@ export const CancelProvisionResponseSchema = z
   .object({
     provision_id: z.string().uuid(),
     status: z.literal("cancelled"),
-    refunded_cents: z.number().int(),
-    balance_cents: z.number().int().nullable(),
+    refunded_cents: CentsStringSchema,
+    balance_cents: CentsStringSchema.nullable(),
   })
   .openapi("CancelProvisionResponse");
 
@@ -108,8 +134,8 @@ export const AuthorizeRequestSchema = z
 export const AuthorizeResponseSchema = z
   .object({
     sufficient: z.boolean(),
-    balance_cents: z.number().int(),
-    required_cents: z.number().int(),
+    balance_cents: CentsStringSchema,
+    required_cents: CentsStringSchema,
   })
   .openapi("AuthorizeResponse");
 
@@ -157,7 +183,7 @@ export const PortalSessionResponseSchema = z
 
 export const BalanceResponseSchema = z
   .object({
-    balance_cents: z.number().int(),
+    balance_cents: CentsStringSchema,
     depleted: z.boolean(),
   })
   .openapi("BalanceResponse");
@@ -193,7 +219,7 @@ export const RedeemPromoResponseSchema = z
   .object({
     redeemed: z.boolean(),
     amount_cents: z.number().int(),
-    balance_cents: z.number().int(),
+    balance_cents: CentsStringSchema,
   })
   .openapi("RedeemPromoResponse");
 
@@ -223,12 +249,15 @@ export const TransferBrandResponseSchema = z
 
 // --- Public Stats ---
 
+// Public-stats values are full-precision decimal strings to preserve sub-cent
+// fidelity in JSON. Consumers wanting display-rounded integers should
+// `Math.ceil(parseFloat(...))` at the presentation layer.
 export const BillingGrowthRowSchema = z
   .object({
     period: z.string(),
-    credited_cents: z.number().int(),
-    consumed_cents: z.number().int(),
-    revenue_cents: z.number().int(),
+    credited_cents: CentsStringSchema,
+    consumed_cents: CentsStringSchema,
+    revenue_cents: CentsStringSchema,
   })
   .openapi("BillingGrowthRow");
 
@@ -236,9 +265,9 @@ export const PublicBillingStatsSchema = z
   .object({
     totalAccounts: z.number().int(),
     accountsWithPaymentMethod: z.number().int(),
-    totalCreditBalanceCents: z.number().int(),
-    totalCreditedCents: z.number().int(),
-    totalConsumedCents: z.number().int(),
+    totalCreditBalanceCents: CentsStringSchema,
+    totalCreditedCents: CentsStringSchema,
+    totalConsumedCents: CentsStringSchema,
     monthlyGrowth: z.array(BillingGrowthRowSchema),
     weeklyGrowth: z.array(BillingGrowthRowSchema),
   })

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -29,7 +29,7 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.orgId).toBe(orgId);
-      expect(res.body.creditBalanceCents).toBe(200);
+      expect(res.body.creditBalanceCents).toBe("200.0000000000");
       expect(res.body.hasPaymentMethod).toBe(false);
       expect(res.body.hasAutoReload).toBe(false);
       expect(res.body).not.toHaveProperty("billingMode");
@@ -85,7 +85,7 @@ describe("Accounts endpoints", () => {
         .set(getAuthHeaders(orgId));
 
       expect(res.status).toBe(200);
-      expect(res.body.creditBalanceCents).toBe(150);
+      expect(res.body.creditBalanceCents).toBe("150.0000000000");
       expect(stripeMocks.createCustomer).not.toHaveBeenCalled();
     });
 
@@ -155,7 +155,7 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
-        balance_cents: 150,
+        balance_cents: "150.0000000000",
         depleted: false,
       });
     });

--- a/tests/integration/credits.test.ts
+++ b/tests/integration/credits.test.ts
@@ -41,7 +41,7 @@ describe("Credits deduction endpoint", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       success: true,
-      balance_cents: 195,
+      balance_cents: "195.0000000000",
       depleted: false,
     });
 
@@ -57,7 +57,7 @@ describe("Credits deduction endpoint", () => {
       );
     expect(entries).toHaveLength(1);
     expect(entries[0].type).toBe("debit");
-    expect(entries[0].amountCents).toBe(5);
+    expect(entries[0].amountCents).toBe("5.0000000000");
     expect(entries[0].status).toBe("confirmed");
   });
 
@@ -79,7 +79,7 @@ describe("Credits deduction endpoint", () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.depleted).toBe(true);
-    expect(res.body.balance_cents).toBe(-2);
+    expect(res.body.balance_cents).toBe("-2.0000000000");
   });
 
   it("does NOT auto-reload (reload removed from deduct)", async () => {
@@ -103,7 +103,7 @@ describe("Credits deduction endpoint", () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     // No reload — just deducts into negative
-    expect(res.body.balance_cents).toBe(-2);
+    expect(res.body.balance_cents).toBe("-2.0000000000");
     expect(res.body.depleted).toBe(true);
     expect(stripeMocks.chargePaymentMethod).not.toHaveBeenCalled();
   });
@@ -120,7 +120,7 @@ describe("Credits deduction endpoint", () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     // Auto-created with 200 cents ($2), then deducted 5
-    expect(res.body.balance_cents).toBe(195);
+    expect(res.body.balance_cents).toBe("195.0000000000");
 
     // Welcome ledger entry should exist
     const welcomeEntries = await db
@@ -133,7 +133,7 @@ describe("Credits deduction endpoint", () => {
         )
       );
     expect(welcomeEntries).toHaveLength(1);
-    expect(welcomeEntries[0].amountCents).toBe(200);
+    expect(welcomeEntries[0].amountCents).toBe("200.0000000000");
   });
 
   it("validates request body", async () => {
@@ -190,13 +190,13 @@ describe("Credits deduction endpoint", () => {
     };
 
     const res1 = await request(app).post("/v1/credits/deduct").set(headers).send(body);
-    expect(res1.body.balance_cents).toBe(90);
+    expect(res1.body.balance_cents).toBe("90.0000000000");
 
     const res2 = await request(app).post("/v1/credits/deduct").set(headers).send(body);
-    expect(res2.body.balance_cents).toBe(80);
+    expect(res2.body.balance_cents).toBe("80.0000000000");
 
     const res3 = await request(app).post("/v1/credits/deduct").set(headers).send(body);
-    expect(res3.body.balance_cents).toBe(70);
+    expect(res3.body.balance_cents).toBe("70.0000000000");
   });
 });
 
@@ -221,7 +221,7 @@ describe("Credits authorize endpoint", () => {
 
     // Mock costs-client to return deterministic prices
     const costsClient = await import("../../src/lib/costs-client.js");
-    vi.spyOn(costsClient, "resolveRequiredCents").mockResolvedValue(100);
+    vi.spyOn(costsClient, "resolveRequiredCents").mockResolvedValue("100.0000000000");
   });
 
   afterAll(async () => {
@@ -243,8 +243,8 @@ describe("Credits authorize endpoint", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       sufficient: true,
-      balance_cents: 500,
-      required_cents: 100,
+      balance_cents: "500.0000000000",
+      required_cents: "100.0000000000",
     });
   });
 
@@ -263,8 +263,8 @@ describe("Credits authorize endpoint", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       sufficient: false,
-      balance_cents: 50,
-      required_cents: 100,
+      balance_cents: "50.0000000000",
+      required_cents: "100.0000000000",
     });
   });
 
@@ -286,8 +286,8 @@ describe("Credits authorize endpoint", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       sufficient: true,
-      balance_cents: 2050,
-      required_cents: 100,
+      balance_cents: "2050.0000000000",
+      required_cents: "100.0000000000",
     });
     expect(stripeMocks.chargePaymentMethod).toHaveBeenCalledWith(
       orgId,
@@ -310,14 +310,14 @@ describe("Credits authorize endpoint", () => {
         )
       );
     expect(reloadEntries).toHaveLength(1);
-    expect(reloadEntries[0].amountCents).toBe(2000);
+    expect(reloadEntries[0].amountCents).toBe("2000.0000000000");
     expect(reloadEntries[0].stripePaymentIntentId).toBe("pi_mock");
   });
 
   it("charges multiple reloads when required amount exceeds single reload", async () => {
     // Override costs-client to return a large required amount
     const costsClient = await import("../../src/lib/costs-client.js");
-    vi.spyOn(costsClient, "resolveRequiredCents").mockResolvedValue(3700);
+    vi.spyOn(costsClient, "resolveRequiredCents").mockResolvedValue("3700.0000000000");
 
     await insertTestAccount({
       orgId,
@@ -337,8 +337,8 @@ describe("Credits authorize endpoint", () => {
     // Need 3700, have 200 → deficit 3500 → ceil(3500/1000) = 4 → charge 4000
     expect(res.body).toEqual({
       sufficient: true,
-      balance_cents: 4200, // 200 + 4000
-      required_cents: 3700,
+      balance_cents: "4200.0000000000", // 200 + 4000
+      required_cents: "3700.0000000000",
     });
     expect(stripeMocks.chargePaymentMethod).toHaveBeenCalledWith(
       orgId,
@@ -373,8 +373,8 @@ describe("Credits authorize endpoint", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       sufficient: false,
-      balance_cents: 50,
-      required_cents: 100,
+      balance_cents: "50.0000000000",
+      required_cents: "100.0000000000",
     });
 
     // Verify cancelled reload entry was written
@@ -464,7 +464,7 @@ describe("Credits authorize endpoint", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(true);
-    expect(res.body.balance_cents).toBe(2050);
+    expect(res.body.balance_cents).toBe("2050.0000000000");
     expect(stripeMocks.chargePaymentMethod).toHaveBeenCalled();
   });
 
@@ -523,7 +523,7 @@ describe("Credits authorize endpoint", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(true);
-    expect(res.body.balance_cents).toBe(2060); // 60 + 2000
+    expect(res.body.balance_cents).toBe("2060.0000000000"); // 60 + 2000
     expect(stripeMocks.chargePaymentMethod).toHaveBeenCalled();
   });
 
@@ -536,7 +536,7 @@ describe("Credits authorize endpoint", () => {
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(true);
     // Auto-created with 200 cents ($2), costs-service mock returns 100
-    expect(res.body.balance_cents).toBe(200);
+    expect(res.body.balance_cents).toBe("200.0000000000");
   });
 
   it("validates request body — rejects empty items", async () => {
@@ -609,7 +609,7 @@ describe("Credits authorize endpoint", () => {
 
     expect(res.status).toBe(200);
     // After reconcile, balance should be 300 (from ledger), not 999
-    expect(res.body.balance_cents).toBe(300);
+    expect(res.body.balance_cents).toBe("300.0000000000");
     expect(res.body.sufficient).toBe(true);
   });
 });
@@ -631,7 +631,7 @@ describe("Credits authorize — reconcile race conditions", () => {
     await cleanTestData();
 
     const costsClient = await import("../../src/lib/costs-client.js");
-    vi.spyOn(costsClient, "resolveRequiredCents").mockResolvedValue(100);
+    vi.spyOn(costsClient, "resolveRequiredCents").mockResolvedValue("100.0000000000");
   });
 
   afterAll(async () => {
@@ -716,7 +716,7 @@ describe("Credits authorize — reconcile race conditions", () => {
       );
     expect(reloadEntries).toHaveLength(1);
     expect(reloadEntries[0].stripePaymentIntentId).toBe("pi_recover_xyz");
-    expect(reloadEntries[0].amountCents).toBe(2000);
+    expect(reloadEntries[0].amountCents).toBe("2000.0000000000");
   });
 
   it("rejects duplicate (org_id, stripe_payment_intent_id) reload rows at the DB level", async () => {

--- a/tests/integration/fractional-cents.test.ts
+++ b/tests/integration/fractional-cents.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { eq, and } from "drizzle-orm";
+import { db } from "../../src/db/index.js";
+import { transactions, billingAccounts } from "../../src/db/schema.js";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
+import { setupStripeMocks } from "../helpers/mock-stripe.js";
+
+// Verifies the fractional-cents pivot: numeric(16,10) ledger + ceil-delta Stripe sync.
+// Spec: see Definition of Done items #1-5 + AC-A through AC-F.
+
+describe("Fractional cents — deduct accepts decimal input", () => {
+  const app = createTestApp();
+  const orgId = "00000000-0000-0000-0000-00000000fc01";
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    setupStripeMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+  });
+
+  it("accepts decimal string '0.42' (AC-B1)", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 200 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: "0.42", description: "fractional-string" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.balance_cents).toBe("199.5800000000");
+
+    const [entry] = await db
+      .select()
+      .from(transactions)
+      .where(and(eq(transactions.orgId, orgId), eq(transactions.source, "charge")));
+    expect(entry.amountCents).toBe("0.4200000000");
+  });
+
+  it("accepts decimal number 0.42 (AC-B1)", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 200 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: 0.42, description: "fractional-number" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.balance_cents).toBe("199.5800000000");
+  });
+
+  it("integer input reads back as numeric.0000000000 (AC-B3)", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 200 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: 100, description: "int-in" });
+
+    expect(res.status).toBe(200);
+    const [entry] = await db
+      .select()
+      .from(transactions)
+      .where(and(eq(transactions.orgId, orgId), eq(transactions.source, "charge")));
+    expect(entry.amountCents).toBe("100.0000000000");
+  });
+
+  it("rejects negative amount (AC-B1)", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 200 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: -1, description: "neg" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects NaN / non-numeric string (AC-B1)", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 200 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: "abc", description: "bad" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects zero (AC-B1)", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 200 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: 0, description: "zero" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects integer part > 16 digits (AC-B1)", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 200 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: "99999999999999999", description: "huge" });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("Fractional cents — provision + confirm with fractional", () => {
+  const app = createTestApp();
+  const orgId = "00000000-0000-0000-0000-00000000fc02";
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    setupStripeMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+  });
+
+  it("provisions fractional 0.123 then confirms with fractional 0.456 — balance preserves precision", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 200 });
+
+    const provRes = await request(app)
+      .post("/v1/credits/provision")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: "0.123", description: "frac-prov" });
+
+    expect(provRes.status).toBe(200);
+    expect(provRes.body.balance_cents).toBe("199.8770000000");
+    const provisionId = provRes.body.provision_id;
+
+    const confRes = await request(app)
+      .post(`/v1/credits/provision/${provisionId}/confirm`)
+      .set(getAuthHeaders(orgId))
+      .send({ actual_amount_cents: "0.456" });
+
+    expect(confRes.status).toBe(200);
+    // Net: 200 - 0.456 = 199.544
+    expect(confRes.body.balance_cents).toBe("199.5440000000");
+    expect(confRes.body.original_amount_cents).toBe("0.1230000000");
+    expect(confRes.body.final_amount_cents).toBe("0.4560000000");
+    expect(confRes.body.adjustment_cents).toBe("-0.3330000000");
+  });
+});
+
+describe("Fractional cents — stress: precision retention", () => {
+  const app = createTestApp();
+  const orgId = "00000000-0000-0000-0000-00000000fc03";
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    setupStripeMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+  });
+
+  it("AC-F1: 100 deducts of 0.0001 from 5.7531 → final exactly 5.7431", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 5.7531 });
+
+    let last;
+    for (let i = 0; i < 100; i++) {
+      last = await request(app)
+        .post("/v1/credits/deduct")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: "0.0001", description: `tick-${i}` });
+      expect(last.status).toBe(200);
+    }
+    expect(last!.body.balance_cents).toBe("5.7431000000");
+  });
+
+  it("AC-F3: mixed 10×0.0001 + 10×0.4 from 5.7531 → final exactly 1.7521", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 5.7531 });
+
+    let last;
+    for (let i = 0; i < 10; i++) {
+      last = await request(app)
+        .post("/v1/credits/deduct")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: "0.0001", description: `mini-${i}` });
+    }
+    for (let i = 0; i < 10; i++) {
+      last = await request(app)
+        .post("/v1/credits/deduct")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: "0.4", description: `big-${i}` });
+    }
+    // 5.7531 - 10*0.0001 - 10*0.4 = 5.7531 - 0.001 - 4 = 1.7521
+    expect(last!.body.balance_cents).toBe("1.7521000000");
+  });
+});
+
+describe("Fractional cents — Stripe ceil-boundary sync", () => {
+  const app = createTestApp();
+  const orgId = "00000000-0000-0000-0000-00000000fc04";
+  let stripeMocks: ReturnType<typeof setupStripeMocks>;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    stripeMocks = setupStripeMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+  });
+
+  it("AC-C1: deduct that crosses ceil-cent boundary fires Stripe call (delta=1)", async () => {
+    // bal 1.5 → deduct 0.6 → bal 0.9. ceil(1.5)=2, ceil(0.9)=1. Delta=+1.
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 1.5 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: "0.6", description: "cross" });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(stripeMocks.createBalanceTransaction).toHaveBeenCalledTimes(1);
+    expect(stripeMocks.createBalanceTransaction).toHaveBeenCalledWith(
+      orgId,
+      expect.any(String),
+      "cus_a",
+      1, // ceil delta
+      "cross",
+      undefined,
+      {}
+    );
+  });
+
+  it("AC-C2: deduct that does NOT cross ceil-cent boundary skips Stripe call", async () => {
+    // bal 1.5 → deduct 0.4 → bal 1.1. ceil(1.5)=2, ceil(1.1)=2. Delta=0 → skip.
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 1.5 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: "0.4", description: "no-cross" });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(stripeMocks.createBalanceTransaction).not.toHaveBeenCalled();
+  });
+
+  it("AC-C4: stripe_balance_txn_id stays null when no Stripe call fired", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 1.5 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: "0.4", description: "no-stripe" });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const [entry] = await db
+      .select()
+      .from(transactions)
+      .where(and(eq(transactions.orgId, orgId), eq(transactions.source, "charge")));
+    expect(entry.stripeBalanceTxnId).toBeNull();
+  });
+
+  it("AC-C4: stripe_balance_txn_id set when Stripe call fires", async () => {
+    stripeMocks.createBalanceTransaction.mockResolvedValue({
+      id: "cbtxn_set_id",
+      amount: 1,
+      currency: "usd",
+      description: "x",
+    });
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 1.5 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: "0.6", description: "with-stripe" });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const [entry] = await db
+      .select()
+      .from(transactions)
+      .where(and(eq(transactions.orgId, orgId), eq(transactions.source, "charge")));
+    expect(entry.stripeBalanceTxnId).toBe("cbtxn_set_id");
+  });
+
+  it("AC-C3: Stripe failure does NOT fail the ledger op", async () => {
+    stripeMocks.createBalanceTransaction.mockRejectedValue(new Error("boom"));
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 1.5 });
+
+    const res = await request(app)
+      .post("/v1/credits/deduct")
+      .set(getAuthHeaders(orgId))
+      .send({ amount_cents: "0.6", description: "stripe-fails" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.balance_cents).toBe("0.9000000000");
+  });
+
+  it("100 sub-cent deducts that don't cross any boundary → 0 Stripe calls", async () => {
+    await insertTestAccount({ orgId, stripeCustomerId: "cus_a", creditBalanceCents: 100 });
+
+    for (let i = 0; i < 100; i++) {
+      await request(app)
+        .post("/v1/credits/deduct")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: "0.0001", description: `sub-${i}` });
+    }
+    await new Promise((r) => setTimeout(r, 100));
+
+    // bal 100 → 99.99. ceil(100)=100, ceil(99.99)=100, delta=0 every step.
+    expect(stripeMocks.createBalanceTransaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("Fractional cents — public-stats string repr", () => {
+  const app = createTestApp();
+  const orgId = "00000000-0000-0000-0000-00000000fc05";
+  const userId = "00000000-0000-0000-0000-000000000099";
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    setupStripeMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("AC-D1: returns string-decimal sums that survive JSON round-trip without precision loss", async () => {
+    await insertTestAccount({ orgId, creditBalanceCents: 100.1234567 });
+    await db.insert(transactions).values([
+      {
+        orgId,
+        userId,
+        type: "credit",
+        status: "confirmed",
+        amountCents: "100.1234567",
+        source: "reload",
+        description: "frac-reload",
+      },
+      {
+        orgId,
+        userId,
+        type: "debit",
+        status: "confirmed",
+        amountCents: "50.0000001",
+        source: "charge",
+        description: "frac-debit",
+      },
+    ]);
+
+    const res = await request(app).get("/public/stats/billing");
+    expect(res.status).toBe(200);
+
+    // Strings, not numbers
+    expect(typeof res.body.totalCreditBalanceCents).toBe("string");
+    expect(typeof res.body.totalCreditedCents).toBe("string");
+    expect(typeof res.body.totalConsumedCents).toBe("string");
+
+    // Round-trip preserves precision
+    const parsed = JSON.parse(JSON.stringify(res.body));
+    expect(parsed.totalCreditedCents).toBe("100.1234567000");
+    expect(parsed.totalConsumedCents).toBe("50.0000001000");
+  });
+});

--- a/tests/integration/migration-0012.test.ts
+++ b/tests/integration/migration-0012.test.ts
@@ -94,7 +94,7 @@ describe("Migration 0012: transactions rename + source unification", () => {
     const rows = await db.select().from(transactions).where(eq(transactions.orgId, orgId));
     expect(rows).toHaveLength(1);
     expect(rows[0].source).toBe("charge");
-    expect(rows[0].amountCents).toBe(50);
+    expect(rows[0].amountCents).toBe("50.0000000000");
   });
 
   it("renames source 'provision' -> 'charge' for all statuses", async () => {
@@ -206,7 +206,7 @@ describe("Migration 0012: transactions rename + source unification", () => {
     // Parent reverted to $X = 100, status cancelled.
     const [parentAfter] = await db.select().from(transactions).where(eq(transactions.id, parent.id));
     expect(parentAfter.status).toBe("cancelled");
-    expect(parentAfter.amountCents).toBe(100);
+    expect(parentAfter.amountCents).toBe("100.0000000000");
     expect(parentAfter.source).toBe("charge");
 
     // Adjust row deleted.
@@ -228,7 +228,7 @@ describe("Migration 0012: transactions rename + source unification", () => {
         )
       );
     expect(charges).toHaveLength(1);
-    expect(charges[0].amountCents).toBe(60);
+    expect(charges[0].amountCents).toBe("60.0000000000");
 
     // Net balance contribution preserved: pre = -60 (parent) + 40 (adjust) = -20.
     // post = 0 (cancelled parent) - 60 (new charge) = -60.
@@ -279,7 +279,7 @@ describe("Migration 0012: transactions rename + source unification", () => {
 
     const [parentAfter] = await db.select().from(transactions).where(eq(transactions.id, parent.id));
     expect(parentAfter.status).toBe("cancelled");
-    expect(parentAfter.amountCents).toBe(100);
+    expect(parentAfter.amountCents).toBe("100.0000000000");
 
     const charges = await db
       .select()
@@ -292,7 +292,7 @@ describe("Migration 0012: transactions rename + source unification", () => {
         )
       );
     expect(charges).toHaveLength(1);
-    expect(charges[0].amountCents).toBe(150);
+    expect(charges[0].amountCents).toBe("150.0000000000");
   });
 
   it("aborts when a provision_cancel row has no matching parent", async () => {

--- a/tests/integration/promo.test.ts
+++ b/tests/integration/promo.test.ts
@@ -44,7 +44,7 @@ describe("Promo endpoints", () => {
       expect(res.body).toEqual({
         redeemed: true,
         amount_cents: 800,
-        balance_cents: 1000,
+        balance_cents: "1000.0000000000",
       });
 
       // Stripe balance transaction should be fired
@@ -70,7 +70,7 @@ describe("Promo endpoints", () => {
       expect(res.status).toBe(200);
       expect(res.body.redeemed).toBe(true);
       // $2 welcome + $10 promo = $12 = 1200 cents
-      expect(res.body.balance_cents).toBe(1200);
+      expect(res.body.balance_cents).toBe("1200.0000000000");
     });
 
     it("returns 400 for invalid promo code", async () => {

--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -38,7 +38,7 @@ describe("Credit provision endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.provision_id).toBeDefined();
-      expect(res.body.balance_cents).toBe(400);
+      expect(res.body.balance_cents).toBe("400.0000000000");
       expect(res.body.depleted).toBe(false);
 
       const entries = await db
@@ -64,7 +64,7 @@ describe("Credit provision endpoints", () => {
         .send({ amount_cents: 200, description: "large task" });
 
       expect(res.status).toBe(200);
-      expect(res.body.balance_cents).toBe(-150);
+      expect(res.body.balance_cents).toBe("-150.0000000000");
       expect(res.body.depleted).toBe(true);
     });
 
@@ -77,7 +77,7 @@ describe("Credit provision endpoints", () => {
       expect(res.status).toBe(200);
       expect(res.body.provision_id).toBeDefined();
       // Auto-created with 200 cents ($2), then provisioned 100
-      expect(res.body.balance_cents).toBe(100);
+      expect(res.body.balance_cents).toBe("100.0000000000");
     });
 
     it("stores workflow headers in provision record", async () => {
@@ -199,10 +199,10 @@ describe("Credit provision endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.status).toBe("confirmed");
-      expect(res.body.original_amount_cents).toBe(100);
-      expect(res.body.final_amount_cents).toBe(100);
-      expect(res.body.adjustment_cents).toBe(0);
-      expect(res.body.balance_cents).toBe(400);
+      expect(res.body.original_amount_cents).toBe("100.0000000000");
+      expect(res.body.final_amount_cents).toBe("100.0000000000");
+      expect(res.body.adjustment_cents).toBe("0.0000000000");
+      expect(res.body.balance_cents).toBe("400.0000000000");
     });
 
     it("on lower actual cost: cancels original hold, writes new charge at $Y, refunds delta", async () => {
@@ -225,9 +225,9 @@ describe("Credit provision endpoints", () => {
         .send({ actual_amount_cents: 60 });
 
       expect(res.status).toBe(200);
-      expect(res.body.adjustment_cents).toBe(40);
-      expect(res.body.final_amount_cents).toBe(60);
-      expect(res.body.balance_cents).toBe(440);
+      expect(res.body.adjustment_cents).toBe("40.0000000000");
+      expect(res.body.final_amount_cents).toBe("60.0000000000");
+      expect(res.body.balance_cents).toBe("440.0000000000");
 
       // Original row mutates to cancelled at $X, no miroir credit row.
       const original = await db
@@ -236,7 +236,7 @@ describe("Credit provision endpoints", () => {
         .where(eq(transactions.id, provisionId));
       expect(original).toHaveLength(1);
       expect(original[0].status).toBe("cancelled");
-      expect(original[0].amountCents).toBe(100);
+      expect(original[0].amountCents).toBe("100.0000000000");
       expect(original[0].source).toBe("charge");
 
       // Exactly one fresh confirmed charge row at $Y.
@@ -252,7 +252,7 @@ describe("Credit provision endpoints", () => {
         );
       expect(confirmed).toHaveLength(1);
       expect(confirmed[0].type).toBe("debit");
-      expect(confirmed[0].amountCents).toBe(60);
+      expect(confirmed[0].amountCents).toBe("60.0000000000");
 
       // No legacy miroir sources written
       const legacy = await db
@@ -287,16 +287,16 @@ describe("Credit provision endpoints", () => {
         .send({ actual_amount_cents: 150 });
 
       expect(res.status).toBe(200);
-      expect(res.body.adjustment_cents).toBe(-50);
-      expect(res.body.final_amount_cents).toBe(150);
-      expect(res.body.balance_cents).toBe(350);
+      expect(res.body.adjustment_cents).toBe("-50.0000000000");
+      expect(res.body.final_amount_cents).toBe("150.0000000000");
+      expect(res.body.balance_cents).toBe("350.0000000000");
 
       const original = await db
         .select()
         .from(transactions)
         .where(eq(transactions.id, provisionId));
       expect(original[0].status).toBe("cancelled");
-      expect(original[0].amountCents).toBe(100);
+      expect(original[0].amountCents).toBe("100.0000000000");
 
       const confirmed = await db
         .select()
@@ -309,7 +309,7 @@ describe("Credit provision endpoints", () => {
           )
         );
       expect(confirmed).toHaveLength(1);
-      expect(confirmed[0].amountCents).toBe(150);
+      expect(confirmed[0].amountCents).toBe("150.0000000000");
     });
 
     it("on same amount: mutates row pending→confirmed, no new row", async () => {
@@ -332,7 +332,7 @@ describe("Credit provision endpoints", () => {
         .send({ actual_amount_cents: 100 });
 
       expect(res.status).toBe(200);
-      expect(res.body.balance_cents).toBe(400);
+      expect(res.body.balance_cents).toBe("400.0000000000");
 
       const all = await db
         .select()
@@ -341,7 +341,7 @@ describe("Credit provision endpoints", () => {
       expect(all).toHaveLength(1);
       expect(all[0].id).toBe(provisionId);
       expect(all[0].status).toBe("confirmed");
-      expect(all[0].amountCents).toBe(100);
+      expect(all[0].amountCents).toBe("100.0000000000");
     });
 
     it("returns 200 idempotently for already confirmed provision", async () => {
@@ -371,7 +371,7 @@ describe("Credit provision endpoints", () => {
       expect(res.status).toBe(200);
       expect(res.body.status).toBe("confirmed");
       expect(res.body.provision_id).toBe(provisionId);
-      expect(res.body.adjustment_cents).toBe(0);
+      expect(res.body.adjustment_cents).toBe("0.0000000000");
     });
 
     it("returns 404 for unknown provision", async () => {
@@ -408,8 +408,8 @@ describe("Credit provision endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.status).toBe("cancelled");
-      expect(res.body.refunded_cents).toBe(100);
-      expect(res.body.balance_cents).toBe(500);
+      expect(res.body.refunded_cents).toBe("100.0000000000");
+      expect(res.body.balance_cents).toBe("500.0000000000");
 
       // Original row mutates to cancelled — no new miroir credit row.
       const all = await db
@@ -460,7 +460,7 @@ describe("Credit provision endpoints", () => {
       expect(res.status).toBe(200);
       expect(res.body.status).toBe("cancelled");
       expect(res.body.provision_id).toBe(provisionId);
-      expect(res.body.refunded_cents).toBe(0);
+      expect(res.body.refunded_cents).toBe("0.0000000000");
     });
 
     it("cannot cancel a confirmed provision", async () => {
@@ -506,7 +506,7 @@ describe("Credit provision endpoints", () => {
         .send({ amount_cents: 100, description: "test" });
 
       expect(res.status).toBe(200);
-      expect(res.body.balance_cents).toBe(150);
+      expect(res.body.balance_cents).toBe("150.0000000000");
       expect(stripeMocks.chargePaymentMethod).not.toHaveBeenCalled();
 
       const creditEntries = await db

--- a/tests/integration/public-stats.test.ts
+++ b/tests/integration/public-stats.test.ts
@@ -27,9 +27,9 @@ describe("GET /public/stats/billing", () => {
     expect(res.body).toEqual({
       totalAccounts: 0,
       accountsWithPaymentMethod: 0,
-      totalCreditBalanceCents: 0,
-      totalCreditedCents: 0,
-      totalConsumedCents: 0,
+      totalCreditBalanceCents: "0.0000000000",
+      totalCreditedCents: "0.0000000000",
+      totalConsumedCents: "0.0000000000",
       monthlyGrowth: [],
       weeklyGrowth: [],
     });
@@ -105,9 +105,9 @@ describe("GET /public/stats/billing", () => {
     expect(res.status).toBe(200);
     expect(res.body.totalAccounts).toBe(2);
     expect(res.body.accountsWithPaymentMethod).toBe(1);
-    expect(res.body.totalCreditBalanceCents).toBe(8000);
-    expect(res.body.totalCreditedCents).toBe(15000);
-    expect(res.body.totalConsumedCents).toBe(11999); // 2000 confirmed + 9999 pending
+    expect(res.body.totalCreditBalanceCents).toBe("8000.0000000000");
+    expect(res.body.totalCreditedCents).toBe("15000.0000000000");
+    expect(res.body.totalConsumedCents).toBe("11999.0000000000"); // 2000 confirmed + 9999 pending
   });
 
   it("returns monthly and weekly growth with credited, consumed, and revenue", async () => {
@@ -153,17 +153,17 @@ describe("GET /public/stats/billing", () => {
     expect(res.body.weeklyGrowth).toBeInstanceOf(Array);
     expect(res.body.weeklyGrowth.length).toBeGreaterThanOrEqual(1);
 
-    // Sum across all periods should match totals
+    // Sum across all periods should match totals (parse string-cents to number for sum)
     const totalMonthlyCredited = res.body.monthlyGrowth.reduce(
-      (sum: number, r: { credited_cents: number }) => sum + r.credited_cents,
+      (sum: number, r: { credited_cents: string }) => sum + parseFloat(r.credited_cents),
       0
     );
     const totalMonthlyConsumed = res.body.monthlyGrowth.reduce(
-      (sum: number, r: { consumed_cents: number }) => sum + r.consumed_cents,
+      (sum: number, r: { consumed_cents: string }) => sum + parseFloat(r.consumed_cents),
       0
     );
     const totalMonthlyRevenue = res.body.monthlyGrowth.reduce(
-      (sum: number, r: { revenue_cents: number }) => sum + r.revenue_cents,
+      (sum: number, r: { revenue_cents: string }) => sum + parseFloat(r.revenue_cents),
       0
     );
 
@@ -229,7 +229,7 @@ describe("GET /public/stats/billing", () => {
 
     const res = await request(app).get("/public/stats/billing");
     expect(res.status).toBe(200);
-    expect(res.body.totalCreditedCents).toBe(1250); // 1000 + 200 + 50
+    expect(res.body.totalCreditedCents).toBe("1250.0000000000"); // 1000 + 200 + 50
   });
 
   it("totalConsumedCents excludes cancelled charges", async () => {
@@ -267,6 +267,6 @@ describe("GET /public/stats/billing", () => {
 
     const res = await request(app).get("/public/stats/billing");
     expect(res.status).toBe(200);
-    expect(res.body.totalConsumedCents).toBe(150);
+    expect(res.body.totalConsumedCents).toBe("150.0000000000");
   });
 });

--- a/tests/integration/webhooks.test.ts
+++ b/tests/integration/webhooks.test.ts
@@ -90,7 +90,7 @@ describe("Stripe webhooks", () => {
       .where(eq(billingAccounts.orgId, orgId))
       .limit(1);
 
-    expect(account.creditBalanceCents).toBe(2200); // 200 + 2000
+    expect(account.creditBalanceCents).toBe("2200.0000000000"); // 200 + 2000
     expect(account.stripePaymentMethodId).toBe("pm_new_123");
   });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -127,5 +127,27 @@ beforeAll(async () => {
   `;
 
   await sql`DROP TABLE IF EXISTS "promo_redemptions"`;
+
+  // Migration 0013 — fractional cents.
+  // Idempotent: only alters when columns are still integer.
+  await sql`
+    DO $$ BEGIN
+      IF (SELECT data_type FROM information_schema.columns
+          WHERE table_name = 'transactions' AND column_name = 'amount_cents') = 'integer'
+      THEN
+        ALTER TABLE "transactions" ALTER COLUMN "amount_cents" TYPE numeric(16,10) USING "amount_cents"::numeric(16,10);
+      END IF;
+    END $$
+  `;
+  await sql`
+    DO $$ BEGIN
+      IF (SELECT data_type FROM information_schema.columns
+          WHERE table_name = 'billing_accounts' AND column_name = 'credit_balance_cents') = 'integer'
+      THEN
+        ALTER TABLE "billing_accounts" ALTER COLUMN "credit_balance_cents" TYPE numeric(16,10) USING "credit_balance_cents"::numeric(16,10);
+        ALTER TABLE "billing_accounts" ALTER COLUMN "credit_balance_cents" SET DEFAULT 200;
+      END IF;
+    END $$
+  `;
 });
 afterAll(() => console.log("Test suite complete."));

--- a/tests/unit/cents.test.ts
+++ b/tests/unit/cents.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePositiveCents,
+  parseNonNegativeCents,
+  addCents,
+  subCents,
+  cmpCents,
+  isDepleted,
+  gte,
+  ceilToInt,
+  stripeCeilDelta,
+} from "../../src/lib/cents.js";
+
+describe("parsePositiveCents — input validation", () => {
+  it("accepts decimal string", () => {
+    expect(parsePositiveCents("0.42")).toBe("0.4200000000");
+  });
+
+  it("accepts decimal number", () => {
+    expect(parsePositiveCents(0.42)).toBe("0.4200000000");
+  });
+
+  it("accepts integer", () => {
+    expect(parsePositiveCents(100)).toBe("100.0000000000");
+    expect(parsePositiveCents("100")).toBe("100.0000000000");
+  });
+
+  it("preserves sub-cent precision", () => {
+    expect(parsePositiveCents("0.0000000001")).toBe("0.0000000001");
+    expect(parsePositiveCents("1.234567")).toBe("1.2345670000");
+  });
+
+  it("rejects negative number", () => {
+    expect(() => parsePositiveCents(-1)).toThrow();
+    expect(() => parsePositiveCents("-0.5")).toThrow();
+  });
+
+  it("rejects zero", () => {
+    expect(() => parsePositiveCents(0)).toThrow();
+    expect(() => parsePositiveCents("0")).toThrow();
+  });
+
+  it("rejects NaN / Infinity", () => {
+    expect(() => parsePositiveCents(NaN)).toThrow();
+    expect(() => parsePositiveCents(Infinity)).toThrow();
+    expect(() => parsePositiveCents(-Infinity)).toThrow();
+  });
+
+  it("rejects non-numeric string", () => {
+    expect(() => parsePositiveCents("abc")).toThrow();
+    expect(() => parsePositiveCents("1.2.3")).toThrow();
+  });
+
+  it("rejects integer part > 16 digits", () => {
+    expect(() => parsePositiveCents("99999999999999999")).toThrow(); // 17 digits
+  });
+
+  it("accepts integer part of exactly 16 digits", () => {
+    expect(parsePositiveCents("9999999999999999")).toBe("9999999999999999.0000000000");
+  });
+
+  it("rejects null/undefined/objects", () => {
+    expect(() => parsePositiveCents(null)).toThrow();
+    expect(() => parsePositiveCents(undefined)).toThrow();
+    expect(() => parsePositiveCents({})).toThrow();
+    expect(() => parsePositiveCents([])).toThrow();
+  });
+});
+
+describe("parseNonNegativeCents — allows zero", () => {
+  it("accepts zero", () => {
+    expect(parseNonNegativeCents(0)).toBe("0.0000000000");
+  });
+
+  it("rejects negative", () => {
+    expect(() => parseNonNegativeCents(-0.0001)).toThrow();
+  });
+});
+
+describe("addCents / subCents / cmpCents", () => {
+  it("preserves sub-cent precision under addition", () => {
+    let bal = "5.7531000000";
+    for (let i = 0; i < 100; i++) bal = subCents(bal, "0.0001");
+    expect(bal).toBe("5.7431000000");
+  });
+
+  it("mixed adds and subs preserve exact math", () => {
+    // 5.7531 - 10*0.0001 - 10*0.4 = 5.7531 - 0.001 - 4 = 1.7521
+    let bal = "5.7531000000";
+    for (let i = 0; i < 10; i++) bal = subCents(bal, "0.0001");
+    for (let i = 0; i < 10; i++) bal = subCents(bal, "0.4");
+    expect(bal).toBe("1.7521000000");
+  });
+
+  it("compares correctly", () => {
+    expect(cmpCents("1.5", "1.5")).toBe(0);
+    expect(cmpCents("1.5", "1.50000")).toBe(0);
+    expect(cmpCents("1.5", "1.4")).toBe(1);
+    expect(cmpCents("1.5", "1.6")).toBe(-1);
+  });
+
+  it("isDepleted true for ≤ 0", () => {
+    expect(isDepleted("0")).toBe(true);
+    expect(isDepleted("-0.0001")).toBe(true);
+    expect(isDepleted("0.0000000001")).toBe(false);
+  });
+
+  it("gte handles fractions", () => {
+    expect(gte("100.0001", "100")).toBe(true);
+    expect(gte("100", "100.0001")).toBe(false);
+    expect(gte("100", "100")).toBe(true);
+  });
+});
+
+describe("stripeCeilDelta — Stripe sync sizing", () => {
+  it("returns 0 when no ceil-cent boundary crossed", () => {
+    // 1.5 → 1.4: ceil(1.5)=2, ceil(1.4)=2, delta=0
+    expect(stripeCeilDelta("1.5", "1.4")).toBe(0);
+    // 1.0 → 0.5: ceil(1.0)=1, ceil(0.5)=1, delta=0
+    expect(stripeCeilDelta("1.0", "0.5")).toBe(0);
+  });
+
+  it("returns positive int when balance dropped past a ceil-cent boundary (debit)", () => {
+    // 1.5 → 0.5: ceil(1.5)=2, ceil(0.5)=1, delta=+1
+    expect(stripeCeilDelta("1.5", "0.5")).toBe(1);
+    // 100 → 95.5: ceil(100)=100, ceil(95.5)=96, delta=+4
+    expect(stripeCeilDelta("100", "95.5")).toBe(4);
+  });
+
+  it("returns negative int when balance rose past a ceil-cent boundary (credit)", () => {
+    // 0.5 → 1.5: ceil(0.5)=1, ceil(1.5)=2, delta=-1
+    expect(stripeCeilDelta("0.5", "1.5")).toBe(-1);
+    // 95.5 → 100: ceil(95.5)=96, ceil(100)=100, delta=-4
+    expect(stripeCeilDelta("95.5", "100")).toBe(-4);
+  });
+
+  it("handles whole-cent moves exactly", () => {
+    expect(stripeCeilDelta("100", "95")).toBe(5);
+    expect(stripeCeilDelta("95", "100")).toBe(-5);
+  });
+
+  it("handles negative balances (Stripe ceil semantics)", () => {
+    // -0.5 → -1.5: ceil(-0.5)=0, ceil(-1.5)=-1, delta=+1
+    expect(stripeCeilDelta("-0.5", "-1.5")).toBe(1);
+  });
+});
+
+describe("ceilToInt", () => {
+  it("rounds up for positive fractional", () => {
+    expect(ceilToInt("1.4")).toBe(2);
+    expect(ceilToInt("0.0001")).toBe(1);
+    expect(ceilToInt("100")).toBe(100);
+  });
+
+  it("rounds toward zero for negative fractional", () => {
+    expect(ceilToInt("-1.4")).toBe(-1);
+    expect(Math.abs(ceilToInt("-0.5"))).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Pivots the ledger from integer cents to `numeric(16,10)` so upstream services stop rounding at every batch and only round at human-facing display. Stripe (integer-only) lags the ledger by ≤1¢ via per-op ceil-cent delta sync.

Companion change: runs-service drops its `Math.ceil` and sends raw fractional amounts (separate workspace).

## Schema

| Table | Column | Before | After |
|-------|--------|--------|-------|
| `transactions` | `amount_cents` | `integer NOT NULL` | `numeric(16,10) NOT NULL` |
| `billing_accounts` | `credit_balance_cents` | `integer NOT NULL` | `numeric(16,10) NOT NULL DEFAULT 200` |

Migration `0013_fractional_cents.sql` is idempotent (column-type guard) and lossless. PostgreSQL `int → numeric` is a value-preserving cast.

## Stripe sync strategy — per-op ceil-delta

`stripeDelta = ceil(oldBalance) - ceil(newBalance)`

- delta = 0 → no Stripe API call (sub-cent ops don't spam Stripe)
- delta ≠ 0 → fire one `createBalanceTransaction` async; on success, attach the txn id to the originating ledger row
- `stripe_balance_txn_id` is set ONLY when a call actually fired, so audits can tell which rows triggered Stripe state changes

Recovery (reconcile Check 3) sends `Math.ceil(amount)` per unsynced row. Bound: ≤1¢ overshoot per recovered fractional row in the rare case the forward fire-and-forget failed; the steady-state ≤1¢ guarantee holds when forward sync works.

## API surface — breaking changes

All response fields named `*_cents` that come from the ledger or the balance cache are now **full-precision decimal strings** (e.g. `"100.4200000000"`). Integer inputs round-trip as `"100.0000000000"`.

| Endpoint | Field | Before | After |
|----------|-------|--------|-------|
| `POST /v1/credits/deduct` | `amount_cents` (req) | int | int OR decimal string |
|  | `balance_cents` (resp) | int | string |
| `POST /v1/credits/authorize` | `balance_cents`, `required_cents` (resp) | int | string |
| `POST /v1/credits/provision` | `amount_cents` (req) | int | int OR decimal string |
|  | `balance_cents` (resp) | int | string |
| `POST /v1/credits/provision/:id/confirm` | `actual_amount_cents` (req) | int | int OR decimal string |
|  | `original_amount_cents`, `final_amount_cents`, `adjustment_cents`, `balance_cents` (resp) | int | string |
| `POST /v1/credits/provision/:id/cancel` | `refunded_cents`, `balance_cents` (resp) | int | string |
| `GET /v1/accounts` | `creditBalanceCents` (resp) | int | string |
| `GET /v1/accounts/balance` | `balance_cents` (resp) | int | string |
| `POST /v1/promo/redeem` | `balance_cents` (resp) | int | string (`amount_cents` stays int — promo amounts are whole-cent only) |
| `GET /public/stats/billing` | `totalCreditBalanceCents`, `totalCreditedCents`, `totalConsumedCents`, `monthlyGrowth.{credited_cents, consumed_cents, revenue_cents}`, `weeklyGrowth.{...}` | int | string |

`reload_amount_cents` and `reload_threshold_cents` stay integer (whole-dollar configs).

Inbound validation rejects loudly: negative, zero, NaN, Infinity, non-numeric strings, integer part > 16 digits. No silent coercion.

## Consumer follow-ups required

| Repo | Path | Reason |
|------|------|--------|
| `runs-service` | bill-after-run code path | drop `Math.ceil`, send fractional `amount_cents` (handled in companion workspace) |
| `api-service` | any client that calls billing endpoints and reads `*_cents` as `number` | switch to string parse; `Math.ceil(parseFloat(x))` for display |
| `dashboard` (`distribute.you/apps/dashboard`) | balance / transactions UI | `parseFloat` then format |
| `distribute.you/apps/landing/src/lib/investors/fetch-metrics.ts` | parses `totalCreditedCents` etc. | switch from `number` to `parseFloat(string)` for the public-stats fields |

## Migration plan

`migrate(db, { migrationsFolder: "./drizzle" })` runs at boot via `src/index.ts` (existing pattern from #82). Migration 0013 is idempotent: re-running on an already-migrated DB is a no-op.

## Verification — Neon preview branch (twilight-river-28884620)

Pre-migration:
- 17 accounts, 107295 transactions
- Per-org balance invariant: 15 orgs balanced, 2 orgs (`6899659f`, `b645207b`) with pre-existing drift (handled by runtime reconcile)

Post-migration:
- Both columns: `numeric(16,10) NOT NULL`
- 17 accounts, 107295 transactions (no row count change)
- Per-org balance invariant: identical pre vs post for every org (cached and computed values match bit-for-bit; pre-existing drift unchanged)
- `SUM(credit_balance_cents)` = `8446` pre = `8446.0000000000` post

## Test plan

- [x] `pnpm test` — 215 tests green (173 existing + 42 new)
- [x] New tests cover:
  - inbound decimal string + number + integer
  - inbound rejection of negative, zero, NaN, non-numeric, > 16 int digits
  - provision + confirm with fractional amounts
  - 100×0.0001 from 5.7531 → final 5.7431 exactly
  - mixed 10×0.0001 + 10×0.4 → final 1.7521 exactly
  - Stripe ceil-boundary cross fires call (delta=1)
  - Stripe no-cross skips call
  - `stripeBalanceTxnId` null when no call, set when call fires
  - Stripe failure non-blocking
  - public-stats string repr survives JSON round-trip
- [x] TypeScript strict mode clean (`pnpm exec tsc --noEmit`)
- [x] OpenAPI spec regenerated
- [x] Neon preview migration verified bit-for-bit balance preservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)