### PR TITLE
fix(billing): expose availableCents + surface reload root cause in cooldown log

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -90,6 +90,9 @@
           "creditBalanceCents": {
             "type": "string"
           },
+          "availableCents": {
+            "type": "string"
+          },
           "reloadAmountCents": {
             "type": "integer",
             "nullable": true
@@ -115,6 +118,7 @@
           "id",
           "orgId",
           "creditBalanceCents",
+          "availableCents",
           "reloadAmountCents",
           "reloadThresholdCents",
           "hasPaymentMethod",

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -14,11 +14,18 @@ import { fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
 
 const router = Router();
 
-function formatAccount(account: typeof billingAccounts.$inferSelect) {
+function formatAccount(
+  account: typeof billingAccounts.$inferSelect,
+  availableCents?: string
+) {
   return {
     id: account.id,
     orgId: account.orgId,
+    // creditBalanceCents is the gross grants total (welcome + promo + reload top-ups,
+    // minus any historical refunds). Pre-#104 this was the displayable balance; now it
+    // does NOT account for runs-service usage. Dashboard should render availableCents.
     creditBalanceCents: account.creditBalanceCents,
+    availableCents: availableCents ?? account.creditBalanceCents,
     reloadAmountCents: account.reloadAmountCents,
     reloadThresholdCents: account.reloadThresholdCents,
     hasPaymentMethod: !!account.stripePaymentMethodId,
@@ -33,10 +40,28 @@ router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
     const userId = req.headers["x-user-id"] as string;
+    const runId = req.headers["x-run-id"] as string;
     const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
 
     const account = await findOrCreateAccount(orgId, userId, wfHeaders);
-    res.json(formatAccount(account));
+
+    // Net available = grants - runs-service spent. If runs-service is unreachable,
+    // fall through with availableCents = creditBalanceCents rather than 502; this
+    // endpoint must stay responsive for dashboard rendering.
+    let availableCents = account.creditBalanceCents;
+    try {
+      const usage = await fetchRunsOrgUsageTotal(orgId, {
+        "x-org-id": orgId,
+        "x-user-id": userId,
+        "x-run-id": runId,
+        ...wfHeaders,
+      });
+      availableCents = subCents(account.creditBalanceCents, usage.spent_cents);
+    } catch (runsErr) {
+      console.warn("[billing-service] /v1/accounts: runs-service usage fetch failed, returning grants as availableCents:", runsErr);
+    }
+
+    res.json(formatAccount(account, availableCents));
   } catch (err) {
     console.error("[billing-service] Error getting/creating account:", err);
     if (isStripeAuthError(err)) {

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -144,7 +144,7 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
           // Cooldown: skip reload if the last reload entry is cancelled and < 15 min old.
           const RELOAD_COOLDOWN_MS = 15 * 60 * 1000;
           const [lastReload] = await tx
-            .select({ status: transactions.status, createdAt: transactions.createdAt })
+            .select({ status: transactions.status, createdAt: transactions.createdAt, description: transactions.description })
             .from(transactions)
             .where(
               and(
@@ -161,7 +161,12 @@ router.post("/v1/credits/authorize", requireOrgHeaders, async (req, res) => {
             Date.now() - new Date(lastReload.createdAt).getTime() < RELOAD_COOLDOWN_MS;
 
           if (reloadOnCooldown) {
-            console.warn(`[billing-service] Auto-reload skipped for org ${orgId}: cooldown active (last failed reload < 15 min ago)`);
+            const lastFailedAt = new Date(lastReload.createdAt).toISOString();
+            const retryAt = new Date(new Date(lastReload.createdAt).getTime() + RELOAD_COOLDOWN_MS).toISOString();
+            const rootCause = lastReload.description ?? "unknown reason";
+            console.warn(
+              `[billing-service] Auto-reload skipped for org ${orgId}: cooldown active until ${retryAt} (last failed ${lastFailedAt}, root cause: ${rootCause})`
+            );
           } else {
             const chargeAmount = computeReloadCharge(availableBalance, requiredCents, lockedAccount.reload_amount_cents);
             try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -26,6 +26,7 @@ export const BillingAccountSchema = z
     id: z.string().uuid(),
     orgId: z.string().uuid(),
     creditBalanceCents: CentsStringSchema,
+    availableCents: CentsStringSchema,
     reloadAmountCents: z.number().int().nullable(),
     reloadThresholdCents: z.number().int().nullable(),
     hasPaymentMethod: z.boolean(),


### PR DESCRIPTION
## Why
Two paper cuts from the #104 cutover, both surfaced today by an org stuck in reload cooldown:

1. **Dashboard shows wrong balance.** Post-#104 \`creditBalanceCents\` is gross grants only — runs-service spend is no longer subtracted in DB. Dashboard rendered \"\$75 credit\" while the org was effectively -\$308 once runs-service usage was included. \`/v1/accounts/balance\` returns the right number; \`/v1/accounts\` did not.

2. **Cooldown log hides the real failure.** When auto-reload skips due to the 15-min cooldown, the warning only said \`last failed reload < 15 min ago\` — no card-declined / insufficient-funds / expired-card detail. Root cause was already stored on the cancelled \`transactions.description\`; just wasn't surfaced.

## Changes
- \`/v1/accounts\` response includes \`availableCents = creditBalanceCents - runs spent_cents\`. Runs-service fetch failures degrade to \`availableCents = creditBalanceCents\` rather than 502.
- \`BillingAccount\` OpenAPI schema gains \`availableCents\`.
- Cooldown skip warning includes \`retryAt\` ISO timestamp and the cancelled row's \`description\` (e.g. \`root cause: Auto-reload failed: Your card has insufficient funds.\`).

## Dashboard follow-up (separate repo)
\`api-service\` / dashboard must switch from \`creditBalanceCents\` to \`availableCents\` to render the correct number. Keeping the old field for back-compat; it now documents itself as grants-only via inline comment.

## Test plan
- [x] \`pnpm build\`
- [ ] Staging smoke: \`/v1/accounts\` returns \`availableCents\`; force a failed reload and verify cooldown log carries the root cause string.