### PR TITLE
fix(billing): runs-client URL — drop /v1 prefix on internal route

### DIFF
--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -34,7 +34,7 @@ export async function fetchRunsExpectedTotals(
   if (!config) return null;
 
   const res = await fetch(
-    `${config.url}/v1/internal/runs-expected-totals?org_id=${encodeURIComponent(orgId)}`,
+    `${config.url}/internal/runs-expected-totals?org_id=${encodeURIComponent(orgId)}`,
     {
       headers: {
         "x-api-key": config.apiKey,


### PR DESCRIPTION
## Summary

PR #99 shipped `fetchRunsExpectedTotals` calling \`\${RUNS_SERVICE_URL}/v1/internal/runs-expected-totals\`, but runs-service mounts internal routes at \`/internal/*\` (no version prefix) per the existing \`/internal/transfer-brand\` convention. The runs-service sister PR (shamanic-technologies/runs-service#107) ships the route at \`/internal/runs-expected-totals\` (correct), so billing's path is the bug.

## Impact (verified against prod data)

- 247 \`/authorize\` calls in production since deploy of #99 (09:29) → **zero** \`billing.reconcile-run.applied\` events emitted.
- Two known under-billed orgs called authorize post-runs-service-deploy (10:08):
  - \`05ba2f3a-937f-4975-af75-82417b108f3b\` — 735 calls — over-billed by \$35.29 — never refunded.
  - \`b645207b-d8e9-40b0-9391-072b777cd9a9\` — pre-10:08 calls — under-billed by \$436.37 — needs the next /authorize after this PR ships.
- Other drift orgs identified: \`6899...\` -\$13.31, \`f0420...\` -\$82.84, \`05ba...\` +\$35.29 (already counted), \`b645...\` -\$436.37.
- Logs showed (would have shown — fire-and-forget, not visible from DB): \`runs-service runs-expected-totals failed for org X: 404 ...\` on every authorize call. The catch in \`reconcileBillingRuns\` silently absorbed and returned, exactly as designed for a "runs-service down" scenario — except runs-service was up; only the path was wrong.

## Fix

One-character path correction in \`src/lib/runs-client.ts\`:
- Before: \`\${url}/v1/internal/runs-expected-totals?org_id=...\`
- After:  \`\${url}/internal/runs-expected-totals?org_id=...\`

## Cross-repo URL contract (now byte-equal)

| Side | String |
|------|--------|
| runs-service producer | \`router.get('/internal/runs-expected-totals', ...)\` in \`src/routes/internal.ts\` |
| billing-service consumer | \`fetch(\`\${RUNS_SERVICE_URL}/internal/runs-expected-totals?org_id=\${...}\`)\` |

## Triage

Staging-first per the same flow as #99. Once merged + deployed, re-audit production DB for newly-written reconcile rows (orgs with traffic will self-correct on the next /authorize). After audit passes, promote both PRs to main via \`release.sh promote\`.

## Test plan

- [x] Local: \`pnpm test\` — 238 tests pass, \`pnpm tsc --noEmit\` clean.
- [ ] After staging deploy: re-query \`run_events WHERE event='billing.reconcile-run.applied'\` — expect non-zero count within minutes for org \`05ba...\` (high authorize traffic).
- [ ] Re-query \`transactions WHERE description LIKE 'Reconcile run%'\` — expect refund row for \`05ba...\`, debit row(s) for under-billed orgs as they re-authorize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)