### PR TITLE
feat(billing): cost_id natural key + by-cost confirm/cancel endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,14 @@ Canonical `transactions.source` values (post-#82/#83):
 
 `charge` lifecycle: provision inserts `(debit, pending)`; confirm with same amount mutates row to `confirmed`; confirm with $Y != $X mutates original to `cancelled` and inserts a new `(debit, confirmed, $Y)`; cancel mutates to `cancelled`. **No miroir credit rows are ever inserted.** `provision_cancel` and `provision_adjust` are dead sources from the pre-#82 era.
 
+## `cost_id` natural key (post-#92)
+
+`transactions.cost_id` (uuid, nullable, indexed) decouples external callers from the billing-internal `transactions.id`. runs-service issues one provision per `runs_costs.id` and confirms/cancels via `POST /v1/credits/provision/by-cost/:cost_id/{confirm,cancel}` — no billing-side id needed.
+
+By-cost lookup picks the **most recent** row by `created_at` (one cost_id can produce a `pending → cancelled` row plus a fresh `confirmed` replacement when the actual amount differs). Only one row per cost_id is non-terminal at a time. Replacement rows carry the same `cost_id` so subsequent calls still hit the active row.
+
+When confirm produces a replacement (amount mismatch), the `provision_id` field in the response points to the **new** confirmed row, not the cancelled original. By-id endpoints (`/provision/:id/{confirm,cancel}`) remain unchanged for back-compat.
+
 ## Fractional cents
 
 `transactions.amount_cents` and `billing_accounts.credit_balance_cents` are `numeric(16,10)`. Drizzle returns them as JS strings — never cast with `Number()` for math (precision loss). Use `parseFloat` for display only; for arithmetic in JS, use `BigInt`-scaled or `numeric.js`-style. Do NOT round inside billing — runs-service sends raw fractional, ledger preserves it.

--- a/drizzle/0014_transactions_cost_id.sql
+++ b/drizzle/0014_transactions_cost_id.sql
@@ -1,0 +1,16 @@
+-- Add cost_id natural key to transactions.
+--
+-- Why:
+--   Decouples runs-service callers from billing-internal transaction ids.
+--   runs-service issues one provision per cost row carrying its `cost_id`
+--   (= runs_costs.id). Confirm/cancel webhooks reference the same `cost_id`
+--   instead of the billing-side provision_id, fixing a class of 409s where
+--   one runs-service provision was reused for N cost rows.
+--
+-- Non-unique:
+--   The same cost_id may appear multiple times across history
+--   (pending → cancelled, then a fresh confirmed row at a different amount).
+--   Only one row per cost_id is in non-terminal state at any moment.
+
+ALTER TABLE "transactions" ADD COLUMN "cost_id" uuid;--> statement-breakpoint
+CREATE INDEX "idx_transactions_cost_id" ON "transactions" USING btree ("cost_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1778803200000,
       "tag": "0013_fractional_cents",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1779408000000,
+      "tag": "0014_transactions_cost_id",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -382,6 +382,11 @@
             "type": "string",
             "format": "uuid"
           },
+          "cost_id": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
           "balance_cents": {
             "type": "string"
           },
@@ -411,6 +416,10 @@
           "description": {
             "type": "string",
             "minLength": 1
+          },
+          "cost_id": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "required": [
@@ -423,6 +432,11 @@
         "properties": {
           "provision_id": {
             "type": "string",
+            "format": "uuid"
+          },
+          "cost_id": {
+            "type": "string",
+            "nullable": true,
             "format": "uuid"
           },
           "status": {
@@ -454,6 +468,47 @@
           "balance_cents"
         ]
       },
+      "ProvisionConflictResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "provision_id": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
+          "cost_id": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
+          "run_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "current_status": {
+            "type": "string",
+            "nullable": true
+          },
+          "current_amount_cents": {
+            "type": "string",
+            "nullable": true
+          },
+          "requested_amount_cents": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "error",
+          "provision_id",
+          "run_id",
+          "current_status",
+          "current_amount_cents"
+        ]
+      },
       "ConfirmProvisionRequest": {
         "type": "object",
         "properties": {
@@ -476,6 +531,11 @@
             "type": "string",
             "format": "uuid"
           },
+          "cost_id": {
+            "type": "string",
+            "nullable": true,
+            "format": "uuid"
+          },
           "status": {
             "type": "string",
             "enum": [
@@ -496,6 +556,21 @@
           "refunded_cents",
           "balance_cents"
         ]
+      },
+      "ConfirmByCostRequest": {
+        "type": "object",
+        "properties": {
+          "actual_amount_cents": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        }
       },
       "RedeemPromoResponse": {
         "type": "object",
@@ -1841,7 +1916,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/ProvisionConflictResponse"
                 }
               }
             }
@@ -1851,7 +1926,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/ProvisionConflictResponse"
                 }
               }
             }
@@ -1961,7 +2036,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/ProvisionConflictResponse"
                 }
               }
             }
@@ -1971,7 +2046,258 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "$ref": "#/components/schemas/ProvisionConflictResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/credits/provision/by-cost/{cost_id}/confirm": {
+      "post": {
+        "summary": "Confirm a provision looked up by cost_id (natural key)",
+        "description": "Confirms the most recent provision row for the given cost_id. Use this when callers (e.g. runs-service) hold the cost_id but not the billing-internal provision_id. Idempotent: re-confirming with the same amount returns 200.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "cost_id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmByCostRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Provision confirmed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfirmProvisionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No provision found for cost_id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvisionConflictResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Existing provision is in incompatible state (cancelled, or confirmed at a different amount)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvisionConflictResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/credits/provision/by-cost/{cost_id}/cancel": {
+      "post": {
+        "summary": "Cancel a provision looked up by cost_id (natural key)",
+        "description": "Cancels the most recent provision row for the given cost_id. Idempotent: re-cancelling an already-cancelled cost_id returns 200.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "cost_id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Provision cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelProvisionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No provision found for cost_id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvisionConflictResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Existing provision is confirmed (cannot cancel)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvisionConflictResponse"
                 }
               }
             }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -71,6 +71,7 @@ export const transactions = pgTable(
     orgId: uuid("org_id").notNull(),
     userId: uuid("user_id").notNull(),
     runId: uuid("run_id"),
+    costId: uuid("cost_id"),
     type: text("type").notNull().default("debit"),
     amountCents: numeric("amount_cents", {
       precision: FRACTIONAL_PRECISION,
@@ -97,6 +98,7 @@ export const transactions = pgTable(
     index("idx_transactions_org_id").on(table.orgId),
     index("idx_transactions_status").on(table.status),
     index("idx_transactions_source").on(table.source),
+    index("idx_transactions_cost_id").on(table.costId),
     uniqueIndex("idx_transactions_reload_pi")
       .on(table.orgId, table.stripePaymentIntentId)
       .where(sql`source = 'reload' AND stripe_payment_intent_id IS NOT NULL`),

--- a/src/routes/provisions.ts
+++ b/src/routes/provisions.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Router, type Request, type Response } from "express";
 import { eq, sql as rawSql } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { billingAccounts, transactions } from "../db/schema.js";
@@ -8,7 +8,7 @@ import { isStripeAuthError } from "../lib/stripe.js";
 import { syncStripeCeilDelta } from "../lib/ledger.js";
 import { findOrCreateAccount } from "../lib/account.js";
 import { traceEvent } from "../lib/trace-client.js";
-import { addCents, subCents, isDepleted, cmpCents } from "../lib/cents.js";
+import { subCents, isDepleted, cmpCents } from "../lib/cents.js";
 
 const router = Router();
 
@@ -20,6 +20,53 @@ interface AccountRow {
   reload_amount_cents: number | null;
   reload_threshold_cents: number | null;
   stripe_payment_method_id: string | null;
+}
+
+interface ProvisionRow {
+  id: string;
+  org_id: string;
+  cost_id: string | null;
+  amount_cents: string;
+  status: string;
+  description: string | null;
+  campaign_id: string | null;
+  brand_ids: string[] | null;
+  workflow_slug: string | null;
+  feature_slug: string | null;
+}
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+async function lookupProvisionById(
+  tx: Tx,
+  provisionId: string,
+  orgId: string
+): Promise<ProvisionRow | undefined> {
+  const rows = await tx.execute(
+    rawSql`SELECT id, org_id, cost_id, amount_cents, status, description,
+                  campaign_id, brand_ids, workflow_slug, feature_slug
+           FROM transactions
+           WHERE id = ${provisionId} AND org_id = ${orgId}
+           FOR UPDATE`
+  );
+  return (rows as unknown as ProvisionRow[])[0];
+}
+
+async function lookupProvisionByCostId(
+  tx: Tx,
+  costId: string,
+  orgId: string
+): Promise<ProvisionRow | undefined> {
+  const rows = await tx.execute(
+    rawSql`SELECT id, org_id, cost_id, amount_cents, status, description,
+                  campaign_id, brand_ids, workflow_slug, feature_slug
+           FROM transactions
+           WHERE cost_id = ${costId} AND org_id = ${orgId}
+           ORDER BY created_at DESC
+           LIMIT 1
+           FOR UPDATE`
+  );
+  return (rows as unknown as ProvisionRow[])[0];
 }
 
 // POST /v1/credits/provision — provision credits (deduct from balance immediately, status=pending)
@@ -37,7 +84,7 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    const { amount_cents, description } = parsed.data;
+    const { amount_cents, description, cost_id } = parsed.data;
 
     await findOrCreateAccount(orgId, userId, fwdHeaders);
 
@@ -67,6 +114,7 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
           orgId,
           userId,
           runId,
+          costId: cost_id,
           type: "debit",
           amountCents: amount_cents,
           status: "pending",
@@ -81,6 +129,7 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
 
       return {
         provision_id: provision.id,
+        cost_id: provision.costId ?? null,
         balance_cents: newBalance,
         depleted: isDepleted(newBalance),
         _oldBalance: oldBalance,
@@ -114,7 +163,7 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
       orgId,
       userId,
       event: "billing.provision.created",
-      detail: { provision_id: result.provision_id, amount_cents, balance_cents: result.balance_cents },
+      detail: { provision_id: result.provision_id, cost_id: result.cost_id, amount_cents, balance_cents: result.balance_cents },
       workflowHeaders: fwdHeaders,
     });
 
@@ -134,15 +183,206 @@ router.post("/v1/credits/provision", requireOrgHeaders, async (req, res) => {
   }
 });
 
-// POST /v1/credits/provision/:id/confirm — confirm provision; on amount mismatch, cancel original and write a fresh charge.
-router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, res) => {
+// --- Confirm helpers ---
+
+interface ConfirmConflict {
+  error: string;
+  status: 404 | 409;
+  current_status: string | null;
+  current_amount_cents: string | null;
+}
+
+interface ConfirmSuccess {
+  provision_id: string;
+  cost_id: string | null;
+  status: "confirmed";
+  original_amount_cents: string;
+  final_amount_cents: string;
+  adjustment_cents: string;
+  balance_cents: string | null;
+  _customerId?: string | null;
+  _oldBalance?: string | null;
+  _adjustmentCents?: string;
+  _newChargeId?: string | null;
+}
+
+type ConfirmResult = ConfirmConflict | ConfirmSuccess;
+
+async function performConfirmInTx(
+  tx: Tx,
+  provision: ProvisionRow | undefined,
+  ctx: { orgId: string; userId: string; runId: string },
+  actualAmountCents: string | undefined
+): Promise<ConfirmResult> {
+  if (!provision) {
+    return {
+      error: "Provision not found",
+      status: 404,
+      current_status: null,
+      current_amount_cents: null,
+    };
+  }
+
+  // Idempotent: re-confirm with same amount on already-confirmed row is a no-op.
+  if (provision.status === "confirmed") {
+    const sameAmount =
+      actualAmountCents === undefined ||
+      cmpCents(actualAmountCents, provision.amount_cents) === 0;
+    if (!sameAmount) {
+      return {
+        error: `Provision already confirmed at ${provision.amount_cents} cents`,
+        status: 409,
+        current_status: provision.status,
+        current_amount_cents: provision.amount_cents,
+      };
+    }
+    const [account] = await tx
+      .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, ctx.orgId))
+      .limit(1);
+
+    return {
+      provision_id: provision.id,
+      cost_id: provision.cost_id,
+      status: "confirmed",
+      original_amount_cents: provision.amount_cents,
+      final_amount_cents: provision.amount_cents,
+      adjustment_cents: "0.0000000000",
+      balance_cents: account?.creditBalanceCents ?? null,
+    };
+  }
+
+  if (provision.status !== "pending") {
+    return {
+      error: `Provision already ${provision.status}`,
+      status: 409,
+      current_status: provision.status,
+      current_amount_cents: provision.amount_cents,
+    };
+  }
+
+  const finalAmount = actualAmountCents ?? provision.amount_cents;
+  const adjustmentCents = subCents(provision.amount_cents, finalAmount);
+
+  if (cmpCents(adjustmentCents, "0") === 0) {
+    await tx
+      .update(transactions)
+      .set({ status: "confirmed", updatedAt: new Date() })
+      .where(eq(transactions.id, provision.id));
+
+    const [account] = await tx
+      .select({
+        creditBalanceCents: billingAccounts.creditBalanceCents,
+        stripeCustomerId: billingAccounts.stripeCustomerId,
+      })
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, ctx.orgId))
+      .limit(1);
+
+    return {
+      provision_id: provision.id,
+      cost_id: provision.cost_id,
+      status: "confirmed",
+      original_amount_cents: provision.amount_cents,
+      final_amount_cents: finalAmount,
+      adjustment_cents: "0.0000000000",
+      balance_cents: account?.creditBalanceCents ?? null,
+      _customerId: account?.stripeCustomerId ?? null,
+      _oldBalance: account?.creditBalanceCents ?? null,
+      _adjustmentCents: "0.0000000000",
+      _newChargeId: null,
+    };
+  }
+
+  // Amount differs: cancel original hold (refund $X) and write a fresh confirmed charge ($Y).
+  const [accountBefore] = await tx
+    .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
+    .from(billingAccounts)
+    .where(eq(billingAccounts.orgId, ctx.orgId))
+    .limit(1);
+  const oldBalance = accountBefore?.creditBalanceCents ?? null;
+
+  await tx
+    .update(billingAccounts)
+    .set({
+      creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${adjustmentCents}::numeric`,
+      updatedAt: new Date(),
+    })
+    .where(eq(billingAccounts.orgId, ctx.orgId));
+
+  await tx
+    .update(transactions)
+    .set({ status: "cancelled", updatedAt: new Date() })
+    .where(eq(transactions.id, provision.id));
+
+  // Carry cost_id onto the replacement row so future calls can still find it.
+  const [newCharge] = await tx
+    .insert(transactions)
+    .values({
+      orgId: ctx.orgId,
+      userId: ctx.userId,
+      runId: ctx.runId,
+      costId: provision.cost_id,
+      type: "debit",
+      amountCents: finalAmount,
+      status: "confirmed",
+      source: "charge",
+      description: provision.description,
+      campaignId: provision.campaign_id ?? undefined,
+      brandIds: provision.brand_ids ?? undefined,
+      workflowSlug: provision.workflow_slug ?? undefined,
+      featureSlug: provision.feature_slug ?? undefined,
+    })
+    .returning();
+
+  const [account] = await tx
+    .select({
+      creditBalanceCents: billingAccounts.creditBalanceCents,
+      stripeCustomerId: billingAccounts.stripeCustomerId,
+    })
+    .from(billingAccounts)
+    .where(eq(billingAccounts.orgId, ctx.orgId))
+    .limit(1);
+
+  // provision_id in the response points to the active confirmed row,
+  // not the cancelled original — so by-cost callers can re-confirm idempotently.
+  return {
+    provision_id: newCharge.id,
+    cost_id: provision.cost_id,
+    status: "confirmed",
+    original_amount_cents: provision.amount_cents,
+    final_amount_cents: finalAmount,
+    adjustment_cents: adjustmentCents,
+    balance_cents: account?.creditBalanceCents ?? null,
+    _customerId: account?.stripeCustomerId ?? null,
+    _oldBalance: oldBalance,
+    _adjustmentCents: adjustmentCents,
+    _newChargeId: newCharge.id,
+  };
+}
+
+interface ConfirmHandlerArgs {
+  req: Request;
+  res: Response;
+  // identifier echoed back in error/log payload — provision_id when the path-id route is used; null when looking up by cost_id
+  reqProvisionId: string | null;
+  reqCostId: string | null;
+  lookup: (tx: Tx, orgId: string) => Promise<ProvisionRow | undefined>;
+}
+
+async function handleConfirm({
+  req,
+  res,
+  reqProvisionId,
+  reqCostId,
+  lookup,
+}: ConfirmHandlerArgs): Promise<void> {
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
     const runId = req.headers["x-run-id"] as string;
-    const wfHeadersRaw = getWorkflowHeaders(req);
-    const wfHeaders = forwardWorkflowHeaders(wfHeadersRaw);
-    const provisionId = req.params.id;
+    const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
     const parsed = ConfirmProvisionRequestSchema.safeParse(req.body);
 
     if (!parsed.success) {
@@ -153,237 +393,76 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
     const { actual_amount_cents } = parsed.data;
 
     const result = await db.transaction(async (tx) => {
-      const provRows = await tx.execute<{
-        id: string;
-        org_id: string;
-        amount_cents: string;
-        status: string;
-        description: string | null;
-        campaign_id: string | null;
-        brand_ids: string[] | null;
-        workflow_slug: string | null;
-        feature_slug: string | null;
-      }>(
-        rawSql`SELECT * FROM transactions WHERE id = ${provisionId} AND org_id = ${orgId} FOR UPDATE`
-      );
-
-      const provision = (provRows as unknown as Array<{
-        id: string;
-        org_id: string;
-        amount_cents: string;
-        status: string;
-        description: string | null;
-        campaign_id: string | null;
-        brand_ids: string[] | null;
-        workflow_slug: string | null;
-        feature_slug: string | null;
-      }>)[0];
-
-      if (!provision) {
-        return {
-          error: "Provision not found" as const,
-          status: 404 as const,
-          current_status: null as string | null,
-          current_amount_cents: null as string | null,
-        };
-      }
-
-      // Idempotent: confirm with same amount on already-confirmed row is a no-op.
-      if (provision.status === "confirmed") {
-        const sameAmount =
-          actual_amount_cents === undefined ||
-          cmpCents(actual_amount_cents, provision.amount_cents) === 0;
-        if (!sameAmount) {
-          return {
-            error: `Provision already confirmed at ${provision.amount_cents} cents` as const,
-            status: 409 as const,
-            current_status: provision.status,
-            current_amount_cents: provision.amount_cents,
-          };
-        }
-        const [account] = await tx
-          .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
-          .from(billingAccounts)
-          .where(eq(billingAccounts.orgId, orgId))
-          .limit(1);
-
-        return {
-          provision_id: provisionId,
-          status: "confirmed" as const,
-          original_amount_cents: provision.amount_cents,
-          final_amount_cents: provision.amount_cents,
-          adjustment_cents: "0.0000000000",
-          balance_cents: account?.creditBalanceCents ?? null,
-        };
-      }
-
-      if (provision.status !== "pending") {
-        return {
-          error: `Provision already ${provision.status}` as const,
-          status: 409 as const,
-          current_status: provision.status,
-          current_amount_cents: provision.amount_cents,
-        };
-      }
-
-      const finalAmount = actual_amount_cents ?? provision.amount_cents;
-      const adjustmentCents = subCents(provision.amount_cents, finalAmount);
-
-      // Same amount → flip status only; no balance change, no new row.
-      if (cmpCents(adjustmentCents, "0") === 0) {
-        await tx
-          .update(transactions)
-          .set({ status: "confirmed", updatedAt: new Date() })
-          .where(eq(transactions.id, provisionId));
-
-        const [account] = await tx
-          .select({
-            creditBalanceCents: billingAccounts.creditBalanceCents,
-            stripeCustomerId: billingAccounts.stripeCustomerId,
-          })
-          .from(billingAccounts)
-          .where(eq(billingAccounts.orgId, orgId))
-          .limit(1);
-
-        return {
-          provision_id: provisionId,
-          status: "confirmed" as const,
-          original_amount_cents: provision.amount_cents,
-          final_amount_cents: finalAmount,
-          adjustment_cents: "0.0000000000",
-          balance_cents: account?.creditBalanceCents ?? null,
-          _customerId: account?.stripeCustomerId ?? null,
-          _oldBalance: account?.creditBalanceCents ?? null,
-          _adjustmentCents: "0.0000000000",
-          _newChargeId: null as string | null,
-        };
-      }
-
-      // Amount differs: cancel original hold (refund $X) and write a fresh confirmed charge ($Y).
-      // Net balance change = (X - Y) = adjustmentCents.
-      const [accountBefore] = await tx
-        .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
-        .from(billingAccounts)
-        .where(eq(billingAccounts.orgId, orgId))
-        .limit(1);
-      const oldBalance = accountBefore?.creditBalanceCents ?? null;
-
-      await tx
-        .update(billingAccounts)
-        .set({
-          creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${adjustmentCents}::numeric`,
-          updatedAt: new Date(),
-        })
-        .where(eq(billingAccounts.orgId, orgId));
-
-      await tx
-        .update(transactions)
-        .set({ status: "cancelled", updatedAt: new Date() })
-        .where(eq(transactions.id, provisionId));
-
-      const [newCharge] = await tx
-        .insert(transactions)
-        .values({
-          orgId,
-          userId,
-          runId,
-          type: "debit",
-          amountCents: finalAmount,
-          status: "confirmed",
-          source: "charge",
-          description: provision.description,
-          campaignId: provision.campaign_id ?? undefined,
-          brandIds: provision.brand_ids ?? undefined,
-          workflowSlug: provision.workflow_slug ?? undefined,
-          featureSlug: provision.feature_slug ?? undefined,
-        })
-        .returning();
-
-      const [account] = await tx
-        .select({
-          creditBalanceCents: billingAccounts.creditBalanceCents,
-          stripeCustomerId: billingAccounts.stripeCustomerId,
-        })
-        .from(billingAccounts)
-        .where(eq(billingAccounts.orgId, orgId))
-        .limit(1);
-
-      return {
-        provision_id: provisionId,
-        status: "confirmed" as const,
-        original_amount_cents: provision.amount_cents,
-        final_amount_cents: finalAmount,
-        adjustment_cents: adjustmentCents,
-        balance_cents: account?.creditBalanceCents ?? null,
-        _customerId: account?.stripeCustomerId ?? null,
-        _oldBalance: oldBalance,
-        _adjustmentCents: adjustmentCents,
-        _newChargeId: newCharge.id,
-      };
+      const provision = await lookup(tx, orgId);
+      return performConfirmInTx(tx, provision, { orgId, userId, runId }, actual_amount_cents);
     });
 
     if ("error" in result && result.error) {
-      const currentStatus = "current_status" in result ? result.current_status : null;
-      const currentAmountCents = "current_amount_cents" in result ? result.current_amount_cents : null;
+      const conflict = result as ConfirmConflict;
       console.warn("[billing-service] provision confirm rejected", {
-        provision_id: provisionId,
+        provision_id: reqProvisionId,
+        cost_id: reqCostId,
         run_id: runId,
         org_id: orgId,
         user_id: userId,
-        status_code: result.status,
-        error: result.error,
-        current_status: currentStatus,
-        current_amount_cents: currentAmountCents,
+        status_code: conflict.status,
+        error: conflict.error,
+        current_status: conflict.current_status,
+        current_amount_cents: conflict.current_amount_cents,
         requested_amount_cents: actual_amount_cents ?? null,
       });
-      res.status(result.status as number).json({
-        error: result.error,
-        provision_id: provisionId,
+      res.status(conflict.status).json({
+        error: conflict.error,
+        provision_id: reqProvisionId,
+        cost_id: reqCostId,
         run_id: runId,
-        current_status: currentStatus,
-        current_amount_cents: currentAmountCents,
+        current_status: conflict.current_status,
+        current_amount_cents: conflict.current_amount_cents,
         requested_amount_cents: actual_amount_cents ?? null,
       });
       return;
     }
 
+    const success = result as ConfirmSuccess;
+
     // Stripe sync: post ONE ceil-delta sized to the net balance change.
-    // The new charge row owns the stripeBalanceTxnId; the cancelled provision row stays null.
-    const customerId = "_customerId" in result ? (result._customerId as string | null) : null;
-    const oldBal = "_oldBalance" in result ? (result._oldBalance as string | null) : null;
-    const newChargeId = "_newChargeId" in result ? (result._newChargeId as string | null) : null;
-    if (customerId && oldBal !== null && newChargeId) {
+    if (success._customerId && success._oldBalance !== undefined && success._oldBalance !== null && success._newChargeId) {
       syncStripeCeilDelta({
         orgId,
         userId,
-        customerId,
-        oldBalance: oldBal,
-        newBalance: result.balance_cents as string,
+        customerId: success._customerId,
+        oldBalance: success._oldBalance,
+        newBalance: success.balance_cents as string,
         description:
-          cmpCents(result.original_amount_cents as string, result.final_amount_cents as string) !== 0
-            ? `Confirmed charge (replacing provision ${provisionId})`
-            : `Provision ${provisionId} confirmed`,
-        ledgerEntryId: newChargeId,
+          cmpCents(success.original_amount_cents, success.final_amount_cents) !== 0
+            ? `Confirmed charge (replacing provision ${success.provision_id})`
+            : `Provision ${success.provision_id} confirmed`,
+        ledgerEntryId: success._newChargeId,
         wfHeaders,
       });
     }
 
-    const adjustment = "_adjustmentCents" in result ? (result._adjustmentCents as string) : "0";
-    const { _customerId: _c, _adjustmentCents: _a, _newChargeId: _n, _oldBalance: _ob, ...response } = result as Record<string, unknown>;
+    const adjustment = success._adjustmentCents ?? "0";
+    const { _customerId, _adjustmentCents, _newChargeId, _oldBalance, ...response } = success;
+    void _customerId;
+    void _adjustmentCents;
+    void _newChargeId;
+    void _oldBalance;
 
     traceEvent({
       runId,
       orgId,
       userId,
       event: "billing.provision.confirmed",
-      detail: { provision_id: provisionId, adjustment_cents: adjustment as unknown as string },
+      detail: { provision_id: success.provision_id, cost_id: success.cost_id, adjustment_cents: adjustment },
       workflowHeaders: wfHeaders,
     });
 
     res.json(response);
   } catch (err) {
     console.error("[billing-service] Error confirming provision", {
-      provision_id: req.params.id,
+      provision_id: reqProvisionId,
+      cost_id: reqCostId,
       run_id: req.headers["x-run-id"],
       org_id: req.headers["x-org-id"],
       user_id: req.headers["x-user-id"],
@@ -391,164 +470,204 @@ router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, 
     });
     res.status(500).json({ error: "Internal server error" });
   }
-});
+}
 
-// POST /v1/credits/provision/:id/cancel — cancel provision, re-credit balance. No miroir row.
-router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, res) => {
+// --- Cancel helpers ---
+
+interface CancelConflict {
+  error: string;
+  status: 404 | 409;
+  current_status: string | null;
+  current_amount_cents: string | null;
+}
+
+interface CancelSuccess {
+  provision_id: string;
+  cost_id: string | null;
+  status: "cancelled";
+  refunded_cents: string;
+  balance_cents: string | null;
+  _customerId?: string | null;
+  _refundedCents?: string;
+  _oldBalance?: string | null;
+}
+
+type CancelResult = CancelConflict | CancelSuccess;
+
+async function performCancelInTx(
+  tx: Tx,
+  provision: ProvisionRow | undefined,
+  ctx: { orgId: string }
+): Promise<CancelResult> {
+  if (!provision) {
+    return {
+      error: "Provision not found",
+      status: 404,
+      current_status: null,
+      current_amount_cents: null,
+    };
+  }
+
+  if (provision.status === "cancelled") {
+    const [account] = await tx
+      .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, ctx.orgId))
+      .limit(1);
+
+    return {
+      provision_id: provision.id,
+      cost_id: provision.cost_id,
+      status: "cancelled",
+      refunded_cents: "0.0000000000",
+      balance_cents: account?.creditBalanceCents ?? null,
+    };
+  }
+
+  if (provision.status !== "pending") {
+    return {
+      error: `Provision already ${provision.status}`,
+      status: 409,
+      current_status: provision.status,
+      current_amount_cents: provision.amount_cents,
+    };
+  }
+
+  const [accountBefore] = await tx
+    .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
+    .from(billingAccounts)
+    .where(eq(billingAccounts.orgId, ctx.orgId))
+    .limit(1);
+  const oldBalance = accountBefore?.creditBalanceCents ?? null;
+
+  await tx
+    .update(billingAccounts)
+    .set({
+      creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${provision.amount_cents}::numeric`,
+      updatedAt: new Date(),
+    })
+    .where(eq(billingAccounts.orgId, ctx.orgId));
+
+  await tx
+    .update(transactions)
+    .set({
+      status: "cancelled",
+      updatedAt: new Date(),
+    })
+    .where(eq(transactions.id, provision.id));
+
+  const [account] = await tx
+    .select({
+      creditBalanceCents: billingAccounts.creditBalanceCents,
+      stripeCustomerId: billingAccounts.stripeCustomerId,
+    })
+    .from(billingAccounts)
+    .where(eq(billingAccounts.orgId, ctx.orgId))
+    .limit(1);
+
+  return {
+    provision_id: provision.id,
+    cost_id: provision.cost_id,
+    status: "cancelled",
+    refunded_cents: provision.amount_cents,
+    balance_cents: account?.creditBalanceCents ?? null,
+    _customerId: account?.stripeCustomerId ?? null,
+    _refundedCents: provision.amount_cents,
+    _oldBalance: oldBalance,
+  };
+}
+
+interface CancelHandlerArgs {
+  req: Request;
+  res: Response;
+  reqProvisionId: string | null;
+  reqCostId: string | null;
+  lookup: (tx: Tx, orgId: string) => Promise<ProvisionRow | undefined>;
+}
+
+async function handleCancel({
+  req,
+  res,
+  reqProvisionId,
+  reqCostId,
+  lookup,
+}: CancelHandlerArgs): Promise<void> {
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
     const runId = req.headers["x-run-id"] as string;
     const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
-    const provisionId = req.params.id;
 
     const result = await db.transaction(async (tx) => {
-      const provRows = await tx.execute<{
-        id: string;
-        org_id: string;
-        amount_cents: string;
-        status: string;
-      }>(
-        rawSql`SELECT * FROM transactions WHERE id = ${provisionId} AND org_id = ${orgId} FOR UPDATE`
-      );
-
-      const provision = (provRows as unknown as Array<{
-        id: string;
-        org_id: string;
-        amount_cents: string;
-        status: string;
-      }>)[0];
-
-      if (!provision) {
-        return {
-          error: "Provision not found" as const,
-          status: 404 as const,
-          current_status: null as string | null,
-          current_amount_cents: null as string | null,
-        };
-      }
-
-      if (provision.status === "cancelled") {
-        const [account] = await tx
-          .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
-          .from(billingAccounts)
-          .where(eq(billingAccounts.orgId, orgId))
-          .limit(1);
-
-        return {
-          provision_id: provisionId,
-          status: "cancelled" as const,
-          refunded_cents: "0.0000000000",
-          balance_cents: account?.creditBalanceCents ?? null,
-        };
-      }
-
-      if (provision.status !== "pending") {
-        return {
-          error: `Provision already ${provision.status}` as const,
-          status: 409 as const,
-          current_status: provision.status,
-          current_amount_cents: provision.amount_cents,
-        };
-      }
-
-      const [accountBefore] = await tx
-        .select({ creditBalanceCents: billingAccounts.creditBalanceCents })
-        .from(billingAccounts)
-        .where(eq(billingAccounts.orgId, orgId))
-        .limit(1);
-      const oldBalance = accountBefore?.creditBalanceCents ?? null;
-
-      await tx
-        .update(billingAccounts)
-        .set({
-          creditBalanceCents: rawSql`${billingAccounts.creditBalanceCents} + ${provision.amount_cents}::numeric`,
-          updatedAt: new Date(),
-        })
-        .where(eq(billingAccounts.orgId, orgId));
-
-      await tx
-        .update(transactions)
-        .set({
-          status: "cancelled",
-          updatedAt: new Date(),
-        })
-        .where(eq(transactions.id, provisionId));
-
-      const [account] = await tx
-        .select({
-          creditBalanceCents: billingAccounts.creditBalanceCents,
-          stripeCustomerId: billingAccounts.stripeCustomerId,
-        })
-        .from(billingAccounts)
-        .where(eq(billingAccounts.orgId, orgId))
-        .limit(1);
-
-      return {
-        provision_id: provisionId,
-        status: "cancelled" as const,
-        refunded_cents: provision.amount_cents,
-        balance_cents: account?.creditBalanceCents ?? null,
-        _customerId: account?.stripeCustomerId ?? null,
-        _refundedCents: provision.amount_cents,
-        _oldBalance: oldBalance,
-      };
+      const provision = await lookup(tx, orgId);
+      return performCancelInTx(tx, provision, { orgId });
     });
 
     if ("error" in result && result.error) {
-      const currentStatus = "current_status" in result ? result.current_status : null;
-      const currentAmountCents = "current_amount_cents" in result ? result.current_amount_cents : null;
+      const conflict = result as CancelConflict;
       console.warn("[billing-service] provision cancel rejected", {
-        provision_id: provisionId,
+        provision_id: reqProvisionId,
+        cost_id: reqCostId,
         run_id: runId,
         org_id: orgId,
         user_id: userId,
-        status_code: result.status,
-        error: result.error,
-        current_status: currentStatus,
-        current_amount_cents: currentAmountCents,
+        status_code: conflict.status,
+        error: conflict.error,
+        current_status: conflict.current_status,
+        current_amount_cents: conflict.current_amount_cents,
       });
-      res.status(result.status as number).json({
-        error: result.error,
-        provision_id: provisionId,
+      res.status(conflict.status).json({
+        error: conflict.error,
+        provision_id: reqProvisionId,
+        cost_id: reqCostId,
         run_id: runId,
-        current_status: currentStatus,
-        current_amount_cents: currentAmountCents,
+        current_status: conflict.current_status,
+        current_amount_cents: conflict.current_amount_cents,
       });
       return;
     }
 
-    const customerId = "_customerId" in result ? result._customerId as string | null : null;
-    const refundedCents = "_refundedCents" in result ? result._refundedCents as string : "0";
-    const oldBal = "_oldBalance" in result ? result._oldBalance as string | null : null;
-    if (customerId && oldBal !== null && cmpCents(refundedCents, "0") > 0) {
+    const success = result as CancelSuccess;
+
+    if (
+      success._customerId &&
+      success._oldBalance !== undefined &&
+      success._oldBalance !== null &&
+      success._refundedCents &&
+      cmpCents(success._refundedCents, "0") > 0
+    ) {
       syncStripeCeilDelta({
         orgId,
         userId,
-        customerId,
-        oldBalance: oldBal,
-        newBalance: result.balance_cents as string,
-        description: `Provision ${provisionId} cancel refund`,
-        ledgerEntryId: provisionId,
+        customerId: success._customerId,
+        oldBalance: success._oldBalance,
+        newBalance: success.balance_cents as string,
+        description: `Provision ${success.provision_id} cancel refund`,
+        ledgerEntryId: success.provision_id,
         wfHeaders,
       });
     }
 
-    const { _customerId: _c, _refundedCents: _r, _oldBalance: _ob, ...response } = result as Record<string, unknown>;
+    const refundedCents = success._refundedCents ?? "0";
+    const { _customerId, _refundedCents, _oldBalance, ...response } = success;
+    void _customerId;
+    void _refundedCents;
+    void _oldBalance;
 
     traceEvent({
       runId,
       orgId,
       userId,
       event: "billing.provision.cancelled",
-      detail: { provision_id: provisionId, refunded_cents: refundedCents },
+      detail: { provision_id: success.provision_id, cost_id: success.cost_id, refunded_cents: refundedCents },
       workflowHeaders: wfHeaders,
     });
 
     res.json(response);
   } catch (err) {
     console.error("[billing-service] Error cancelling provision", {
-      provision_id: req.params.id,
+      provision_id: reqProvisionId,
+      cost_id: reqCostId,
       run_id: req.headers["x-run-id"],
       org_id: req.headers["x-org-id"],
       user_id: req.headers["x-user-id"],
@@ -556,6 +675,56 @@ router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, r
     });
     res.status(500).json({ error: "Internal server error" });
   }
+}
+
+// --- Routes ---
+
+// POST /v1/credits/provision/:id/confirm — confirm provision by billing-internal id
+router.post("/v1/credits/provision/:id/confirm", requireOrgHeaders, async (req, res) => {
+  const provisionId = req.params.id;
+  await handleConfirm({
+    req,
+    res,
+    reqProvisionId: provisionId,
+    reqCostId: null,
+    lookup: (tx, orgId) => lookupProvisionById(tx, provisionId, orgId),
+  });
+});
+
+// POST /v1/credits/provision/:id/cancel — cancel provision by billing-internal id
+router.post("/v1/credits/provision/:id/cancel", requireOrgHeaders, async (req, res) => {
+  const provisionId = req.params.id;
+  await handleCancel({
+    req,
+    res,
+    reqProvisionId: provisionId,
+    reqCostId: null,
+    lookup: (tx, orgId) => lookupProvisionById(tx, provisionId, orgId),
+  });
+});
+
+// POST /v1/credits/provision/by-cost/:cost_id/confirm — confirm provision by natural cost_id key
+router.post("/v1/credits/provision/by-cost/:cost_id/confirm", requireOrgHeaders, async (req, res) => {
+  const costId = req.params.cost_id;
+  await handleConfirm({
+    req,
+    res,
+    reqProvisionId: null,
+    reqCostId: costId,
+    lookup: (tx, orgId) => lookupProvisionByCostId(tx, costId, orgId),
+  });
+});
+
+// POST /v1/credits/provision/by-cost/:cost_id/cancel — cancel provision by natural cost_id key
+router.post("/v1/credits/provision/by-cost/:cost_id/cancel", requireOrgHeaders, async (req, res) => {
+  const costId = req.params.cost_id;
+  await handleCancel({
+    req,
+    res,
+    reqProvisionId: null,
+    reqCostId: costId,
+    lookup: (tx, orgId) => lookupProvisionByCostId(tx, costId, orgId),
+  });
 });
 
 export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -17,7 +17,8 @@ export const ErrorResponseSchema = z
 export const ProvisionConflictResponseSchema = z
   .object({
     error: z.string(),
-    provision_id: z.string().uuid(),
+    provision_id: z.string().uuid().nullable(),
+    cost_id: z.string().uuid().nullable().optional(),
     run_id: z.string().nullable(),
     current_status: z.string().nullable(),
     current_amount_cents: z.string().nullable(),
@@ -89,12 +90,14 @@ export const ProvisionRequestSchema = z
   .object({
     amount_cents: PositiveCentsSchema,
     description: z.string().min(1),
+    cost_id: z.string().uuid().optional(),
   })
   .openapi("ProvisionRequest");
 
 export const ProvisionResponseSchema = z
   .object({
     provision_id: z.string().uuid(),
+    cost_id: z.string().uuid().nullable().optional(),
     balance_cents: CentsStringSchema,
     depleted: z.boolean(),
   })
@@ -109,6 +112,7 @@ export const ConfirmProvisionRequestSchema = z
 export const ConfirmProvisionResponseSchema = z
   .object({
     provision_id: z.string().uuid(),
+    cost_id: z.string().uuid().nullable().optional(),
     status: z.literal("confirmed"),
     original_amount_cents: CentsStringSchema,
     final_amount_cents: CentsStringSchema,
@@ -120,11 +124,18 @@ export const ConfirmProvisionResponseSchema = z
 export const CancelProvisionResponseSchema = z
   .object({
     provision_id: z.string().uuid(),
+    cost_id: z.string().uuid().nullable().optional(),
     status: z.literal("cancelled"),
     refunded_cents: CentsStringSchema,
     balance_cents: CentsStringSchema.nullable(),
   })
   .openapi("CancelProvisionResponse");
+
+export const ConfirmByCostRequestSchema = z
+  .object({
+    actual_amount_cents: PositiveCentsSchema.optional(),
+  })
+  .openapi("ConfirmByCostRequest");
 
 // --- Authorize ---
 
@@ -616,6 +627,64 @@ registry.registerPath({
     },
     409: {
       description: "Provision already confirmed or cancelled",
+      content: { "application/json": { schema: ProvisionConflictResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/credits/provision/by-cost/{cost_id}/confirm",
+  summary: "Confirm a provision looked up by cost_id (natural key)",
+  description:
+    "Confirms the most recent provision row for the given cost_id. " +
+    "Use this when callers (e.g. runs-service) hold the cost_id but not the billing-internal provision_id. " +
+    "Idempotent: re-confirming with the same amount returns 200.",
+  request: {
+    headers: protectedHeaders,
+    params: z.object({ cost_id: z.string().uuid() }),
+    body: {
+      content: { "application/json": { schema: ConfirmByCostRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Provision confirmed",
+      content: { "application/json": { schema: ConfirmProvisionResponseSchema } },
+    },
+    404: {
+      description: "No provision found for cost_id",
+      content: { "application/json": { schema: ProvisionConflictResponseSchema } },
+    },
+    409: {
+      description: "Existing provision is in incompatible state (cancelled, or confirmed at a different amount)",
+      content: { "application/json": { schema: ProvisionConflictResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/credits/provision/by-cost/{cost_id}/cancel",
+  summary: "Cancel a provision looked up by cost_id (natural key)",
+  description:
+    "Cancels the most recent provision row for the given cost_id. " +
+    "Idempotent: re-cancelling an already-cancelled cost_id returns 200.",
+  request: {
+    headers: protectedHeaders,
+    params: z.object({ cost_id: z.string().uuid() }),
+  },
+  responses: {
+    200: {
+      description: "Provision cancelled",
+      content: { "application/json": { schema: CancelProvisionResponseSchema } },
+    },
+    404: {
+      description: "No provision found for cost_id",
+      content: { "application/json": { schema: ProvisionConflictResponseSchema } },
+    },
+    409: {
+      description: "Existing provision is confirmed (cannot cancel)",
       content: { "application/json": { schema: ProvisionConflictResponseSchema } },
     },
   },

--- a/tests/integration/provisions.test.ts
+++ b/tests/integration/provisions.test.ts
@@ -489,6 +489,197 @@ describe("Credit provision endpoints", () => {
     });
   });
 
+  describe("cost_id natural key — by-cost/:cost_id endpoints", () => {
+    const costIdA = "cccc0000-0000-0000-0000-00000000000a";
+    const costIdB = "cccc0000-0000-0000-0000-00000000000b";
+    const unknownCostId = "cccc0000-0000-0000-0000-0000ffffffff";
+
+    it("persists cost_id on provision row when provided", async () => {
+      await insertTestAccount({ orgId, creditBalanceCents: 500 });
+
+      const res = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "with cost_id", cost_id: costIdA });
+
+      expect(res.status).toBe(200);
+      expect(res.body.cost_id).toBe(costIdA);
+
+      const [row] = await db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.id, res.body.provision_id));
+      expect(row.costId).toBe(costIdA);
+    });
+
+    it("confirm by-cost/:cost_id flips status; second call same amount is idempotent", async () => {
+      await insertTestAccount({ orgId, creditBalanceCents: 500 });
+
+      const provRes = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "by-cost flow", cost_id: costIdA });
+      expect(provRes.status).toBe(200);
+
+      const first = await request(app)
+        .post(`/v1/credits/provision/by-cost/${costIdA}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({});
+      expect(first.status).toBe(200);
+      expect(first.body.status).toBe("confirmed");
+      expect(first.body.cost_id).toBe(costIdA);
+      expect(first.body.provision_id).toBe(provRes.body.provision_id);
+
+      const second = await request(app)
+        .post(`/v1/credits/provision/by-cost/${costIdA}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({});
+      expect(second.status).toBe(200);
+      expect(second.body.status).toBe("confirmed");
+      expect(second.body.adjustment_cents).toBe("0.0000000000");
+
+      const all = await db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.orgId, orgId));
+      expect(all).toHaveLength(1);
+      expect(all[0].status).toBe("confirmed");
+    });
+
+    it("returns 409 with structured body when re-confirming at a different amount", async () => {
+      await insertTestAccount({ orgId, creditBalanceCents: 500 });
+
+      await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "x", cost_id: costIdA });
+
+      const first = await request(app)
+        .post(`/v1/credits/provision/by-cost/${costIdA}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({ actual_amount_cents: 100 });
+      expect(first.status).toBe(200);
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      const second = await request(app)
+        .post(`/v1/credits/provision/by-cost/${costIdA}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({ actual_amount_cents: 150 });
+
+      expect(second.status).toBe(409);
+      expect(second.body.cost_id).toBe(costIdA);
+      expect(second.body.current_status).toBe("confirmed");
+      expect(second.body.current_amount_cents).toBe("100.0000000000");
+      expect(second.body.requested_amount_cents).toBe("150.0000000000");
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[billing-service] provision confirm rejected",
+        expect.objectContaining({
+          cost_id: costIdA,
+          current_status: "confirmed",
+          current_amount_cents: "100.0000000000",
+          requested_amount_cents: "150.0000000000",
+        })
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("returns 409 when confirming a cancelled cost_id", async () => {
+      await insertTestAccount({ orgId, creditBalanceCents: 500 });
+
+      await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "x", cost_id: costIdA });
+
+      const cancelRes = await request(app)
+        .post(`/v1/credits/provision/by-cost/${costIdA}/cancel`)
+        .set(getAuthHeaders(orgId))
+        .send();
+      expect(cancelRes.status).toBe(200);
+
+      const confirmRes = await request(app)
+        .post(`/v1/credits/provision/by-cost/${costIdA}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({});
+      expect(confirmRes.status).toBe(409);
+      expect(confirmRes.body.cost_id).toBe(costIdA);
+      expect(confirmRes.body.current_status).toBe("cancelled");
+    });
+
+    it("re-cancel of cancelled cost_id is idempotent (200)", async () => {
+      await insertTestAccount({ orgId, creditBalanceCents: 500 });
+
+      await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "x", cost_id: costIdA });
+
+      const first = await request(app)
+        .post(`/v1/credits/provision/by-cost/${costIdA}/cancel`)
+        .set(getAuthHeaders(orgId))
+        .send();
+      expect(first.status).toBe(200);
+      expect(first.body.refunded_cents).toBe("100.0000000000");
+
+      const second = await request(app)
+        .post(`/v1/credits/provision/by-cost/${costIdA}/cancel`)
+        .set(getAuthHeaders(orgId))
+        .send();
+      expect(second.status).toBe(200);
+      expect(second.body.refunded_cents).toBe("0.0000000000");
+      expect(second.body.cost_id).toBe(costIdA);
+    });
+
+    it("returns 404 with cost_id in body for unknown cost_id", async () => {
+      await insertTestAccount({ orgId });
+
+      const res = await request(app)
+        .post(`/v1/credits/provision/by-cost/${unknownCostId}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({});
+
+      expect(res.status).toBe(404);
+      expect(res.body.cost_id).toBe(unknownCostId);
+      expect(res.body.provision_id).toBe(null);
+      expect(res.body.current_status).toBe(null);
+    });
+
+    it("amount-mismatch confirm carries cost_id onto replacement row; subsequent by-cost lookup hits the latest row", async () => {
+      await insertTestAccount({ orgId, creditBalanceCents: 500 });
+
+      const provRes = await request(app)
+        .post("/v1/credits/provision")
+        .set(getAuthHeaders(orgId))
+        .send({ amount_cents: 100, description: "x", cost_id: costIdB });
+
+      const confirmRes = await request(app)
+        .post(`/v1/credits/provision/by-cost/${costIdB}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({ actual_amount_cents: 60 });
+      expect(confirmRes.status).toBe(200);
+      expect(confirmRes.body.adjustment_cents).toBe("40.0000000000");
+      expect(confirmRes.body.cost_id).toBe(costIdB);
+
+      // Replacement row carries cost_id; subsequent same-amount confirm idempotently finds it.
+      const reConfirm = await request(app)
+        .post(`/v1/credits/provision/by-cost/${costIdB}/confirm`)
+        .set(getAuthHeaders(orgId))
+        .send({ actual_amount_cents: 60 });
+      expect(reConfirm.status).toBe(200);
+      expect(reConfirm.body.provision_id).toBe(confirmRes.body.provision_id);
+      expect(reConfirm.body.provision_id).not.toBe(provRes.body.provision_id);
+
+      const rows = await db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.costId, costIdB));
+      expect(rows).toHaveLength(2);
+      expect(rows.find((r) => r.status === "cancelled")?.amountCents).toBe("100.0000000000");
+      expect(rows.find((r) => r.status === "confirmed")?.amountCents).toBe("60.0000000000");
+    });
+  });
+
   describe("No auto-reload on provision (reload only in authorize)", () => {
     it("does not auto-reload even when balance drops below threshold", async () => {
       await insertTestAccount({

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -95,6 +95,8 @@ beforeAll(async () => {
   await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "brand_ids" text[]`;
   await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "stripe_payment_intent_id" text`;
   await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "type" text DEFAULT 'debit' NOT NULL`;
+  await sql`ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "cost_id" uuid`;
+  await sql`CREATE INDEX IF NOT EXISTS "idx_transactions_cost_id" ON "transactions" USING btree ("cost_id")`;
 
   // Renamed indexes (rename path) + create-if-missing (fresh DB path).
   await sql`ALTER INDEX IF EXISTS "idx_credit_ledger_org_id" RENAME TO "idx_transactions_org_id"`;


### PR DESCRIPTION
## Summary

- Adds `transactions.cost_id` (uuid, nullable, indexed) so external callers can address provisions by the natural key (`runs_costs.id`) instead of a billing-internal `provision_id`.
- New endpoints: `POST /v1/credits/provision/by-cost/:cost_id/{confirm,cancel}`. Lookup picks the most recent row for the cost_id (FOR UPDATE).
- Replacement rows on amount-mismatch confirm now carry the same `cost_id`, so subsequent confirms still resolve to the active row. `provision_id` in the response also points to the active confirmed row, not the cancelled original.
- Old `:id`-path endpoints (`/provision/:id/{confirm,cancel}`) stay live unchanged for back-compat during the runs-service migration.
- Conflict response body and `console.warn` log line now include `cost_id` alongside the existing `provision_id`, `current_status`, `current_amount_cents`, `requested_amount_cents`.

## Why

Production bug seen on run `fe0d6b64-5576-45cb-ac3c-1ddaabd07128` (live since at least 2026-04-26): runs-service was creating ONE provision for N cost rows in a single POST, then per-cost webhooks each tried to confirm the SAME provision_id. The first call replaced/cancelled the row and the second hit 409 ("Provision already cancelled"), silently dropping the second cost from billing. The architectural fix is to decouple the two services on the natural key — billing tracks `cost_id`, runs-service stops storing any billing id.

## ⚠️ Deployment ordering

**This service ships first.** runs-service must NOT auto-merge its sister PR until this one is live in the same env (staging-then-prod). The runs-service change drops `runs_costs.billing_provision_id` and switches calls to the new by-cost endpoints — if it ships before billing has the column + endpoints, runs-service will 404.

## Test plan

- [x] `pnpm test` — 222 tests, all green (24 in provisions.test.ts including 7 new `cost_id`-flow tests covering: persist, idempotent same-amount re-confirm, 409 on amount mismatch with structured body + warn log, 409 on confirming cancelled cost_id, idempotent re-cancel, 404 with cost_id echoed, replacement-row cost_id carryover)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm run build` — clean
- [x] `openapi.json` regenerated and committed
- [ ] Manual: hit `/by-cost/:cost_id/{confirm,cancel}` against staging once deployed, watch warn lines on a deliberately-replayed mismatch confirm