### PR TITLE
feat(billing): add total_revenue_cents to /public/stats/billing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,10 +136,16 @@ All three balance/usage/available endpoints fail loud (502) when runs-service is
 
 ### `GET /public/stats/billing`
 
+Composed from stripe-service `getStats()` + local `localPromos` (post-#112):
+
 ```jsonc
 {
-  "total_balance_cents": "14514.0000000000",        // SUM(billing_accounts.balance_cents)
-  "total_credited_cents": "254500.0000000000",      // lifetime POSITIVE sum of succeeded credit-type CBTs
+  "total_accounts": 2,
+  "accounts_with_payment_method": 1,                // from stripe-service
+  "total_credited_cents": "15400.0000000000",       // total_paid_cents + total_local_credits_cents
+  "total_paid_cents": "15000.0000000000",           // stripe-service Stripe payments (gross)
+  "total_revenue_cents": "15000.0000000000",        // cumulative all-time Stripe revenue (currently = total_paid_cents; will become net once stripe-service exposes refund totals)
+  "total_local_credits_cents": "400.0000000000",    // SUM(local_promos.amount_cents)
   "monthly_growth": [
     { "period": "2026-05-01", "credited_cents": "25000.0000000000", "revenue_cents": "23000.0000000000" }
   ],
@@ -147,7 +153,7 @@ All three balance/usage/available endpoints fail loud (502) when runs-service is
 }
 ```
 
-Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed lives in runs-service.
+Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed lives in runs-service. Endpoint returns 502 if stripe-service unreachable.
 
 ## Endpoints reference
 

--- a/openapi.json
+++ b/openapi.json
@@ -46,6 +46,9 @@
           "total_paid_cents": {
             "type": "string"
           },
+          "total_revenue_cents": {
+            "type": "string"
+          },
           "total_local_credits_cents": {
             "type": "string"
           },
@@ -67,6 +70,7 @@
           "accounts_with_payment_method",
           "total_credited_cents",
           "total_paid_cents",
+          "total_revenue_cents",
           "total_local_credits_cents",
           "monthly_growth",
           "weekly_growth"

--- a/src/routes/public-stats.ts
+++ b/src/routes/public-stats.ts
@@ -100,6 +100,7 @@ router.get("/public/stats/billing", async (_req, res) => {
       accounts_with_payment_method: ssStats.accounts_with_payment_method,
       total_credited_cents: addCents(localCreditStats.totalLocalCredits, ssStats.total_paid_cents),
       total_paid_cents: ssStats.total_paid_cents,
+      total_revenue_cents: ssStats.total_paid_cents,
       total_local_credits_cents: localCreditStats.totalLocalCredits,
       monthly_growth: mergeGrowthRows(monthlyLocal, ssStats.monthly_growth),
       weekly_growth: mergeGrowthRows(weeklyLocal, ssStats.weekly_growth),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -188,6 +188,12 @@ export const PublicBillingStatsSchema = z
     total_credited_cents: CentsStringSchema,
     /** Lifetime stripe-service paid only. */
     total_paid_cents: CentsStringSchema,
+    /**
+     * Cumulative all-time Stripe revenue, top-level alias for investor/landing-page consumers.
+     * Currently equals `total_paid_cents` (gross — refunds not subtracted). Will become net
+     * (paid − refunded) once stripe-service exposes refund totals.
+     */
+    total_revenue_cents: CentsStringSchema,
     /** Lifetime local promo credits only. */
     total_local_credits_cents: CentsStringSchema,
     monthly_growth: z.array(BillingGrowthRowSchema),

--- a/tests/integration/public-stats.test.ts
+++ b/tests/integration/public-stats.test.ts
@@ -35,6 +35,7 @@ describe("GET /public/stats/billing", () => {
     expect(res.body.accounts_with_payment_method).toBe(0);
     expect(res.body.total_credited_cents).toBe("0.0000000000");
     expect(res.body.total_paid_cents).toBe("0.0000000000");
+    expect(res.body.total_revenue_cents).toBe("0.0000000000");
     expect(res.body.total_local_credits_cents).toBe("0.0000000000");
     expect(res.body.monthly_growth).toEqual([]);
     expect(res.body.weekly_growth).toEqual([]);
@@ -64,6 +65,7 @@ describe("GET /public/stats/billing", () => {
     expect(res.body.total_accounts).toBe(2);
     expect(res.body.accounts_with_payment_method).toBe(1);
     expect(res.body.total_paid_cents).toBe("15000.0000000000");
+    expect(res.body.total_revenue_cents).toBe("15000.0000000000");
     expect(res.body.total_local_credits_cents).toBe("400.0000000000");
     expect(res.body.total_credited_cents).toBe("15400.0000000000");
   });


### PR DESCRIPTION
## Summary
- Adds top-level `total_revenue_cents` to `GET /public/stats/billing` for investor/landing-page consumers (`apps/landing/.../investors`).
- **Path B (gross alias).** Currently equals `total_paid_cents` exactly — stripe-service does not yet expose refund totals, so net (paid − refunded) is not computable here.
- Field name locked in now to avoid a future rename when stripe-service ships refund aggregation (Path A, deferred).

## Why "revenue" if not net?
The consumer wants a single cumulative metric labeled "Revenue". Summing `monthly_growth[].revenue_cents` client-side is fragile (bucket truncation, missing pre-history months). Exposing the cumulative value as a top-level field is the clean fix — and surfacing it under the user-facing name (`revenue`) now lets us flip the formula later without a client-side rename.

## Future work (Path A, separate PR)
1. stripe-service extends `/public/stats/billing` with `total_refunded_cents` + per-period `refunded_cents`
2. billing-service computes `total_revenue_cents = total_paid_cents − total_refunded_cents` and shifts per-period `revenue_cents` to net

## Test plan
- [x] `pnpm test` — 86/86 green (added 2 assertions in `tests/integration/public-stats.test.ts`)
- [x] `pnpm build` — type-check + openapi regen green
- [ ] Manual `curl staging /public/stats/billing | jq .total_revenue_cents` post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)