### PR TITLE
chore(billing): explicit logs and error bodies on provision confirm/cancel conflicts

### DIFF
--- a/src/routes/provisions.ts
+++ b/src/routes/provisions.ts
@@ -120,7 +120,12 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
 
     res.json(response);
   } catch (err) {
-    console.error("[billing-service] Error creating provision:", err);
+    console.error("[billing-service] Error creating provision", {
+      run_id: req.headers["x-run-id"],
+      org_id: req.headers["x-org-id"],
+      user_id: req.headers["x-user-id"],
+      err,
+    });
     if (isStripeAuthError(err)) {
       res.status(502).json({ error: "Payment provider authentication failed" });
       return;
@@ -175,7 +180,12 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
       }>)[0];
 
       if (!provision) {
-        return { error: "Provision not found" as const, status: 404 as const };
+        return {
+          error: "Provision not found" as const,
+          status: 404 as const,
+          current_status: null as string | null,
+          current_amount_cents: null as string | null,
+        };
       }
 
       // Idempotent: confirm with same amount on already-confirmed row is a no-op.
@@ -187,6 +197,8 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
           return {
             error: `Provision already confirmed at ${provision.amount_cents} cents` as const,
             status: 409 as const,
+            current_status: provision.status,
+            current_amount_cents: provision.amount_cents,
           };
         }
         const [account] = await tx
@@ -206,7 +218,12 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
       }
 
       if (provision.status !== "pending") {
-        return { error: `Provision already ${provision.status}` as const, status: 409 as const };
+        return {
+          error: `Provision already ${provision.status}` as const,
+          status: 409 as const,
+          current_status: provision.status,
+          current_amount_cents: provision.amount_cents,
+        };
       }
 
       const finalAmount = actual_amount_cents ?? provision.amount_cents;
@@ -306,7 +323,27 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
     });
 
     if ("error" in result && result.error) {
-      res.status(result.status as number).json({ error: result.error });
+      const currentStatus = "current_status" in result ? result.current_status : null;
+      const currentAmountCents = "current_amount_cents" in result ? result.current_amount_cents : null;
+      console.warn("[billing-service] provision confirm rejected", {
+        provision_id: provisionId,
+        run_id: runId,
+        org_id: orgId,
+        user_id: userId,
+        status_code: result.status,
+        error: result.error,
+        current_status: currentStatus,
+        current_amount_cents: currentAmountCents,
+        requested_amount_cents: actual_amount_cents ?? null,
+      });
+      res.status(result.status as number).json({
+        error: result.error,
+        provision_id: provisionId,
+        run_id: runId,
+        current_status: currentStatus,
+        current_amount_cents: currentAmountCents,
+        requested_amount_cents: actual_amount_cents ?? null,
+      });
       return;
     }
 
@@ -345,7 +382,13 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
 
     res.json(response);
   } catch (err) {
-    console.error("[billing-service] Error confirming provision:", err);
+    console.error("[billing-service] Error confirming provision", {
+      provision_id: req.params.id,
+      run_id: req.headers["x-run-id"],
+      org_id: req.headers["x-org-id"],
+      user_id: req.headers["x-user-id"],
+      err,
+    });
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -355,6 +398,7 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
+    const runId = req.headers["x-run-id"] as string;
     const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
     const provisionId = req.params.id;
 
@@ -376,7 +420,12 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
       }>)[0];
 
       if (!provision) {
-        return { error: "Provision not found" as const, status: 404 as const };
+        return {
+          error: "Provision not found" as const,
+          status: 404 as const,
+          current_status: null as string | null,
+          current_amount_cents: null as string | null,
+        };
       }
 
       if (provision.status === "cancelled") {
@@ -395,7 +444,12 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
       }
 
       if (provision.status !== "pending") {
-        return { error: `Provision already ${provision.status}` as const, status: 409 as const };
+        return {
+          error: `Provision already ${provision.status}` as const,
+          status: 409 as const,
+          current_status: provision.status,
+          current_amount_cents: provision.amount_cents,
+        };
       }
 
       const [accountBefore] = await tx
@@ -442,7 +496,25 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
     });
 
     if ("error" in result && result.error) {
-      res.status(result.status as number).json({ error: result.error });
+      const currentStatus = "current_status" in result ? result.current_status : null;
+      const currentAmountCents = "current_amount_cents" in result ? result.current_amount_cents : null;
+      console.warn("[billing-service] provision cancel rejected", {
+        provision_id: provisionId,
+        run_id: runId,
+        org_id: orgId,
+        user_id: userId,
+        status_code: result.status,
+        error: result.error,
+        current_status: currentStatus,
+        current_amount_cents: currentAmountCents,
+      });
+      res.status(result.status as number).json({
+        error: result.error,
+        provision_id: provisionId,
+        run_id: runId,
+        current_status: currentStatus,
+        current_amount_cents: currentAmountCents,
+      });
       return;
     }
 
@@ -465,7 +537,7 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
     const { _customerId: _c, _refundedCents: _r, _oldBalance: _ob, ...response } = result as Record<string, unknown>;
 
     traceEvent({
-      runId: req.headers["x-run-id"] as string,
+      runId,
       orgId,
       userId,
       event: "billing.provision.cancelled",
@@ -475,7 +547,13 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
 
     res.json(response);
   } catch (err) {
-    console.error("[billing-service] Error cancelling provision:", err);
+    console.error("[billing-service] Error cancelling provision", {
+      provision_id: req.params.id,
+      run_id: req.headers["x-run-id"],
+      org_id: req.headers["x-org-id"],
+      user_id: req.headers["x-user-id"],
+      err,
+    });
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -14,6 +14,17 @@ export const ErrorResponseSchema = z
   .object({ error: z.string() })
   .openapi("ErrorResponse");
 
+export const ProvisionConflictResponseSchema = z
+  .object({
+    error: z.string(),
+    provision_id: z.string().uuid(),
+    run_id: z.string().nullable(),
+    current_status: z.string().nullable(),
+    current_amount_cents: z.string().nullable(),
+    requested_amount_cents: z.string().nullable().optional(),
+  })
+  .openapi("ProvisionConflictResponse");
+
 /**
  * Inbound fractional-cents amount. Accepts decimal string or finite number.
  * Rejects negative, zero, NaN, non-numeric, or integer part > 16 digits.
@@ -577,11 +588,11 @@ registry.registerPath({
     },
     404: {
       description: "Provision not found",
-      content: { "application/json": { schema: ErrorResponseSchema } },
+      content: { "application/json": { schema: ProvisionConflictResponseSchema } },
     },
     409: {
       description: "Provision already confirmed or cancelled",
-      content: { "application/json": { schema: ErrorResponseSchema } },
+      content: { "application/json": { schema: ProvisionConflictResponseSchema } },
     },
   },
 });
@@ -601,11 +612,11 @@ registry.registerPath({
     },
     404: {
       description: "Provision not found",
-      content: { "application/json": { schema: ErrorResponseSchema } },
+      content: { "application/json": { schema: ProvisionConflictResponseSchema } },
     },
     409: {
       description: "Provision already confirmed or cancelled",
-      content: { "application/json": { schema: ErrorResponseSchema } },
+      content: { "application/json": { schema: ProvisionConflictResponseSchema } },
     },
   },
 });


### PR DESCRIPTION
## Summary

- Add `console.warn` on every 4xx return in `POST /v1/credits/provision/:id/confirm` and `/cancel` with full context: `provision_id`, `run_id`, `org_id`, `user_id`, `current_status`, `current_amount_cents`, `requested_amount_cents`.
- Expand 4xx JSON error body with the same fields so callers (runs-service) can log and trace without round-tripping to billing.
- New `ProvisionConflictResponseSchema` for 404/409 on confirm/cancel (replaces `ErrorResponseSchema` so OpenAPI matches actual response).
- Enrich existing 500 `console.error` lines with header context.

No behavior change to success paths, ledger, or Stripe sync.

## Why

Production webhook chain surfaced `502 - {"error":"billing-service unavailable: billing-service returned 409"}` for cost `ceb6c7f6-a212-4655-827f-1b54a2732a8f` on run `fe0d6b64-5576-45cb-ac3c-1ddaabd07128`. Billing's previous error body was a single string with no `provision_id` or `current_status`, so the failure was untraceable from logs alone.

DB investigation (table `transactions`, run `fe0d6b64-...`) confirmed the root cause is in **runs-service**, not billing: one provision (`7c9ea30d-...`, $0.02) was created for two cost items. The first webhook converted cost #1 → confirm replaced the row at $0.001984, original flipped to `cancelled`. The second webhook for cost `ceb6c7f6-...` tried to confirm the same `provision_id` again → already `cancelled` → 409 path `Provision already cancelled` (`src/routes/provisions.ts:209`).

A separate workspace was spawned in `runs-service` to fix the actual race (1:N cost-to-provision mapping, idempotent webhook, error-body forwarding).

## Test plan

- [x] `npx tsc --noEmit` passes.
- [ ] After deploy: trigger a known 409 (or wait for the next late webhook) and confirm `[billing-service] provision confirm rejected {...}` appears in logs with all fields.
- [ ] Confirm runs-service receives the rich JSON body (visible in its logs once the runs-service PR lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)