### PR TITLE
feat(billing): add reconcileBillingRuns + rename existing reconcile

### DIFF
--- a/src/lib/ledger.ts
+++ b/src/lib/ledger.ts
@@ -34,7 +34,7 @@ export function syncStripeCeilDelta(args: {
   // Note: do NOT pass `ledgerEntryId` as `idempotencyKey` here. Multiple distinct
   // Stripe operations (initial debit, provision adjustment, cancel refund) target the
   // same ledger row id with different params; reusing the key would trigger
-  // StripeIdempotencyError. Recovery via reconcile() Check 3 owns idempotency keying.
+  // StripeIdempotencyError. Recovery via reconcileBillingStripe() Check 3 owns idempotency keying.
   createBalanceTransaction(
     args.orgId,
     args.userId,

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -1,0 +1,54 @@
+/** Client for fetching expected per-run cost totals from runs-service. */
+
+export interface RunExpectedTotal {
+  run_id: string;
+  expected_cents: string;
+}
+
+export interface RunsExpectedTotalsResult {
+  total_expected_cents: string;
+  runs: RunExpectedTotal[];
+}
+
+function getRunsServiceConfig() {
+  const url = process.env.RUNS_SERVICE_URL;
+  const apiKey = process.env.RUNS_SERVICE_API_KEY;
+  if (!url || !apiKey) return null;
+  return { url, apiKey };
+}
+
+/**
+ * Fetch expected per-run cost totals (platform actuals on completed/failed runs)
+ * for an org. Used by reconcileBillingRuns to detect drift between billing-side
+ * confirmed charges and runs-side recorded actuals.
+ *
+ * Returns null when runs-service is not configured (local dev / unit tests where
+ * runs-service is intentionally absent). Callers treat null as "skip reconcile".
+ * Network or HTTP errors throw — callers decide whether to swallow per-org.
+ */
+export async function fetchRunsExpectedTotals(
+  orgId: string,
+  wfHeaders: Record<string, string>
+): Promise<RunsExpectedTotalsResult | null> {
+  const config = getRunsServiceConfig();
+  if (!config) return null;
+
+  const res = await fetch(
+    `${config.url}/v1/internal/runs-expected-totals?org_id=${encodeURIComponent(orgId)}`,
+    {
+      headers: {
+        "x-api-key": config.apiKey,
+        ...wfHeaders,
+      },
+    }
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `runs-service runs-expected-totals failed for org ${orgId}: ${res.status} ${body}`
+    );
+  }
+
+  return (await res.json()) as RunsExpectedTotalsResult;
+}

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -16,6 +16,7 @@ import { sendEmail } from "../lib/email-client.js";
 import { resolveRequiredCents } from "../lib/costs-client.js";
 import { findOrCreateAccount } from "../lib/account.js";
 import { traceEvent } from "../lib/trace-event.js";
+import { fetchRunsExpectedTotals } from "../lib/runs-client.js";
 import { addCents, subCents, gte as gteCents, isDepleted, cmpCents } from "../lib/cents.js";
 
 const router = Router();
@@ -43,26 +44,35 @@ interface AccountRow {
   stripe_payment_method_id: string | null;
 }
 
-// Namespace key for advisory locks scoped to billing reconcile (any constant int4).
-const RECONCILE_LOCK_NAMESPACE = 0x42111331;
+// Namespace keys for advisory locks scoped to billing reconciles (constant int4 each).
+// Distinct namespaces per reconcile flavor so a Stripe reconcile lock does not
+// block a Runs reconcile (or vice versa) within the same /authorize call.
+const RECONCILE_BILLING_STRIPE_LOCK_NAMESPACE = 0x42111331;
+const RECONCILE_BILLING_RUNS_LOCK_NAMESPACE = 0x42111332;
 
 /**
- * Reconcile the billing account against the ledger and Stripe.
- * Runs 3 self-healing checks before authorize checks sufficiency.
+ * Reconcile the billing account against its own ledger and Stripe.
+ * Runs 3 self-healing checks before authorize checks sufficiency:
+ *   1. cache (billing_accounts.credit_balance_cents) vs ledger sum
+ *   2. Stripe payment intents missing from the ledger (recover reload rows)
+ *   3. Ledger rows confirmed but never synced to Stripe (push to Stripe)
+ *
+ * Scope: intra-billing + Stripe only. Does NOT reconcile against runs-service —
+ * that is `reconcileBillingRuns`.
  *
  * Wrapped in a transaction with `pg_try_advisory_xact_lock` keyed on orgId — concurrent
  * /authorize calls for the same org skip reconcile (the in-flight one will fix any drift).
  * Without the lock, N parallel reconcilers each detect the same drift, insert duplicate
  * ledger rows for the same Stripe PI, and post duplicate balance txns.
  */
-async function reconcile(
+async function reconcileBillingStripe(
   orgId: string,
   userId: string,
   wfHeaders: Record<string, string>
 ): Promise<void> {
   await db.transaction(async (tx) => {
     const lockRows = (await tx.execute(
-      rawSql`SELECT pg_try_advisory_xact_lock(${RECONCILE_LOCK_NAMESPACE}::int, hashtext(${orgId})) AS locked`
+      rawSql`SELECT pg_try_advisory_xact_lock(${RECONCILE_BILLING_STRIPE_LOCK_NAMESPACE}::int, hashtext(${orgId})) AS locked`
     )) as unknown as { locked: boolean }[];
     if (!lockRows[0]?.locked) {
       return;
@@ -193,6 +203,200 @@ async function reconcile(
       }
     }
   });
+}
+
+/**
+ * Reconcile the billing ledger against runs-service recorded actuals.
+ *
+ * Detects per-run drift between:
+ *   - billing-side: sum of confirmed `charge` transactions per `run_id`
+ *   - runs-side:    sum of `runs_costs.total_cost_in_usd_cents` for platform actuals
+ *
+ * On gap > 0 (under-billed): inserts a `(debit, charge, confirmed, gap)` row and
+ * decrements the balance — catching up revenue that should have been billed.
+ * On gap < 0 (over-billed): inserts a `(credit, refund, confirmed, |gap|)` row
+ * and increments the balance — refunding the over-charge.
+ *
+ * Exact, no threshold: even a sub-cent gap is corrected. Idempotent: the newly
+ * inserted row contributes to `billed` on the next call so subsequent reconciles
+ * compute gap=0 and noop. No state column required.
+ *
+ * Global gate: org-level totals are compared first (one SUM per side); the
+ * per-run sweep only runs when totals diverge. Trade-off: per-run drifts that
+ * exactly cancel at the org level go uncorrected (rare — historical drift is
+ * one-sided under-billing). The org balance remains correct in that case; only
+ * the per-row ledger labels are off.
+ *
+ * Cross-service call: a single HTTP GET to runs-service. Performed BEFORE the
+ * DB transaction opens so we never hold a billing-side row lock across an
+ * external network round-trip.
+ */
+async function reconcileBillingRuns(
+  orgId: string,
+  userId: string,
+  runId: string,
+  wfHeaders: Record<string, string>
+): Promise<void> {
+  let expectedFromRuns: Awaited<ReturnType<typeof fetchRunsExpectedTotals>>;
+  try {
+    expectedFromRuns = await fetchRunsExpectedTotals(orgId, wfHeaders);
+  } catch (err) {
+    // Best-effort: do not break /authorize on a transient runs-service outage.
+    // Future /authorize will retry; missed reconciles converge on the next run.
+    console.error(
+      `[billing-service] reconcileBillingRuns: runs-service fetch failed for org ${orgId}:`,
+      err
+    );
+    return;
+  }
+  if (!expectedFromRuns) return; // runs-service not configured (dev / test)
+
+  const result = await db.transaction(async (tx) => {
+    const lockRows = (await tx.execute(
+      rawSql`SELECT pg_try_advisory_xact_lock(${RECONCILE_BILLING_RUNS_LOCK_NAMESPACE}::int, hashtext(${orgId})) AS locked`
+    )) as unknown as { locked: boolean }[];
+    if (!lockRows[0]?.locked) return null;
+
+    const accountRows = (await tx.execute(
+      rawSql`SELECT * FROM billing_accounts WHERE org_id = ${orgId} FOR UPDATE`
+    )) as unknown as AccountRow[];
+    const account = accountRows[0];
+    if (!account) return null;
+
+    // Global gate: org-level confirmed charges vs runs-side expected.
+    const billedRows = (await tx.execute(
+      rawSql`SELECT COALESCE(SUM(amount_cents), 0)::numeric(16,10)::text AS total_billed
+             FROM transactions
+             WHERE org_id = ${orgId}
+               AND source = 'charge'
+               AND status = 'confirmed'`
+    )) as unknown as { total_billed: string }[];
+    const totalBilled = billedRows[0]?.total_billed ?? "0";
+
+    if (cmpCents(expectedFromRuns.total_expected_cents, totalBilled) === 0) {
+      return null; // no org-level drift — skip per-run sweep
+    }
+
+    // Per-run sweep.
+    const collected: {
+      entryId: string;
+      runId: string;
+      oldBalance: string;
+      newBalance: string;
+      description: string;
+      action: "debit" | "refund";
+      gap: string;
+    }[] = [];
+    let currentBalance = account.credit_balance_cents;
+
+    for (const { run_id: targetRunId, expected_cents } of expectedFromRuns.runs) {
+      const sumRows = (await tx.execute(
+        rawSql`SELECT COALESCE(SUM(amount_cents), 0)::numeric(16,10)::text AS billed
+               FROM transactions
+               WHERE run_id = ${targetRunId}
+                 AND org_id = ${orgId}
+                 AND source = 'charge'
+                 AND status = 'confirmed'`
+      )) as unknown as { billed: string }[];
+      const billed = sumRows[0]?.billed ?? "0";
+
+      const gap = subCents(expected_cents, billed);
+      const cmp = cmpCents(gap, "0");
+      if (cmp === 0) continue;
+
+      const isUnderBilled = cmp > 0;
+      const absGap = isUnderBilled ? gap : subCents("0", gap);
+      const oldBalance = currentBalance;
+      const newBalance = isUnderBilled
+        ? subCents(oldBalance, absGap)
+        : addCents(oldBalance, absGap);
+      const description = isUnderBilled
+        ? `Reconcile run ${targetRunId}: under-billed by ${absGap}`
+        : `Reconcile run ${targetRunId}: over-billed by ${absGap}`;
+
+      await tx
+        .update(billingAccounts)
+        .set({ creditBalanceCents: newBalance, updatedAt: new Date() })
+        .where(eq(billingAccounts.orgId, orgId));
+
+      const [entry] = await tx
+        .insert(transactions)
+        .values({
+          orgId,
+          userId,
+          runId: targetRunId,
+          type: isUnderBilled ? "debit" : "credit",
+          amountCents: absGap,
+          status: "confirmed",
+          source: isUnderBilled ? "charge" : "refund",
+          description,
+        })
+        .returning();
+
+      currentBalance = newBalance;
+      collected.push({
+        entryId: entry.id,
+        runId: targetRunId,
+        oldBalance,
+        newBalance,
+        description,
+        action: isUnderBilled ? "debit" : "refund",
+        gap,
+      });
+
+      console.warn(
+        `[billing-service] reconcileBillingRuns gap ${isUnderBilled ? ">" : "<"} 0`,
+        {
+          org_id: orgId,
+          run_id: targetRunId,
+          gap_cents: gap,
+          billed_cents: billed,
+          expected_cents,
+        }
+      );
+    }
+
+    return { customerId: account.stripe_customer_id, collected };
+  });
+
+  if (!result || result.collected.length === 0) return;
+
+  // Post-commit: Stripe ceil-delta sync + trace event for each correction.
+  for (const { entryId, oldBalance, newBalance, description } of result.collected) {
+    if (result.customerId) {
+      syncStripeCeilDelta({
+        orgId,
+        userId,
+        customerId: result.customerId,
+        oldBalance,
+        newBalance,
+        description,
+        ledgerEntryId: entryId,
+        wfHeaders,
+      });
+    }
+  }
+
+  traceEvent(
+    runId,
+    {
+      service: "billing-service",
+      event: "billing.reconcile-run.applied",
+      data: {
+        fixed_count: result.collected.length,
+        entries: result.collected.map((c) => ({
+          run_id: c.runId,
+          gap_cents: c.gap,
+          action: c.action,
+        })),
+      },
+    },
+    {
+      "x-org-id": orgId,
+      "x-user-id": userId,
+      ...wfHeaders,
+    }
+  );
 }
 
 // POST /v1/credits/deduct — deduct credits from org balance (allows negative balances)
@@ -348,10 +552,13 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
     // Ensure account exists (auto-create with $2 trial credit if new)
     await findOrCreateAccount(orgId, userId, wfHeaders);
 
-    // Run reconciliation checks before checking sufficiency.
-    // reconcile() acquires a per-org advisory lock; concurrent calls for the same org
+    // Run reconciliation checks before checking sufficiency. Each acquires its
+    // own per-org advisory lock; concurrent /authorize calls for the same org
     // skip and rely on the in-flight reconcile to fix any drift.
-    await reconcile(orgId, userId, wfHeaders);
+    // Order: Stripe-side first (cheap-when-clean, no external dependency cost
+    // when ledger is healthy) → runs-side second (depends on runs-service HTTP).
+    await reconcileBillingStripe(orgId, userId, wfHeaders);
+    await reconcileBillingRuns(orgId, userId, runId, wfHeaders);
 
     const result = await db.transaction(async (tx) => {
       const rows = await tx.execute(

--- a/tests/integration/reconcile-billing-runs.test.ts
+++ b/tests/integration/reconcile-billing-runs.test.ts
@@ -1,0 +1,490 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { eq, and, desc } from "drizzle-orm";
+import { db } from "../../src/db/index.js";
+import { transactions, billingAccounts } from "../../src/db/schema.js";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
+import { setupStripeMocks } from "../helpers/mock-stripe.js";
+
+const orgId = "00000000-0000-0000-0000-000000000bb1";
+const userId = "00000000-0000-0000-0000-000000000099";
+
+const authorizeBody = {
+  items: [{ costName: "anthropic-sonnet-4-5-tokens-input", quantity: 1000 }],
+  description: "reconcile-billing-runs test",
+};
+
+describe("Credits authorize — reconcileBillingRuns (billing <> runs-service drift)", () => {
+  const app = createTestApp();
+  let stripeMocks: ReturnType<typeof setupStripeMocks>;
+  let fetchRunsExpectedTotalsSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    stripeMocks = setupStripeMocks();
+    await cleanTestData();
+
+    // costs-service mock — required so /authorize resolves prices without HTTP
+    const costsClient = await import("../../src/lib/costs-client.js");
+    vi.spyOn(costsClient, "resolveRequiredCents").mockResolvedValue("10.0000000000");
+
+    // runs-service mock — default to "no drift" so other tests don't accidentally
+    // mutate the ledger. Each test below overrides with its own expectations.
+    const runsClient = await import("../../src/lib/runs-client.js");
+    fetchRunsExpectedTotalsSpy = vi.fn().mockResolvedValue({
+      total_expected_cents: "0.0000000000",
+      runs: [],
+    });
+    vi.spyOn(runsClient, "fetchRunsExpectedTotals").mockImplementation(
+      fetchRunsExpectedTotalsSpy
+    );
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("no drift: total expected matches total billed → no reconcile rows, balance unchanged", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_norun",
+      creditBalanceCents: 500,
+    });
+
+    // Welcome credit + pre-existing $5 charge → ledger sum = $495 = cache
+    // (so reconcileBillingStripe Check 1 finds no drift).
+    const runR1 = "00000000-0000-0000-0000-000000000ba1";
+    await db.insert(transactions).values([
+      {
+        orgId,
+        userId,
+        type: "credit",
+        amountCents: "500.0000000000",
+        status: "confirmed",
+        source: "welcome",
+        description: "Trial credit",
+      },
+      {
+        orgId,
+        userId,
+        runId: runR1,
+        type: "debit",
+        amountCents: "5.0000000000",
+        status: "confirmed",
+        source: "charge",
+        description: "existing charge",
+      },
+    ]);
+    // Cache must equal ledger sum or Check 1 would fix it before reconcileBillingRuns runs.
+    await db
+      .update(billingAccounts)
+      .set({ creditBalanceCents: "495.0000000000" })
+      .where(eq(billingAccounts.orgId, orgId));
+
+    fetchRunsExpectedTotalsSpy.mockResolvedValue({
+      total_expected_cents: "5.0000000000",
+      runs: [{ run_id: runR1, expected_cents: "5.0000000000" }],
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+
+    // Exactly the two pre-existing rows — no reconcile inserts.
+    const allTxns = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.orgId, orgId));
+    expect(allTxns).toHaveLength(2);
+    expect(allTxns.some((t) => t.description?.startsWith("Reconcile run"))).toBe(false);
+
+    const [acct] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId));
+    expect(acct.creditBalanceCents).toBe("495.0000000000");
+  });
+
+  it("under-billed: inserts catch-up debit per run and decrements balance", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_under",
+      creditBalanceCents: 100,
+    });
+
+    const runR1 = "00000000-0000-0000-0000-000000000ba2";
+    // billed = $0 (no existing confirmed charge), expected = $3 → gap = $3
+    fetchRunsExpectedTotalsSpy.mockResolvedValue({
+      total_expected_cents: "3.0000000000",
+      runs: [{ run_id: runR1, expected_cents: "3.0000000000" }],
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+
+    const recon = await db
+      .select()
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.orgId, orgId),
+          eq(transactions.runId, runR1)
+        )
+      );
+    expect(recon).toHaveLength(1);
+    expect(recon[0].type).toBe("debit");
+    expect(recon[0].source).toBe("charge");
+    expect(recon[0].status).toBe("confirmed");
+    expect(recon[0].amountCents).toBe("3.0000000000");
+    expect(recon[0].description).toContain("under-billed by 3.0000000000");
+
+    const [acct] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId));
+    expect(acct.creditBalanceCents).toBe("97.0000000000");
+  });
+
+  it("over-billed: inserts refund credit per run and increments balance", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_over",
+      creditBalanceCents: 100,
+    });
+
+    const runR1 = "00000000-0000-0000-0000-000000000ba3";
+    // Welcome credit $100 + pre-existing $5 over-charge → ledger sum = $95 = cache.
+    await db.insert(transactions).values([
+      {
+        orgId,
+        userId,
+        type: "credit",
+        amountCents: "100.0000000000",
+        status: "confirmed",
+        source: "welcome",
+        description: "Trial credit",
+      },
+      {
+        orgId,
+        userId,
+        runId: runR1,
+        type: "debit",
+        amountCents: "5.0000000000",
+        status: "confirmed",
+        source: "charge",
+        description: "existing over-charge",
+      },
+    ]);
+    await db
+      .update(billingAccounts)
+      .set({ creditBalanceCents: "95.0000000000" })
+      .where(eq(billingAccounts.orgId, orgId));
+
+    fetchRunsExpectedTotalsSpy.mockResolvedValue({
+      total_expected_cents: "3.0000000000",
+      runs: [{ run_id: runR1, expected_cents: "3.0000000000" }],
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+
+    const refunds = await db
+      .select()
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.orgId, orgId),
+          eq(transactions.source, "refund")
+        )
+      );
+    expect(refunds).toHaveLength(1);
+    expect(refunds[0].type).toBe("credit");
+    expect(refunds[0].amountCents).toBe("2.0000000000");
+    expect(refunds[0].runId).toBe(runR1);
+    expect(refunds[0].description).toContain("over-billed by 2.0000000000");
+
+    const [acct] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId));
+    expect(acct.creditBalanceCents).toBe("97.0000000000");
+  });
+
+  it("idempotent: re-running with the same expected totals after a reconcile is a noop", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_idem",
+      creditBalanceCents: 100,
+    });
+
+    const runR1 = "00000000-0000-0000-0000-000000000ba4";
+    fetchRunsExpectedTotalsSpy.mockResolvedValue({
+      total_expected_cents: "2.5000000000",
+      runs: [{ run_id: runR1, expected_cents: "2.5000000000" }],
+    });
+
+    await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    const txnsAfterFirst = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.runId, runR1));
+    expect(txnsAfterFirst).toHaveLength(1);
+    expect(txnsAfterFirst[0].amountCents).toBe("2.5000000000");
+
+    // Second call: same expected (2.5), billed now also 2.5 from prior reconcile → gap=0
+    await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    const txnsAfterSecond = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.runId, runR1));
+    expect(txnsAfterSecond).toHaveLength(1); // no new row
+  });
+
+  it("preserves fractional precision: expected=1.2345678901 vs billed=0.5 → debit=0.7345678901", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_frac",
+      creditBalanceCents: 100,
+    });
+
+    const runR1 = "00000000-0000-0000-0000-000000000ba5";
+    // Welcome credit $100 + partial $0.5 charge → ledger sum $99.5 = cache.
+    await db.insert(transactions).values([
+      {
+        orgId,
+        userId,
+        type: "credit",
+        amountCents: "100.0000000000",
+        status: "confirmed",
+        source: "welcome",
+        description: "Trial credit",
+      },
+      {
+        orgId,
+        userId,
+        runId: runR1,
+        type: "debit",
+        amountCents: "0.5000000000",
+        status: "confirmed",
+        source: "charge",
+        description: "fractional partial charge",
+      },
+    ]);
+    await db
+      .update(billingAccounts)
+      .set({ creditBalanceCents: "99.5000000000" })
+      .where(eq(billingAccounts.orgId, orgId));
+
+    fetchRunsExpectedTotalsSpy.mockResolvedValue({
+      total_expected_cents: "1.2345678901",
+      runs: [{ run_id: runR1, expected_cents: "1.2345678901" }],
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+    expect(res.status).toBe(200);
+
+    const recon = await db
+      .select()
+      .from(transactions)
+      .where(
+        and(
+          eq(transactions.orgId, orgId),
+          eq(transactions.runId, runR1),
+          eq(transactions.description, "Reconcile run " + runR1 + ": under-billed by 0.7345678901")
+        )
+      );
+    expect(recon).toHaveLength(1);
+    expect(recon[0].amountCents).toBe("0.7345678901");
+  });
+
+  it("global gate: total expected == total billed → per-run sweep skipped even when individual run row would not match", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_gate",
+      creditBalanceCents: 100,
+    });
+
+    const runR1 = "00000000-0000-0000-0000-000000000ba6";
+    await db.insert(transactions).values({
+      orgId,
+      userId,
+      runId: runR1,
+      type: "debit",
+      amountCents: "10.0000000000",
+      status: "confirmed",
+      source: "charge",
+      description: "billed against R1",
+    });
+
+    // expected on runs-service side is also 10 total but allocated to a DIFFERENT run.
+    // The global gate matches → no per-run sweep, even though run R1's billed=10 and run R2's expected=10.
+    const runR2 = "00000000-0000-0000-0000-000000000ba7";
+    fetchRunsExpectedTotalsSpy.mockResolvedValue({
+      total_expected_cents: "10.0000000000",
+      runs: [{ run_id: runR2, expected_cents: "10.0000000000" }],
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+    expect(res.status).toBe(200);
+
+    const allTxns = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.orgId, orgId));
+    expect(allTxns).toHaveLength(1); // only the pre-existing row
+  });
+
+  it("multi-run drift: applies per-run gaps independently, balance reflects net change", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_multi",
+      creditBalanceCents: 100,
+    });
+
+    const runA = "00000000-0000-0000-0000-000000000ba8";
+    const runB = "00000000-0000-0000-0000-000000000ba9";
+    // billed: A=0, B=0; expected: A=3, B=2 → +5 debit total, balance 100 → 95.
+    fetchRunsExpectedTotalsSpy.mockResolvedValue({
+      total_expected_cents: "5.0000000000",
+      runs: [
+        { run_id: runA, expected_cents: "3.0000000000" },
+        { run_id: runB, expected_cents: "2.0000000000" },
+      ],
+    });
+
+    await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    const [aRow] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.runId, runA));
+    expect(aRow.amountCents).toBe("3.0000000000");
+    expect(aRow.source).toBe("charge");
+
+    const [bRow] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.runId, runB));
+    expect(bRow.amountCents).toBe("2.0000000000");
+    expect(bRow.source).toBe("charge");
+
+    const [acct] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId));
+    expect(acct.creditBalanceCents).toBe("95.0000000000");
+  });
+
+  it("fires Stripe ceil-delta per reconcile insert", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_stripe_sync",
+      creditBalanceCents: 100,
+    });
+
+    const runR1 = "00000000-0000-0000-0000-000000000baa";
+    fetchRunsExpectedTotalsSpy.mockResolvedValue({
+      total_expected_cents: "3.0000000000",
+      runs: [{ run_id: runR1, expected_cents: "3.0000000000" }],
+    });
+
+    await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // ceil(100) → ceil(97) = -3 delta from Stripe's perspective (positive = customer owes)
+    expect(stripeMocks.createBalanceTransaction).toHaveBeenCalledWith(
+      orgId,
+      expect.any(String),
+      "cus_stripe_sync",
+      3,
+      expect.stringContaining("Reconcile run"),
+      undefined,
+      {}
+    );
+  });
+
+  it("runs-service down (HTTP error): authorize still succeeds, no reconcile rows written", async () => {
+    await insertTestAccount({
+      orgId,
+      stripeCustomerId: "cus_runs_down",
+      creditBalanceCents: 100,
+    });
+
+    fetchRunsExpectedTotalsSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders(orgId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+
+    const allTxns = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.orgId, orgId));
+    expect(allTxns).toHaveLength(0);
+  });
+
+  it("account not found: noop, does not 500", async () => {
+    // No billing account inserted. Note: /authorize auto-creates via findOrCreateAccount,
+    // so a missing account at the start gets auto-provisioned with the trial credit.
+    // We simulate a drift detected against the auto-created account.
+    const runR1 = "00000000-0000-0000-0000-000000000bab";
+    fetchRunsExpectedTotalsSpy.mockResolvedValue({
+      total_expected_cents: "0.5000000000",
+      runs: [{ run_id: runR1, expected_cents: "0.5000000000" }],
+    });
+
+    const res = await request(app)
+      .post("/v1/credits/authorize")
+      .set(getAuthHeaders("00000000-0000-0000-0000-000000000bac"))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+
+    // Reconcile fired against the newly auto-created account
+    const recon = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.runId, runR1))
+      .orderBy(desc(transactions.createdAt));
+    expect(recon).toHaveLength(1);
+    expect(recon[0].source).toBe("charge");
+    expect(recon[0].amountCents).toBe("0.5000000000");
+  });
+});


### PR DESCRIPTION
## Summary

- Renames the existing `reconcile()` in `src/routes/credits.ts` to `reconcileBillingStripe()` so the two reconcile flavors are unambiguous (scope: intra-billing + Stripe).
- Adds `reconcileBillingRuns()` — a new internal function that detects and corrects per-run drift between billing-side confirmed charges and runs-service recorded actuals. Runs in `/v1/credits/authorize` after `reconcileBillingStripe()` with its own org-scoped advisory lock.
- Adds `src/lib/runs-client.ts` with `fetchRunsExpectedTotals(orgId, wfHeaders)` HTTP client.

## Why

A historical confirm-drop bug (fixed in runs-service v0.22.1 / PR #105) caused under-billing across ~3,337 prod runs (~$397 net loss, Mar 21 → May 12 2026). New runs are now fine, but the historical drift remains uncorrected and no safety net exists for future drift. `reconcileBillingRuns` provides both:
1. Future drift converges automatically on every `/authorize` call.
2. Historical drift is captured the next time each affected org calls `/authorize`. For orgs that don't `/authorize` again, a separate one-shot backfill script can call `reconcileBillingRuns` per org (deferred — not in this PR).

## Behavior

- **Pulls expected per-run totals** from runs-service via `GET /v1/internal/runs-expected-totals?org_id=X` (sister PR in runs-service). Filters: `cost_source='platform'` AND `runs_costs.status='actual'` AND `runs.status IN ('completed','failed')`.
- **Global gate**: compares org-level totals first; per-run sweep only runs when they diverge. Per-run drifts that cancel out at the org level go uncorrected (rare — historical drift is one-sided under-billing). Org balance stays correct in that case; only per-row ledger labels drift.
- **Per-run correction**:
  - `gap > 0` (under-billed): inserts `(type='debit', source='charge', status='confirmed', amount_cents=gap, run_id, description='Reconcile run <id>: under-billed by <gap>')` and decrements balance.
  - `gap < 0` (over-billed): inserts `(type='credit', source='refund', status='confirmed', amount_cents=|gap|, ...)` and increments balance.
- **Exact** — no threshold, sub-cent gaps corrected. Precision preserved via `subCents`/`addCents` string math (numeric(16,10)).
- **Idempotent** — the inserted row contributes to `billed` next time, so a re-run computes `gap=0` and noops. No state column.
- **Stripe ceil-delta** fires per correction (same fire-and-forget pattern as `/confirm`).
- **Trace event** `billing.reconcile-run.applied` emitted with `{ fixed_count, entries: [{run_id, gap_cents, action}] }`.
- **Cross-service HTTP** happens BEFORE the DB transaction opens — never hold a row lock across an external network round-trip.
- **Best-effort**: runs-service outage logs an error and returns; next `/authorize` retries. Authorize itself never fails on a runs-service blip.

## Deployment ordering

Depends on the sister PR in `runs-service` exposing `GET /v1/internal/runs-expected-totals`. Until that ships, `reconcileBillingRuns` here will log a 404 from runs-service every `/authorize` call — no functional impact (treated as a transient outage), but noisy. Merge order: runs-service PR first, then this one.

Triage: **staging-first** (user request). Audit staging DB after deploy. Promote via `release.sh promote` once green.

## Test plan

- [x] `pnpm test` — 238 tests pass (10 new reconcile-billing-runs cases).
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm generate:openapi` — no diff (no new public route).
- [ ] After staging deploy: curl `/v1/credits/authorize` for a known under-billed historical org; verify a `Reconcile run <id>: under-billed by <amount>` row appears in `transactions`.
- [ ] After staging deploy: audit `SELECT description, amount_cents FROM transactions WHERE description LIKE 'Reconcile run%' ORDER BY created_at DESC LIMIT 50;` for sane values.
- [ ] No regressions in existing `/authorize` flow (existing `reconcileBillingStripe` tests still pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)