### PR TITLE
perf(billing): prefetch per-run billed sums in reconcileBillingRuns

### DIFF
--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -278,6 +278,24 @@ async function reconcileBillingRuns(
     }
 
     // Per-run sweep.
+    // Pre-fetch per-run confirmed billed sums in a SINGLE query so a 200k-run
+    // org doesn't trigger 200k round-trips inside the transaction (which would
+    // exceed Postgres statement_timeout and abort the whole reconcile).
+    const billedRowsByRun = (await tx.execute(
+      rawSql`SELECT run_id::text AS run_id,
+                    COALESCE(SUM(amount_cents), 0)::numeric(16,10)::text AS billed
+             FROM transactions
+             WHERE org_id = ${orgId}
+               AND source = 'charge'
+               AND status = 'confirmed'
+               AND run_id IS NOT NULL
+             GROUP BY run_id`
+    )) as unknown as { run_id: string; billed: string }[];
+    const billedByRun = new Map<string, string>();
+    for (const row of billedRowsByRun) {
+      billedByRun.set(row.run_id, row.billed);
+    }
+
     const collected: {
       entryId: string;
       runId: string;
@@ -290,15 +308,7 @@ async function reconcileBillingRuns(
     let currentBalance = account.credit_balance_cents;
 
     for (const { run_id: targetRunId, expected_cents } of expectedFromRuns.runs) {
-      const sumRows = (await tx.execute(
-        rawSql`SELECT COALESCE(SUM(amount_cents), 0)::numeric(16,10)::text AS billed
-               FROM transactions
-               WHERE run_id = ${targetRunId}
-                 AND org_id = ${orgId}
-                 AND source = 'charge'
-                 AND status = 'confirmed'`
-      )) as unknown as { billed: string }[];
-      const billed = sumRows[0]?.billed ?? "0";
+      const billed = billedByRun.get(targetRunId) ?? "0";
 
       const gap = subCents(expected_cents, billed);
       const cmp = cmpCents(gap, "0");


### PR DESCRIPTION
## Summary

Replaces the per-run SELECT loop in \`reconcileBillingRuns\` with a single \`GROUP BY run_id\` prefetch, eliminating an N-round-trip-inside-a-transaction bottleneck that would deadlock \`/authorize\` for any large org.

## Why

Pre-flight production DB analysis (post-PR #99 + #100 merge to staging) surfaced 16 orgs with detectable drift between billing-side confirmed charges and runs-service recorded actuals. Top under-billed org \`b645207b-d8e9-40b0-9391-072b777cd9a9\` has **203,674 terminal runs with platform actuals** and \$447.49 of under-billing.

The pre-fix \`reconcileBillingRuns\` would have issued ~203k SELECT round-trips inside a single transaction holding:
1. \`billing_accounts FOR UPDATE\` row lock.
2. \`pg_try_advisory_xact_lock(RECONCILE_BILLING_RUNS_LOCK_NAMESPACE, hashtext(orgId))\` org advisory lock.

Even at 1ms per query, that's a 3+ minute transaction. Postgres statement_timeout (or Neon idle-tx-timeout) aborts the whole reconcile → nothing committed → next \`/authorize\` repeats. Permanent deadlock for any large-traffic org.

## Fix

One \`GROUP BY run_id\` SELECT before the loop, then O(1) Map lookup per expected run. SQL round-trips drop from N → 1.

Existing tests cover the behavior (the SQL change is internal — same per-run gap math, same INSERT semantics). All 238 tests pass.

## Triage

Staging-first. Stacks on #99 + #100. Merge to staging, no separate audit step needed beyond \`pnpm test\`. Once merged, promote all three to main via \`release.sh promote\`.

## Test plan

- [x] \`pnpm test\` — 238 tests green.
- [x] \`pnpm tsc --noEmit\` — clean.
- [ ] After staging deploy + promote-to-main: re-audit prod DB for newly-written \`Reconcile run%\` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)