### PR TITLE
ci: pin pnpm to v10, bump Node to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Pin `pnpm/action-setup@v4` to `version: 10` (was `latest`)
- Bump `actions/setup-node@v4` to `node-version: 22` (was `20`)

## Why

`pnpm@latest` rolled to `11.0.8`, which requires Node ≥ 22.13 — it uses `node:sqlite` (a built-in introduced in Node 22). Every fresh CI run on staging now errors at the action-setup step:

```
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

Pinning pnpm prevents the next 12.x release from breaking the same way.

## Test plan

- [ ] CI passes on this PR (proves the fix on the branch run)
- [ ] After merge, staging CI is green again