### PR TITLE
hotfix: Derive balance_cents from succeeded topups + local promos; drop Stripe customer.balance reads (SS v0.16.3 contract)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,42 +2,22 @@
 
 ## Vocabulary (Stripe-aligned)
 
-Naming follows Stripe Customer Balance + Topups + Refunds APIs. When in doubt, search Stripe docs for the same term.
+Naming follows Stripe Topups + Refunds APIs. When in doubt, search Stripe docs for the same term.
 
 ### Core money concepts
 
 | Term | Definition | Source of truth |
 |---|---|---|
-| **balance** | Org's prepaid balance liability (what we owe the org). Net of all succeeded customer-balance transactions. | `billing_accounts.balance_cents` |
+| **balance** | Org's prepaid credit liability (what we owe the org). | `SUM(succeeded payment_intents.amount_received)` via stripe-service + `SUM(local_promos.amount_cents)` |
 | **usage** | Platform AI cost consumed by org. Lifetime, all-time. | runs-service `GET /internal/org-usage-total` |
 | **available** | Funds usable right now for new work. `balance − usage`. | computed at request time |
-| **topup** | Auto/manual Stripe payment that increases balance. | `customer_balance_transactions WHERE type='payment'` |
-| **gift** | Non-payment credit (welcome bonus, manual adjustment). | `customer_balance_transactions WHERE type='gift'` |
-| **promo** | Promo-code redemption credit. | `customer_balance_transactions WHERE type='promo'` |
-| **refund** | Funds returned to org (or to org's card). | `customer_balance_transactions WHERE type='refund'` |
+| **topup** | Auto/manual Stripe payment that increases balance. | stripe-service `payment_intents` (status='succeeded') |
+| **gift / promo** | Non-payment credit (welcome bonus, promo redemption, manual adjustment). | `local_promos.amount_cents` |
+| **refund** | Funds returned to org. | stripe-service `refunds` (visibility only — does not auto-deduct from billing balance) |
 
-### Signed amount convention
+### Stripe `customer.balance` is NOT used
 
-`customer_balance_transactions.amount_cents` is **signed**, matching Stripe `customer_balance_transactions.amount`:
-
-| Sign | Meaning | Examples |
-|---|---|---|
-| **negative** | balance increases (org receives credit) | topup, gift, promo, refund |
-| **positive** | balance decreases (org spends) | usage_applied (legacy, frozen post-#104) |
-
-So `balance_cents = − SUM(amount_cents) WHERE status='succeeded'`.
-
-> Convention rationale: Stripe `customer.balance` is negative when customer has credit, positive when customer owes. We mirror their sign on per-transaction `amount` so `customer.balance = SUM(cbt.amount)` works out of the box.
-
-### Status lifecycle (Stripe PaymentIntent semantics)
-
-| Status | Impact on balance | Stripe analog |
-|---|---|---|
-| `requires_capture` | none — authorization only | PaymentIntent `requires_capture` |
-| `succeeded` | applied to balance | PaymentIntent `succeeded` |
-| `canceled` | none — never applied | PaymentIntent `canceled` (single L, US spelling) |
-
-Only `succeeded` rows affect `balance`. `requires_capture` and `canceled` are visible in history but do not move money.
+Pre-#104, billing-service wrote `usage_applied` CBTs to Stripe via `customers.createBalanceTransaction`. Those debits contaminated `customer.balance` (it no longer represented pure prepaid credit). Post-#0016 stripe-service v0.16.3 dropped `customer.balance` from its API surface entirely. Billing-service must **never read `customer.balance`** — derive `balance` from `payment_intents.amount_received` (real money paid) plus local promo grants.
 
 ## BYOK (Bring Your Own Key) cost source
 
@@ -50,49 +30,25 @@ Only `succeeded` rows affect `balance`. `requires_capture` and `canceled` are vi
 
 When reconciling or computing real cost: `WHERE rc.status='actual' AND rc.cost_source='platform'`. Including `org` rows would over-state.
 
-## Customer balance transaction types (`type` column)
+## Local promos (`local_promos` table)
 
-| type | direction | meaning |
-|---|---|---|
-| `payment` | credit (negative amount) | Stripe top-up succeeded (auto or manual) |
-| `gift` | credit (negative amount) | $2 welcome bonus on signup; manual adjustments |
-| `promo` | credit (negative amount) | promo code redemption |
-| `refund` | credit (negative amount) | exceptional refund |
-| `usage_applied` | debit (positive amount) | **Frozen post-#104.** Usage now tracked in runs-service, not in billing ledger. Legacy rows archived to `cbt_archive_pre104_usage`. |
+The only persistent ledger billing-service owns. One row per (org, promo_code) — `UNIQUE (org_id, promo_code_id)`. Welcome trial = `code='welcome'` ($2 grant), seeded by migration 0016. Other codes are admin-managed.
 
-`usage_applied` lifecycle (historical only, pre-#104): provision inserted `(positive amount, requires_capture)`; confirm mutated to `succeeded`; cancel mutated to `canceled`. **No mirror credit rows ever inserted.**
-
-Post-#107: legacy `usage_applied` rows deleted from prod and copied to `cbt_archive_pre104_usage` (same DB, audit-only). `GET /v1/customer_balance_transactions` filters `type != 'usage_applied'` as defense-in-depth.
-
-## `cost_id` natural key (post-#92)
-
-`customer_balance_transactions.cost_id` (uuid, nullable, indexed) decouples external callers from the billing-internal `customer_balance_transactions.id`. runs-service issues one provision per `runs_costs.id` and confirms/cancels via the by-cost endpoints — no billing-side id needed.
-
-By-cost lookup picks the **most recent** row by `created_at` (one cost_id can produce a `requires_capture → canceled` row plus a fresh `succeeded` replacement when the actual amount differs). Only one row per cost_id is non-terminal at a time. Replacement rows carry the same `cost_id` so subsequent calls still hit the active row.
-
-> **Note**: provision/confirm/cancel endpoints on `/v1/customer_balance` are documented for completeness but **currently no-op** (frozen post-#104). Usage truth lives in runs-service. See "Billing/runs ownership target" below.
-
-## `balance_transaction_id` canonical key (post-#96)
-
-There is **one** id surfaced in billing responses: `balance_transaction_id` (= `customer_balance_transactions.id`). Internal code uses `balanceTransactionId` consistently. The deprecated `provision_id` and `transaction_id` aliases were removed in v3.
-
-## Fractional cents
-
-`customer_balance_transactions.amount_cents` and `billing_accounts.balance_cents` are `numeric(16,10)`. Drizzle returns them as JS strings — never cast with `Number()` for math (precision loss). Use `parseFloat` for display only; for arithmetic in JS, use `BigInt`-scaled or `numeric.js`-style. Do NOT round inside billing — runs-service sends raw fractional, ledger preserves it.
-
-Stripe `customers.createBalanceTransaction` only takes integer cents. The Stripe-sync layer in `src/lib/ledger.ts` ceils ledger balance and only fires a balance txn when the integer floor crosses a boundary. Stripe is fire-and-forget visibility; ledger is source of truth.
+`amount_cents` is positive (these are credits). `numeric(16,10)` — Drizzle returns it as a JS string. Use Decimal.js (via `src/lib/cents.ts` helpers) for arithmetic; never cast to Number for math.
 
 ## Billing/runs ownership target
 
-Runs-service owns run-level usage truth. Billing-service must not create new run-cost provision/confirm/cancel rows. Authorize computes available credits as:
+- **Billing-service** owns: local promo grants (`local_promos`), topup config (`billing_accounts.topup_amount_cents`, `topup_threshold_cents`).
+- **Stripe-service** owns: Stripe customers, payment methods, payment intents, refunds, checkout sessions, billing portal sessions. Mirror DB synced via webhooks + boot back-fill.
+- **Runs-service** owns: run-level usage truth. `spent_cents` from `GET /internal/org-usage-total?org_id=...` includes platform `actual + provisioned` costs, excludes canceled and `org`/BYOK costs.
 
-```
-balance (from billing) − usage (from runs-service)
-```
+Billing never duplicates Stripe state and never persists run-level usage rows.
 
-The runs-service total is fetched from `GET /internal/org-usage-total?org_id=...` and includes platform `actual + provisioned` costs, excluding canceled and org/BYOK costs. Billing-service owns Stripe customers, payment methods, topups, gift/promo grants, and Stripe payment/refund records.
+## Fractional cents
 
-Do not sync Stripe Customer Balance Transactions for internal balance. Stripe is payment processor + audit; available credits come from billing balance minus runs usage.
+`local_promos.amount_cents` is `numeric(16,10)`. Drizzle returns it as a JS string — never cast with `Number()` for math (precision loss). Use the `addCents/subCents/cmpCents/isDepleted/gte` helpers in `src/lib/cents.ts` (Decimal.js-backed, precision 50). `parseFloat` is for display only.
+
+`payment_intents.amount_received` from Stripe is **integer cents** (Stripe's `amount` minor unit). Sum returns a `Decimal.toFixed(10)` string for arithmetic-compatibility with the helpers above.
 
 ## Public surface field names
 
@@ -100,44 +56,32 @@ Do not sync Stripe Customer Balance Transactions for internal balance. Stripe is
 
 ```jsonc
 {
-  "balance_cents": "2091.0000000000",     // billing-owned credit balance
-  "usage_cents": "136803.0000000000",     // mirrored from runs-service
-  "available_cents": "-134712.0000000000", // balance − usage; USE THIS for depletion/budget gates
-  "topup_amount_cents": 2500,             // auto-topup amount per Stripe Topups API
-  "topup_threshold_cents": 500,           // auto-topup triggers when available_cents < threshold
+  "id": "<uuid>",
+  "org_id": "<uuid>",
+  "balance_cents": "55200.0000000000",       // SUM(succeeded PI.amount_received) + SUM(local_promos.amount_cents)
+  "usage_cents": "38289.2958000000",         // runs-service spent_cents (platform actual+provisioned)
+  "available_cents": "16910.7042000000",     // balance_cents − usage_cents; USE THIS for depletion/budget gates
+  "topup_amount_cents": 2500,                // auto-topup amount
+  "topup_threshold_cents": 500,              // auto-topup triggers when available_cents < threshold
   "has_payment_method": true,                // derived from customer.invoice_settings.default_payment_method != null
-  "has_auto_topup": true
+  "has_auto_topup": true,
+  "created_at": "...",
+  "updated_at": "..."
 }
 ```
 
-All three balance/usage/available endpoints fail loud (502) when runs-service or stripe-service is unreachable. PATCH/DELETE call runs-service to keep the response shape consistent.
+All three balance/usage/available endpoints fail loud (502) when runs-service or stripe-service is unreachable.
 
-`balance_cents` is derived from Stripe `customer.balance` with sign-flipped semantics: Stripe convention is `balance > 0` = customer owes, `balance < 0` = customer has credit. Billing surfaces the credit-positive value (`balance_cents = -customer.balance`).
-
-### `GET /v1/customer_balance_transactions`
-
-```jsonc
-{
-  "object": "list",
-  "data": [
-    {
-      "id": "<uuid>",
-      "object": "customer_balance_transaction",
-      "amount_cents": "-2500.0000000000",          // signed: negative = credit, positive = debit
-      "type": "payment",                          // 'payment' | 'gift' | 'promo' | 'refund'
-      "status": "succeeded",                      // 'requires_capture' | 'succeeded' | 'canceled'
-      "stripe_payment_intent_id": "pi_xxx",
-      "stripe_balance_transaction_id": "txn_xxx", // Stripe-side CBT id (visibility only)
-      "cost_id": null,                            // present only for legacy usage_applied rows
-      "created": 1234567890                       // unix seconds, Stripe convention
-    }
-  ]
-}
-```
+`balance_cents` composition (`src/routes/accounts.ts:composeAccountFunds`):
+1. `getCustomerByOrg(identity)` → Stripe customer (for `id` and `default_payment_method`)
+2. `sumSucceededTopupsForCustomer(identity, customer.id)` → paginates `GET /v1/payment_intents?customer=cus_X` and sums `amount_received` where `status='succeeded'`
+3. `sumLocalPromoCreditsForOrg(orgId)` → SUM `local_promos.amount_cents`
+4. `fetchRunsOrgUsageTotal(orgId, identity)` → runs-service `spent_cents`
+5. `balance_cents = paid_topups + local_credits` ; `available_cents = balance_cents − usage`
 
 ### `GET /public/stats/billing`
 
-Composed from stripe-service `getStats()` + local `localPromos` (post-#112):
+Composed from stripe-service `getStats()` + local `localPromos`:
 
 ```jsonc
 {
@@ -145,7 +89,7 @@ Composed from stripe-service `getStats()` + local `localPromos` (post-#112):
   "accounts_with_payment_method": 1,                // from stripe-service
   "total_credited_cents": "15400.0000000000",       // total_paid_cents + total_local_credits_cents
   "total_paid_cents": "15000.0000000000",           // stripe-service Stripe payments (gross)
-  "total_revenue_cents": "15000.0000000000",        // cumulative all-time Stripe revenue (currently = total_paid_cents; will become net once stripe-service exposes refund totals)
+  "total_revenue_cents": "15000.0000000000",        // cumulative all-time Stripe revenue
   "total_local_credits_cents": "400.0000000000",    // SUM(local_promos.amount_cents)
   "monthly_growth": [
     { "period": "2026-05-01", "credited_cents": "25000.0000000000", "revenue_cents": "23000.0000000000" }
@@ -162,12 +106,10 @@ Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed liv
 |---|---|---|
 | `GET` | `/v1/accounts` | account snapshot (balance, usage, available, topup config) |
 | `GET` | `/v1/accounts/balance` | shortcut: `{ available_cents, depleted }` |
-| `GET` | `/v1/customer_balance_transactions` | paginated ledger history (filters `type != 'usage_applied'`) |
 | `PATCH` | `/v1/accounts/auto_topup` | configure auto-topup |
 | `DELETE` | `/v1/accounts/auto_topup` | disable auto-topup |
 | `POST` | `/v1/checkout-sessions` | one-shot top-up via Stripe Checkout |
 | `POST` | `/v1/portal-sessions` | Stripe Customer Portal session |
-| `POST` | `/v1/customer_balance/authorize` | check if `available_cents >= amount` (auth-only, no balance impact) |
-| `POST` | `/v1/customer_balance/usage_apply` | notify-only endpoint (post-#104 placeholder; runs-service is truth) |
-| `POST` | `/v1/promotion_codes/redeem` | redeem promo code → insert `type='promo'` CBT |
-| `POST` | `/v1/webhooks/stripe` | Stripe webhook receiver |
+| `POST` | `/v1/customer_balance/authorize` | check if `available_cents >= amount` ; auto-reload via PI if configured |
+| `POST` | `/v1/customer_balance/usage_apply` | proactive topup hint after a run; no-op for the ledger |
+| `POST` | `/v1/promotion_codes/redeem` | redeem promo code → insert `local_promos` row |

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -18,7 +18,6 @@ export type IdentityHeaders = Record<string, string>;
 export interface StripeCustomer {
   id: string;
   object: "customer";
-  balance: number;
   metadata: Record<string, string>;
   invoice_settings: {
     default_payment_method: string | null;
@@ -45,31 +44,17 @@ export interface StripePaymentIntent {
   id: string;
   object: "payment_intent";
   amount: number;
+  amount_received: number | null;
   currency: string;
   customer: string | null;
   status: StripePaymentIntentStatus;
   last_payment_error: { code?: string; message?: string } | null;
 }
 
-export interface StripeBalanceTransaction {
-  id: string;
-  object: "customer_balance_transaction";
-  amount: number;
-  currency: string;
-  type: string;
-  customer: string;
-  credit_note: string | null;
-  invoice: string | null;
-  description: string | null;
-  metadata: Record<string, string>;
-  created: number;
-  livemode: boolean;
-}
-
-export interface StripeBalanceTransactionList {
+export interface StripePaymentIntentList {
   object: "list";
   url: string;
-  data: StripeBalanceTransaction[];
+  data: StripePaymentIntent[];
   has_more: boolean;
 }
 
@@ -190,18 +175,63 @@ export async function getPaymentIntent(
   return call("GET", `/v1/payment_intents/${id}`, identity);
 }
 
-// --- Balance Transactions (org-implicit) ---
-
-export async function listBalanceTransactions(
+export async function listPaymentIntents(
   identity: IdentityHeaders,
-  query: { limit?: number; starting_after?: string; ending_before?: string } = {}
-): Promise<StripeBalanceTransactionList> {
+  query: { customer: string; limit?: number; starting_after?: string }
+): Promise<StripePaymentIntentList> {
   const params = new URLSearchParams();
+  params.set("customer", query.customer);
   if (query.limit !== undefined) params.set("limit", String(query.limit));
   if (query.starting_after) params.set("starting_after", query.starting_after);
-  if (query.ending_before) params.set("ending_before", query.ending_before);
-  const qs = params.toString();
-  return call("GET", `/v1/balance_transactions${qs ? `?${qs}` : ""}`, identity);
+  return call("GET", `/v1/payment_intents?${params.toString()}`, identity);
+}
+
+const TOPUP_PAGE_LIMIT = 100;
+const TOPUP_PAGE_CAP = 200;
+
+/**
+ * Paginate every payment_intent for `customerId` and sum `amount_received`
+ * across rows with `status === 'succeeded'`. The result is the total money
+ * the org has actually paid into Stripe — the source of truth for the
+ * billing-side `balance_cents` post-#0016.
+ *
+ * Returns a numeric(16,10)-formatted string for arithmetic-compatibility
+ * with addCents/subCents helpers.
+ *
+ * Throws if pagination loops past TOPUP_PAGE_CAP pages or if stripe-service
+ * reports `has_more=true` with an empty page (broken contract).
+ */
+export async function sumSucceededTopupsForCustomer(
+  identity: IdentityHeaders,
+  customerId: string
+): Promise<string> {
+  let total = new Decimal(0);
+  let startingAfter: string | undefined;
+  for (let i = 0; i < TOPUP_PAGE_CAP; i += 1) {
+    const page = await listPaymentIntents(identity, {
+      customer: customerId,
+      limit: TOPUP_PAGE_LIMIT,
+      starting_after: startingAfter,
+    });
+    for (const pi of page.data) {
+      if (pi.status === "succeeded" && typeof pi.amount_received === "number") {
+        total = total.plus(pi.amount_received);
+      }
+    }
+    if (!page.has_more) {
+      return total.toFixed(10);
+    }
+    const last = page.data[page.data.length - 1];
+    if (!last) {
+      throw new Error(
+        "stripe-service /v1/payment_intents returned has_more=true with empty page"
+      );
+    }
+    startingAfter = last.id;
+  }
+  throw new Error(
+    `stripe-service /v1/payment_intents pagination exceeded ${TOPUP_PAGE_CAP} pages for customer ${customerId}`
+  );
 }
 
 // --- Checkout / Portal ---
@@ -258,17 +288,6 @@ export async function updateCustomer(
 }
 
 // --- Derivations from Stripe customer ---
-
-/**
- * Derive billing-side balance_cents (positive=credit) from Stripe customer.balance
- * (positive=customer-owes, negative=customer-credit). Sign-flip mirrors the
- * old getBalance semantics. Returned as numeric(16,10)-formatted string for
- * arithmetic-compatibility with addCents/subCents helpers.
- */
-export function deriveBalanceCents(customer: StripeCustomer): string {
-  const stripeBalance = customer.balance ?? 0;
-  return new Decimal(-stripeBalance).toFixed(10);
-}
 
 export function deriveHasPaymentMethod(customer: StripeCustomer): boolean {
   return Boolean(customer.invoice_settings?.default_payment_method);

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -10,7 +10,7 @@ import { fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
 import { sumLocalPromoCreditsForOrg } from "../lib/promos.js";
 import {
   getCustomerByOrg,
-  deriveBalanceCents,
+  sumSucceededTopupsForCustomer,
   deriveHasPaymentMethod,
 } from "../lib/stripe-service-client.js";
 
@@ -40,13 +40,13 @@ async function composeAccountFunds(
   availableCents: string;
   hasPaymentMethod: boolean;
 }> {
-  const [customer, localCredits, runsUsage] = await Promise.all([
-    getCustomerByOrg(identity),
+  const customer = await getCustomerByOrg(identity);
+  const [paidTopups, localCredits, runsUsage] = await Promise.all([
+    sumSucceededTopupsForCustomer(identity, customer.id),
     sumLocalPromoCreditsForOrg(orgId),
     fetchRunsOrgUsageTotal(orgId, identity),
   ]);
-  const ssBalance = deriveBalanceCents(customer);
-  const balanceCents = addCents(ssBalance, localCredits);
+  const balanceCents = addCents(paidTopups, localCredits);
   const availableCents = subCents(balanceCents, runsUsage.spent_cents);
   return {
     balanceCents,

--- a/src/routes/customer_balance.ts
+++ b/src/routes/customer_balance.ts
@@ -12,7 +12,7 @@ import { addCents, subCents, gte as gteCents, parseNonNegativeCents } from "../l
 import { sumLocalPromoCreditsForOrg } from "../lib/promos.js";
 import {
   getCustomerByOrg,
-  deriveBalanceCents,
+  sumSucceededTopupsForCustomer,
   deriveHasPaymentMethod,
   type StripeCustomer,
 } from "../lib/stripe-service-client.js";
@@ -71,13 +71,13 @@ async function computeAvailable(
   orgId: string,
   identity: Record<string, string>
 ): Promise<AvailableSnapshot> {
-  const [customer, localCredits, runsUsage] = await Promise.all([
-    getCustomerByOrg(identity),
+  const customer = await getCustomerByOrg(identity);
+  const [paidTopups, localCredits, runsUsage] = await Promise.all([
+    sumSucceededTopupsForCustomer(identity, customer.id),
     sumLocalPromoCreditsForOrg(orgId),
     fetchRunsOrgUsageTotal(orgId, identity),
   ]);
-  const ssBalance = deriveBalanceCents(customer);
-  const balanceCents = addCents(ssBalance, localCredits);
+  const balanceCents = addCents(paidTopups, localCredits);
   const availableCents = subCents(balanceCents, runsUsage.spent_cents);
   return { customer, balanceCents, usageCents: runsUsage.spent_cents, availableCents };
 }
@@ -250,18 +250,19 @@ router.post("/v1/customer_balance/usage_apply", requireOrgHeaders, async (req, r
       return;
     }
 
-    const [customer, localCredits] = await Promise.all([
-      getCustomerByOrg(identity),
-      sumLocalPromoCreditsForOrg(orgId),
-    ]);
+    const customer = await getCustomerByOrg(identity);
 
     if (!deriveHasPaymentMethod(customer)) {
       res.status(202).json({ acknowledged: true, topup_triggered: false });
       return;
     }
 
-    const ssBalance = deriveBalanceCents(customer);
-    const balanceCents = addCents(ssBalance, localCredits);
+    const [paidTopups, localCredits] = await Promise.all([
+      sumSucceededTopupsForCustomer(identity, customer.id),
+      sumLocalPromoCreditsForOrg(orgId),
+    ]);
+
+    const balanceCents = addCents(paidTopups, localCredits);
     const availableCents = subCents(balanceCents, spentTotalCents);
     const thresholdCents = String(account.topupThresholdCents);
 

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -8,7 +8,8 @@ export interface StripeServiceMocks {
   getCustomerByOrg: ReturnType<typeof vi.fn>;
   createPaymentIntent: ReturnType<typeof vi.fn>;
   getPaymentIntent: ReturnType<typeof vi.fn>;
-  listBalanceTransactions: ReturnType<typeof vi.fn>;
+  listPaymentIntents: ReturnType<typeof vi.fn>;
+  sumSucceededTopupsForCustomer: ReturnType<typeof vi.fn>;
   listCustomersByMetadata: ReturnType<typeof vi.fn>;
   updateCustomer: ReturnType<typeof vi.fn>;
   createCheckoutSession: ReturnType<typeof vi.fn>;
@@ -23,7 +24,6 @@ function buildMockCustomer(overrides: Partial<ssClient.StripeCustomer> = {}): ss
   return {
     id: MOCK_CUSTOMER_ID,
     object: "customer",
-    balance: 0,
     metadata: {},
     invoice_settings: { default_payment_method: null },
     ...overrides,
@@ -48,6 +48,7 @@ export function setupStripeMocks(): StripeServiceMocks {
       id: "pi_mock",
       object: "payment_intent",
       amount: 0,
+      amount_received: 0,
       currency: "usd",
       customer: MOCK_CUSTOMER_ID,
       status: "succeeded",
@@ -57,17 +58,19 @@ export function setupStripeMocks(): StripeServiceMocks {
       id: "pi_mock",
       object: "payment_intent",
       amount: 0,
+      amount_received: 0,
       currency: "usd",
       customer: MOCK_CUSTOMER_ID,
       status: "succeeded",
       last_payment_error: null,
     }),
-    listBalanceTransactions: vi.fn().mockResolvedValue({
+    listPaymentIntents: vi.fn().mockResolvedValue({
       object: "list",
-      url: "/v1/balance_transactions",
+      url: "/v1/payment_intents",
       data: [],
       has_more: false,
     }),
+    sumSucceededTopupsForCustomer: vi.fn().mockResolvedValue("0.0000000000"),
     createCheckoutSession: vi.fn().mockResolvedValue({
       url: "https://checkout.stripe.com/pay/cs_mock",
       session_id: "cs_mock",
@@ -100,7 +103,10 @@ export function setupStripeMocks(): StripeServiceMocks {
   vi.spyOn(ssClient, "getCustomerByOrg").mockImplementation(mocks.getCustomerByOrg);
   vi.spyOn(ssClient, "createPaymentIntent").mockImplementation(mocks.createPaymentIntent);
   vi.spyOn(ssClient, "getPaymentIntent").mockImplementation(mocks.getPaymentIntent);
-  vi.spyOn(ssClient, "listBalanceTransactions").mockImplementation(mocks.listBalanceTransactions);
+  vi.spyOn(ssClient, "listPaymentIntents").mockImplementation(mocks.listPaymentIntents);
+  vi.spyOn(ssClient, "sumSucceededTopupsForCustomer").mockImplementation(
+    mocks.sumSucceededTopupsForCustomer
+  );
   vi.spyOn(ssClient, "createCheckoutSession").mockImplementation(mocks.createCheckoutSession);
   vi.spyOn(ssClient, "createPortalSession").mockImplementation(mocks.createPortalSession);
   vi.spyOn(ssClient, "listCustomersByMetadata").mockImplementation(mocks.listCustomersByMetadata);
@@ -112,22 +118,6 @@ export function setupStripeMocks(): StripeServiceMocks {
 }
 
 /**
- * Helper: build a customer with a specific Stripe `balance` (Stripe sign:
- * negative = credit). Test code stays in Stripe's native units.
- */
-export function customerWithStripeBalance(stripeBalance: number, overrides: Partial<ssClient.StripeCustomer> = {}): ssClient.StripeCustomer {
-  return buildMockCustomer({ balance: stripeBalance, ...overrides });
-}
-
-/**
- * Helper: build a customer that mirrors billing's "balance_cents" (positive =
- * credit). Sign-flipped to Stripe convention internally.
- */
-export function customerWithBillingCredits(billingBalanceCents: number, overrides: Partial<ssClient.StripeCustomer> = {}): ssClient.StripeCustomer {
-  return buildMockCustomer({ balance: -billingBalanceCents, ...overrides });
-}
-
-/**
  * Helper: build a customer that has a default payment method attached.
  */
 export function customerWithDefaultPM(overrides: Partial<ssClient.StripeCustomer> = {}): ssClient.StripeCustomer {
@@ -135,4 +125,11 @@ export function customerWithDefaultPM(overrides: Partial<ssClient.StripeCustomer
     invoice_settings: { default_payment_method: "pm_mock_card" },
     ...overrides,
   });
+}
+
+/**
+ * Helper: build a customer with no payment method (default mock state).
+ */
+export function customerWithoutPM(overrides: Partial<ssClient.StripeCustomer> = {}): ssClient.StripeCustomer {
+  return buildMockCustomer(overrides);
 }

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -4,8 +4,6 @@ import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
 import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
 import {
   setupStripeMocks,
-  customerWithStripeBalance,
-  customerWithBillingCredits,
   customerWithDefaultPM,
 } from "../helpers/mock-stripe.js";
 
@@ -54,9 +52,9 @@ describe("Accounts endpoints", () => {
       expect(ssMocks.ensureCustomer).toHaveBeenCalled();
     });
 
-    it("composes balance = SS.balance + local credits, available = balance − usage", async () => {
+    it("composes balance = paid topups + local credits, available = balance − usage", async () => {
       await insertTestAccount({ orgId });
-      ssMocks.getCustomerByOrg.mockResolvedValue(customerWithBillingCredits(1000));
+      ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("1000.0000000000");
       fetchRunsOrgUsageTotalSpy.mockResolvedValue({
         org_id: orgId,
         spent_cents: "75.0000000000",
@@ -76,7 +74,7 @@ describe("Accounts endpoints", () => {
 
     it("returns negative available_cents when usage > balance", async () => {
       await insertTestAccount({ orgId });
-      ssMocks.getCustomerByOrg.mockResolvedValue(customerWithBillingCredits(75));
+      ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("75.0000000000");
       fetchRunsOrgUsageTotalSpy.mockResolvedValue({
         org_id: orgId,
         spent_cents: "383.0000000000",
@@ -103,17 +101,24 @@ describe("Accounts endpoints", () => {
       expect(res.body.has_payment_method).toBe(true);
     });
 
-    it("Stripe customer.balance sign-flipped: negative balance = credit", async () => {
+    it("balance reflects only succeeded payment intents (failed PIs excluded)", async () => {
       await insertTestAccount({ orgId });
-      // Stripe convention: balance=-500 means customer has 500 cents of credit.
-      ssMocks.getCustomerByOrg.mockResolvedValue(customerWithStripeBalance(-500));
+      // Helper already filters succeeded — assert by configuring its return.
+      ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("55000.0000000000");
+      fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+        org_id: orgId,
+        spent_cents: "38289.2958000000",
+        as_of: "2026-05-13T00:00:00.000Z",
+      });
 
       const res = await request(app)
         .get("/v1/accounts")
         .set(getAuthHeaders(orgId));
 
       expect(res.status).toBe(200);
-      expect(res.body.balance_cents).toBe("500.0000000000");
+      // 55000 paid + 0 local + (-38289.2958 usage) = 16710.7042
+      expect(res.body.balance_cents).toBe("55000.0000000000");
+      expect(res.body.available_cents).toBe("16710.7042000000");
     });
 
     it("returns 502 when runs-service unavailable", async () => {
@@ -130,6 +135,19 @@ describe("Accounts endpoints", () => {
     it("returns 502 when stripe-service unavailable", async () => {
       await insertTestAccount({ orgId });
       ssMocks.getCustomerByOrg.mockRejectedValue(new Error("stripe-service down"));
+
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set(getAuthHeaders(orgId));
+
+      expect(res.status).toBe(502);
+    });
+
+    it("returns 502 when payment_intents listing fails", async () => {
+      await insertTestAccount({ orgId });
+      ssMocks.sumSucceededTopupsForCustomer.mockRejectedValue(
+        new Error("stripe-service /v1/payment_intents 500")
+      );
 
       const res = await request(app)
         .get("/v1/accounts")
@@ -167,7 +185,7 @@ describe("Accounts endpoints", () => {
   describe("GET /v1/accounts/balance", () => {
     it("returns balance minus usage", async () => {
       await insertTestAccount({ orgId });
-      ssMocks.getCustomerByOrg.mockResolvedValue(customerWithBillingCredits(150));
+      ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("150.0000000000");
       fetchRunsOrgUsageTotalSpy.mockResolvedValue({
         org_id: orgId,
         spent_cents: "25.0000000000",
@@ -187,7 +205,7 @@ describe("Accounts endpoints", () => {
 
     it("marks depleted when available <= 0", async () => {
       await insertTestAccount({ orgId });
-      ssMocks.getCustomerByOrg.mockResolvedValue(customerWithBillingCredits(0));
+      // Default sum mock returns "0", default usage 0 → available = 0 → depleted.
 
       const res = await request(app)
         .get("/v1/accounts/balance")

--- a/tests/integration/authorize-runs-total.test.ts
+++ b/tests/integration/authorize-runs-total.test.ts
@@ -9,7 +9,6 @@ import {
 } from "../helpers/test-db.js";
 import {
   setupStripeMocks,
-  customerWithBillingCredits,
   customerWithDefaultPM,
 } from "../helpers/mock-stripe.js";
 
@@ -21,7 +20,7 @@ const authorizeBody = {
   description: "runs-total authorize test",
 };
 
-describe("Customer balance authorize — composed SS + local − usage", () => {
+describe("Customer balance authorize — composed paid topups + local − usage", () => {
   const app = createTestApp();
   let ssMocks: ReturnType<typeof setupStripeMocks>;
   let fetchRunsOrgUsageTotalSpy: ReturnType<typeof vi.fn>;
@@ -50,10 +49,10 @@ describe("Customer balance authorize — composed SS + local − usage", () => {
     await closeDb();
   });
 
-  it("sufficient when SS balance + local credits − usage covers required", async () => {
+  it("sufficient when paid topups + local credits − usage covers required", async () => {
     await insertTestAccount({ orgId });
     await insertTestPromoGrant({ orgId, userId, amountCents: 100, promoCode: "welcome" });
-    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithBillingCredits(0));
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
     fetchRunsOrgUsageTotalSpy.mockResolvedValue({
       org_id: orgId,
       spent_cents: "40.0000000000",
@@ -75,12 +74,7 @@ describe("Customer balance authorize — composed SS + local − usage", () => {
 
   it("insufficient + no topup config → returns sufficient:false without reload", async () => {
     await insertTestAccount({ orgId });
-    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithBillingCredits(0));
-    fetchRunsOrgUsageTotalSpy.mockResolvedValue({
-      org_id: orgId,
-      spent_cents: "0.0000000000",
-      as_of: "x",
-    });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
 
     const res = await request(app)
       .post("/v1/customer_balance/authorize")
@@ -94,22 +88,10 @@ describe("Customer balance authorize — composed SS + local − usage", () => {
 
   it("insufficient + topup configured + SS has PM → calls reload and re-evaluates", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
-    ssMocks.getCustomerByOrg
-      .mockResolvedValueOnce({
-        ...customerWithBillingCredits(0),
-        ...customerWithDefaultPM(),
-        balance: 0,
-      })
-      .mockResolvedValueOnce({
-        ...customerWithBillingCredits(1000),
-        ...customerWithDefaultPM(),
-        balance: -1000,
-      });
-    fetchRunsOrgUsageTotalSpy.mockResolvedValue({
-      org_id: orgId,
-      spent_cents: "0.0000000000",
-      as_of: "x",
-    });
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+    ssMocks.sumSucceededTopupsForCustomer
+      .mockResolvedValueOnce("0.0000000000")
+      .mockResolvedValueOnce("1000.0000000000");
 
     const res = await request(app)
       .post("/v1/customer_balance/authorize")
@@ -124,11 +106,8 @@ describe("Customer balance authorize — composed SS + local − usage", () => {
 
   it("reload status=failed → sufficient:false", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
-    ssMocks.getCustomerByOrg.mockResolvedValue({
-      ...customerWithBillingCredits(0),
-      ...customerWithDefaultPM(),
-      balance: 0,
-    });
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
     ssMocks.reloadViaPaymentIntent.mockResolvedValue({
       status: "failed",
       failure_reason: "card_declined",
@@ -145,11 +124,8 @@ describe("Customer balance authorize — composed SS + local − usage", () => {
 
   it("reload throws (SS down) → 502", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
-    ssMocks.getCustomerByOrg.mockResolvedValue({
-      ...customerWithBillingCredits(0),
-      ...customerWithDefaultPM(),
-      balance: 0,
-    });
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
     ssMocks.reloadViaPaymentIntent.mockRejectedValue(new Error("SS down"));
 
     const res = await request(app)
@@ -162,11 +138,8 @@ describe("Customer balance authorize — composed SS + local − usage", () => {
 
   it("coalesces concurrent reload calls for same org", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
-    ssMocks.getCustomerByOrg.mockResolvedValue({
-      ...customerWithBillingCredits(0),
-      ...customerWithDefaultPM(),
-      balance: 0,
-    });
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
 
     ssMocks.reloadViaPaymentIntent.mockImplementation(
       () =>

--- a/tests/integration/usage-apply.test.ts
+++ b/tests/integration/usage-apply.test.ts
@@ -4,7 +4,6 @@ import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
 import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
 import {
   setupStripeMocks,
-  customerWithBillingCredits,
   customerWithDefaultPM,
 } from "../helpers/mock-stripe.js";
 
@@ -32,11 +31,8 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
       topupAmountCents: 1000,
       topupThresholdCents: 500,
     });
-    ssMocks.getCustomerByOrg.mockResolvedValue({
-      ...customerWithBillingCredits(1000),
-      ...customerWithDefaultPM(),
-      balance: -1000,
-    });
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("1000.0000000000");
 
     const res = await request(app)
       .post("/v1/customer_balance/usage_apply")
@@ -54,11 +50,8 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
       topupAmountCents: 1000,
       topupThresholdCents: 500,
     });
-    ssMocks.getCustomerByOrg.mockResolvedValue({
-      ...customerWithBillingCredits(600),
-      ...customerWithDefaultPM(),
-      balance: -600,
-    });
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("600.0000000000");
 
     const res = await request(app)
       .post("/v1/customer_balance/usage_apply")
@@ -76,7 +69,8 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
       topupAmountCents: 1000,
       topupThresholdCents: 500,
     });
-    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithBillingCredits(100));
+    // default mock customer has no PM
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("100.0000000000");
 
     const res = await request(app)
       .post("/v1/customer_balance/usage_apply")
@@ -107,11 +101,8 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
       topupAmountCents: 1000,
       topupThresholdCents: 500,
     });
-    ssMocks.getCustomerByOrg.mockResolvedValue({
-      ...customerWithBillingCredits(600),
-      ...customerWithDefaultPM(),
-      balance: -600,
-    });
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("600.0000000000");
     ssMocks.reloadViaPaymentIntent.mockResolvedValue({
       status: "failed",
       failure_reason: "decline",

--- a/tests/unit/stripe-service-client.test.ts
+++ b/tests/unit/stripe-service-client.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  sumSucceededTopupsForCustomer,
+  type StripePaymentIntent,
+  type StripePaymentIntentList,
+} from "../../src/lib/stripe-service-client.js";
+
+function pi(
+  id: string,
+  status: StripePaymentIntent["status"],
+  amount_received: number | null
+): StripePaymentIntent {
+  return {
+    id,
+    object: "payment_intent",
+    amount: amount_received ?? 0,
+    amount_received,
+    currency: "usd",
+    customer: "cus_test",
+    status,
+    last_payment_error: null,
+  };
+}
+
+function pageBody(data: StripePaymentIntent[], has_more: boolean): StripePaymentIntentList {
+  return {
+    object: "list",
+    url: "/v1/payment_intents",
+    data,
+    has_more,
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("sumSucceededTopupsForCustomer", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 0 when no payment intents exist", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(pageBody([], false)));
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("0.0000000000");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sums only succeeded payment intents with numeric amount_received", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pageBody(
+          [
+            pi("pi_1", "succeeded", 2500),
+            pi("pi_2", "requires_payment_method", 0),
+            pi("pi_3", "succeeded", 3000),
+            pi("pi_4", "canceled", null),
+            pi("pi_5", "succeeded", null),
+            pi("pi_6", "succeeded", 1750),
+          ],
+          false
+        )
+      )
+    );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("7250.0000000000");
+  });
+
+  it("paginates with starting_after when has_more=true", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          pageBody(
+            [pi("pi_p1_1", "succeeded", 1000), pi("pi_p1_2", "succeeded", 2000)],
+            true
+          )
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(pageBody([pi("pi_p2_1", "succeeded", 500)], false))
+      );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("3500.0000000000");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondUrl = fetchMock.mock.calls[1]?.[0] as string;
+    expect(secondUrl).toContain("starting_after=pi_p1_2");
+    expect(secondUrl).toContain("customer=cus_test");
+  });
+
+  it("throws when has_more=true is paired with an empty page", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(pageBody([], true)));
+
+    await expect(sumSucceededTopupsForCustomer({}, "cus_test")).rejects.toThrow(
+      "has_more=true with empty page"
+    );
+  });
+
+  it("throws when pagination exceeds the safety cap", async () => {
+    let id = 0;
+    fetchMock.mockImplementation(async () => {
+      id += 1;
+      return jsonResponse(pageBody([pi(`pi_${id}`, "succeeded", 1)], true));
+    });
+
+    await expect(sumSucceededTopupsForCustomer({}, "cus_test")).rejects.toThrow(
+      /pagination exceeded \d+ pages/
+    );
+  });
+
+  it("propagates stripe-service errors (fail-loud)", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("oops", { status: 500, headers: { "content-type": "text/plain" } })
+    );
+
+    await expect(sumSucceededTopupsForCustomer({}, "cus_test")).rejects.toThrow(
+      /stripe-service GET \/v1\/payment_intents.*failed: 500/
+    );
+  });
+
+  it("preserves fractional precision when amount_received is integer cents", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pageBody(
+          [pi("pi_1", "succeeded", 55000), pi("pi_2", "succeeded", 200)],
+          false
+        )
+      )
+    );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("55200.0000000000");
+  });
+});


### PR DESCRIPTION
Automated by release.sh