### PR TITLE
feat(billing): POST /internal/credits/grant for platform-issued grants (DIS-64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,3 +134,4 @@ Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed liv
 | `POST` | `/v1/customer_balance/authorize` | check if `balance_cents >= amount` ; auto-reload via PI if configured |
 | `POST` | `/v1/customer_balance/usage_apply` | proactive topup hint after a run; no-op for the ledger |
 | `POST` | `/v1/promotion_codes/redeem` | redeem promo code → insert `local_promos` row |
+| `POST` | `/internal/credits/grant` | platform-issued grant — body `{orgId, amountCents, reason: invite_reward\|invite_welcome}` → `{ok, newBalanceCents}`. Idempotent on `(orgId, reason)`. `invite_welcome` replaces the existing `$2` welcome row. Used by api-service invite claim handler (DIS-64). |

--- a/drizzle/0017_invite_promo_codes.sql
+++ b/drizzle/0017_invite_promo_codes.sql
@@ -1,0 +1,14 @@
+-- Seed platform-issued grant promo codes for DIS-64 (Wave 0.5 invite-only gate).
+--
+-- These two codes back the `POST /internal/credits/grant` endpoint:
+--   - invite_reward:  $25 to the inviter when an invitee signs up
+--   - invite_welcome: $25 to the invitee (replaces the $2 welcome via DELETE
+--     of the existing welcome row in the same tx — see lib/promos.ts grantCredit)
+--
+-- max_redemptions = NULL: cap is enforced upstream (3 invites/org in client-service),
+-- not by the promo code row.
+
+INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")
+VALUES ('invite_reward', 2500, NULL, NULL),
+       ('invite_welcome', 2500, NULL, NULL)
+ON CONFLICT ("code") DO NOTHING;

--- a/openapi.json
+++ b/openapi.json
@@ -347,6 +347,50 @@
           "code"
         ]
       },
+      "CreditGrantResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "newBalanceCents": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok",
+          "newBalanceCents"
+        ]
+      },
+      "CreditGrantRequest": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amountCents": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "invite_reward",
+              "invite_welcome"
+            ]
+          }
+        },
+        "required": [
+          "orgId",
+          "amountCents",
+          "reason"
+        ]
+      },
       "TransferBrandTableResult": {
         "type": "object",
         "properties": {
@@ -1457,6 +1501,63 @@
           },
           "409": {
             "description": "Promo code already redeemed by this org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/credits/grant": {
+      "post": {
+        "summary": "Grant platform-issued credit to an org (no user-redeemable code required)",
+        "description": "Inserts a local_promos row for an org under a reserved platform reason. Idempotent on (orgId, reason). When reason='invite_welcome', the existing $2 welcome row (if any) is deleted in the same tx so the invitee ends at the grant amount (not stacked). Returns the org's spendable balance after the grant.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreditGrantRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Grant applied (or already applied — idempotent)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreditGrantResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body or unknown reason",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "stripe-service or runs-service unavailable (balance compose failed)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -90,3 +90,16 @@ export type NewLocalPromo = typeof localPromos.$inferInsert;
 
 export const WELCOME_PROMO_CODE = "welcome";
 export const WELCOME_PROMO_AMOUNT_CENTS = 200;
+
+// Platform-issued grant codes (DIS-64 Wave 0.5 invite-only gate).
+// Backed by migration 0017. The invite_welcome grant replaces (not stacks)
+// the $2 welcome row at grant time — see lib/promos.ts grantCredit.
+export const INVITE_REWARD_CODE = "invite_reward";
+export const INVITE_WELCOME_CODE = "invite_welcome";
+export const INVITE_GRANT_AMOUNT_CENTS = 2500;
+
+export const PLATFORM_GRANT_REASONS = [
+  INVITE_REWARD_CODE,
+  INVITE_WELCOME_CODE,
+] as const;
+export type PlatformGrantReason = (typeof PLATFORM_GRANT_REASONS)[number];

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import checkoutRoutes from "./routes/checkout.js";
 import portalRoutes from "./routes/portal.js";
 import promotionCodesRoutes from "./routes/promotion_codes.js";
 import internalRoutes from "./routes/internal.js";
+import creditsRoutes from "./routes/credits.js";
 import { requireApiKey } from "./middleware/auth.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -41,6 +42,7 @@ app.get("/openapi.json", (_req, res) => {
 // Protected routes (service-to-service)
 app.use(requireApiKey);
 app.use(internalRoutes);
+app.use(creditsRoutes);
 app.use(accountsRoutes);
 app.use(customerBalanceRoutes);
 app.use(checkoutRoutes);

--- a/src/lib/promos.ts
+++ b/src/lib/promos.ts
@@ -5,6 +5,9 @@ import {
   localPromoCodes,
   localPromos,
   WELCOME_PROMO_CODE,
+  INVITE_WELCOME_CODE,
+  PLATFORM_GRANT_REASONS,
+  type PlatformGrantReason,
 } from "../db/schema.js";
 
 export class PromoNotFoundError extends Error {
@@ -124,6 +127,136 @@ export async function hasRedeemed(orgId: string, promoCodeId: string): Promise<b
     .where(and(eq(localPromos.orgId, orgId), eq(localPromos.promoCodeId, promoCodeId)))
     .limit(1);
   return !!row;
+}
+
+// System sentinel — internal grants have no human user. Matches the convention
+// used in /internal/transfer-brand (see routes/internal.ts).
+const SYSTEM_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+export class UnknownGrantReasonError extends Error {
+  constructor(reason: string) {
+    super(`unknown grant reason: ${reason}`);
+  }
+}
+
+export class GrantPromoCodeMissingError extends Error {
+  constructor(code: string) {
+    super(`grant promo code seed missing: ${code} (run migration 0017)`);
+  }
+}
+
+export interface GrantResult {
+  localPromoId: string;
+  promoCodeId: string;
+  alreadyGranted: boolean;
+}
+
+/**
+ * Platform-issued credit grant. Used by `/internal/credits/grant` to add credits
+ * without requiring a user-redeemable promo code.
+ *
+ * Idempotency: the UNIQUE (org_id, promo_code_id) index on local_promos makes
+ * repeated calls with the same (orgId, reason) a no-op (no double-grant).
+ *
+ * `invite_welcome` semantics: replaces (not stacks with) the $2 welcome row.
+ * The tx (a) inserts billing_accounts ON CONFLICT DO NOTHING so a concurrent
+ * findOrCreateAccount won't fire its own welcome-redeem branch, then (b)
+ * deletes any existing welcome row, then (c) inserts the invite_welcome row.
+ *
+ * `invite_reward` is purely additive — no override.
+ *
+ * Fails loud on unknown reasons (rejected upstream at the route).
+ */
+export async function grantCredit(
+  orgId: string,
+  amountCents: number,
+  reason: PlatformGrantReason
+): Promise<GrantResult> {
+  if (!PLATFORM_GRANT_REASONS.includes(reason)) {
+    throw new UnknownGrantReasonError(reason);
+  }
+
+  const codeRows = await db
+    .select()
+    .from(localPromoCodes)
+    .where(
+      reason === INVITE_WELCOME_CODE
+        ? rawSql`${localPromoCodes.code} IN (${reason}, ${WELCOME_PROMO_CODE})`
+        : eq(localPromoCodes.code, reason)
+    );
+
+  const grantCode = codeRows.find((r) => r.code === reason);
+  if (!grantCode) throw new GrantPromoCodeMissingError(reason);
+
+  const welcomeCode =
+    reason === INVITE_WELCOME_CODE
+      ? codeRows.find((r) => r.code === WELCOME_PROMO_CODE)
+      : undefined;
+
+  const description =
+    reason === INVITE_WELCOME_CODE
+      ? `Invite welcome: $${(amountCents / 100).toFixed(2)}`
+      : `Invite reward: $${(amountCents / 100).toFixed(2)}`;
+
+  return await db.transaction(async (tx) => {
+    // Pre-create the billing_accounts row so a concurrent findOrCreateAccount
+    // sees an existing row and skips its welcome-redeem side-effect path.
+    await tx
+      .insert(billingAccounts)
+      .values({ orgId })
+      .onConflictDoNothing();
+
+    if (reason === INVITE_WELCOME_CODE && welcomeCode) {
+      await tx
+        .delete(localPromos)
+        .where(
+          and(
+            eq(localPromos.orgId, orgId),
+            eq(localPromos.promoCodeId, welcomeCode.id)
+          )
+        );
+    }
+
+    const inserted = await tx
+      .insert(localPromos)
+      .values({
+        orgId,
+        userId: SYSTEM_USER_ID,
+        amountCents: String(amountCents),
+        promoCodeId: grantCode.id,
+        description,
+      })
+      .onConflictDoNothing({
+        target: [localPromos.orgId, localPromos.promoCodeId],
+      })
+      .returning();
+
+    if (inserted.length > 0) {
+      return {
+        localPromoId: inserted[0].id,
+        promoCodeId: grantCode.id,
+        alreadyGranted: false,
+      };
+    }
+
+    // Already granted — fetch existing row for the returned id.
+    const [existing] = await tx
+      .select({ id: localPromos.id })
+      .from(localPromos)
+      .where(
+        and(
+          eq(localPromos.orgId, orgId),
+          eq(localPromos.promoCodeId, grantCode.id)
+        )
+      )
+      .limit(1);
+
+    return {
+      localPromoId: existing.id,
+      promoCodeId: grantCode.id,
+      alreadyGranted: true,
+    };
+  });
 }
 
 /** Re-export billing_accounts table for callers that need it alongside promo helpers. */

--- a/src/routes/credits.ts
+++ b/src/routes/credits.ts
@@ -1,0 +1,86 @@
+import { Router } from "express";
+import { CreditGrantRequestSchema } from "../schemas.js";
+import {
+  grantCredit,
+  sumLocalPromoCreditsForOrg,
+  UnknownGrantReasonError,
+  GrantPromoCodeMissingError,
+} from "../lib/promos.js";
+import { addCents, subCents } from "../lib/cents.js";
+import {
+  getCustomerByOrg,
+  sumSucceededTopupsForCustomer,
+} from "../lib/stripe-service-client.js";
+import { fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
+
+const router = Router();
+
+// System sentinel userId mirroring routes/internal.ts. Internal grants are
+// service-to-service; downstream stripe-service / runs-service calls need an
+// identity header pair but there is no human user behind the action.
+const INTERNAL_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+// POST /internal/credits/grant — platform-issued credit grant.
+//
+// Auth: x-api-key only (orgId is in the body; no x-org-id header required).
+// Body: { orgId, amountCents, reason: 'invite_reward' | 'invite_welcome' }
+// Resp: { ok: true, newBalanceCents }
+//
+// Fails loud on:
+//   - invalid body / unknown reason → 400
+//   - stripe-service or runs-service unreachable while composing balance → 502
+//     (grant write itself is already committed and idempotent — caller may retry)
+router.post("/internal/credits/grant", async (req, res) => {
+  const parsed = CreditGrantRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.issues[0].message });
+    return;
+  }
+  const { orgId, amountCents, reason } = parsed.data;
+
+  try {
+    await grantCredit(orgId, amountCents, reason);
+  } catch (err) {
+    if (err instanceof UnknownGrantReasonError) {
+      res.status(400).json({ error: err.message });
+      return;
+    }
+    if (err instanceof GrantPromoCodeMissingError) {
+      console.error("[billing-service] credits/grant seed missing:", err);
+      res.status(500).json({ error: err.message });
+      return;
+    }
+    throw err;
+  }
+
+  const identity: Record<string, string> = {
+    "x-org-id": orgId,
+    "x-user-id": INTERNAL_USER_ID,
+  };
+
+  let newBalanceCents: string;
+  try {
+    const customer = await getCustomerByOrg(identity);
+    const [paidTopups, localCredits, runsUsage] = await Promise.all([
+      sumSucceededTopupsForCustomer(identity, customer.id),
+      sumLocalPromoCreditsForOrg(orgId),
+      fetchRunsOrgUsageTotal(orgId, identity),
+    ]);
+    const credited = addCents(paidTopups, localCredits);
+    newBalanceCents = subCents(credited, runsUsage.spent_cents);
+  } catch (err) {
+    console.error("[billing-service] credits/grant compose balance failed:", err);
+    res
+      .status(502)
+      .json({ error: "Grant applied but failed to compose new balance" });
+    return;
+  }
+
+  console.log(
+    `[billing-service] credit grant: org=${orgId} amount=${amountCents} reason=${reason} balance=${newBalanceCents}`
+  );
+
+  res.json({ ok: true as const, newBalanceCents });
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -146,6 +146,24 @@ export const RedeemPromotionCodeResponseSchema = z
   })
   .openapi("RedeemPromotionCodeResponse");
 
+// --- Internal Credit Grant (DIS-64 platform-issued grants) ---
+
+export const CreditGrantRequestSchema = z
+  .object({
+    orgId: z.string().uuid(),
+    amountCents: z.number().int().positive(),
+    reason: z.enum(["invite_reward", "invite_welcome"]),
+  })
+  .openapi("CreditGrantRequest");
+
+export const CreditGrantResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    /** Spendable funds after the grant (credited_cents − usage_cents). */
+    newBalanceCents: CentsStringSchema,
+  })
+  .openapi("CreditGrantResponse");
+
 // --- Transfer Brand ---
 
 export const TransferBrandRequestSchema = z
@@ -475,6 +493,38 @@ registry.registerPath({
 
 const internalHeaders = z.object({
   "x-api-key": z.string(),
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/internal/credits/grant",
+  summary: "Grant platform-issued credit to an org (no user-redeemable code required)",
+  description:
+    "Inserts a local_promos row for an org under a reserved platform reason. " +
+    "Idempotent on (orgId, reason). " +
+    "When reason='invite_welcome', the existing $2 welcome row (if any) is deleted " +
+    "in the same tx so the invitee ends at the grant amount (not stacked). " +
+    "Returns the org's spendable balance after the grant.",
+  request: {
+    headers: internalHeaders,
+    body: {
+      content: { "application/json": { schema: CreditGrantRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Grant applied (or already applied — idempotent)",
+      content: { "application/json": { schema: CreditGrantResponseSchema } },
+    },
+    400: {
+      description: "Invalid body or unknown reason",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "stripe-service or runs-service unavailable (balance compose failed)",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
 });
 
 registry.registerPath({

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -8,6 +8,7 @@ import checkoutRoutes from "../../src/routes/checkout.js";
 import portalRoutes from "../../src/routes/portal.js";
 import promotionCodesRoutes from "../../src/routes/promotion_codes.js";
 import internalRoutes from "../../src/routes/internal.js";
+import creditsRoutes from "../../src/routes/credits.js";
 import { requireApiKey } from "../../src/middleware/auth.js";
 
 export function createTestApp() {
@@ -20,6 +21,7 @@ export function createTestApp() {
 
   app.use(requireApiKey);
   app.use(internalRoutes);
+  app.use(creditsRoutes);
   app.use(accountsRoutes);
   app.use(customerBalanceRoutes);
   app.use(checkoutRoutes);

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,17 +1,28 @@
-import { eq, ne } from "drizzle-orm";
+import { eq, notInArray } from "drizzle-orm";
 import { db, sql } from "../../src/db/index.js";
 import {
   billingAccounts,
   localPromoCodes,
   localPromos,
   WELCOME_PROMO_CODE,
+  INVITE_REWARD_CODE,
+  INVITE_WELCOME_CODE,
 } from "../../src/db/schema.js";
+
+const SEEDED_PROMO_CODES = [
+  WELCOME_PROMO_CODE,
+  INVITE_REWARD_CODE,
+  INVITE_WELCOME_CODE,
+];
 
 export async function cleanTestData() {
   await db.delete(localPromos);
   await db.delete(billingAccounts);
-  // Keep the seeded welcome code; remove any test-created codes.
-  await db.delete(localPromoCodes).where(ne(localPromoCodes.code, WELCOME_PROMO_CODE));
+  // Keep seeded codes (welcome + invite_reward + invite_welcome); remove any
+  // test-created codes.
+  await db
+    .delete(localPromoCodes)
+    .where(notInArray(localPromoCodes.code, SEEDED_PROMO_CODES));
 }
 
 export async function insertTestAccount(data: {

--- a/tests/integration/credits-grant.test.ts
+++ b/tests/integration/credits-grant.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import {
+  cleanTestData,
+  insertTestAccount,
+  insertTestPromoGrant,
+  closeDb,
+} from "../helpers/test-db.js";
+import { setupStripeMocks } from "../helpers/mock-stripe.js";
+import { db } from "../../src/db/index.js";
+import {
+  billingAccounts,
+  localPromoCodes,
+  localPromos,
+  WELCOME_PROMO_CODE,
+  INVITE_REWARD_CODE,
+  INVITE_WELCOME_CODE,
+} from "../../src/db/schema.js";
+
+describe("POST /internal/credits/grant", () => {
+  const app = createTestApp();
+  const orgId = "00000000-0000-0000-0000-000000000001";
+  const systemUserId = "00000000-0000-0000-0000-000000000000";
+  let ssMocks: ReturnType<typeof setupStripeMocks>;
+  let fetchRunsOrgUsageTotalSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    ssMocks = setupStripeMocks();
+    await cleanTestData();
+
+    const runsClient = await import("../../src/lib/runs-client.js");
+    fetchRunsOrgUsageTotalSpy = vi.fn().mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "0.0000000000",
+      as_of: "2026-05-27T00:00:00.000Z",
+    });
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(
+      fetchRunsOrgUsageTotalSpy
+    );
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  function authHeaders() {
+    return {
+      "X-API-Key": "test-api-key",
+      "Content-Type": "application/json",
+    };
+  }
+
+  async function getPromoCodeId(code: string): Promise<string> {
+    const [row] = await db
+      .select()
+      .from(localPromoCodes)
+      .where(eq(localPromoCodes.code, code))
+      .limit(1);
+    if (!row) throw new Error(`promo code missing in test seed: ${code}`);
+    return row.id;
+  }
+
+  async function getPromosForOrg(targetOrgId: string) {
+    return db
+      .select()
+      .from(localPromos)
+      .where(eq(localPromos.orgId, targetOrgId));
+  }
+
+  it("T1: virgin org invite_welcome grant inserts billing_accounts + invite_welcome row, balance $25", async () => {
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_welcome" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.newBalanceCents).toBe("2500.0000000000");
+
+    const [account] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId))
+      .limit(1);
+    expect(account).toBeDefined();
+
+    const grants = await getPromosForOrg(orgId);
+    expect(grants).toHaveLength(1);
+    const inviteWelcomeId = await getPromoCodeId(INVITE_WELCOME_CODE);
+    expect(grants[0].promoCodeId).toBe(inviteWelcomeId);
+    expect(grants[0].amountCents).toBe("2500.0000000000");
+    expect(grants[0].userId).toBe(systemUserId);
+  });
+
+  it("T2: virgin org invite_reward grant inserts billing_accounts + invite_reward row, balance $25", async () => {
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_reward" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.newBalanceCents).toBe("2500.0000000000");
+
+    const grants = await getPromosForOrg(orgId);
+    expect(grants).toHaveLength(1);
+    const inviteRewardId = await getPromoCodeId(INVITE_REWARD_CODE);
+    expect(grants[0].promoCodeId).toBe(inviteRewardId);
+  });
+
+  it("T3: invite_welcome override — replaces existing $2 welcome (final $25, not $27)", async () => {
+    await insertTestAccount({ orgId });
+    await insertTestPromoGrant({
+      orgId,
+      userId: systemUserId,
+      amountCents: 200,
+      promoCode: WELCOME_PROMO_CODE,
+    });
+
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_welcome" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.newBalanceCents).toBe("2500.0000000000");
+
+    const grants = await getPromosForOrg(orgId);
+    expect(grants).toHaveLength(1);
+    const inviteWelcomeId = await getPromoCodeId(INVITE_WELCOME_CODE);
+    expect(grants[0].promoCodeId).toBe(inviteWelcomeId);
+    expect(grants[0].amountCents).toBe("2500.0000000000");
+  });
+
+  it("T4: double invite_welcome grant is idempotent (balance unchanged)", async () => {
+    await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_welcome" });
+
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_welcome" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.newBalanceCents).toBe("2500.0000000000");
+
+    const grants = await getPromosForOrg(orgId);
+    expect(grants).toHaveLength(1);
+  });
+
+  it("T5: double invite_reward grant is idempotent (balance unchanged)", async () => {
+    await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_reward" });
+
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_reward" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.newBalanceCents).toBe("2500.0000000000");
+
+    const grants = await getPromosForOrg(orgId);
+    expect(grants).toHaveLength(1);
+  });
+
+  it("T6: invite_reward is additive — does NOT override welcome ($2 + $25 = $27)", async () => {
+    await insertTestAccount({ orgId });
+    await insertTestPromoGrant({
+      orgId,
+      userId: systemUserId,
+      amountCents: 200,
+      promoCode: WELCOME_PROMO_CODE,
+    });
+
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_reward" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.newBalanceCents).toBe("2700.0000000000");
+
+    const grants = await getPromosForOrg(orgId);
+    expect(grants).toHaveLength(2);
+    const codes = await Promise.all([
+      getPromoCodeId(WELCOME_PROMO_CODE),
+      getPromoCodeId(INVITE_REWARD_CODE),
+    ]);
+    expect(grants.map((g) => g.promoCodeId).sort()).toEqual(codes.sort());
+  });
+
+  it("T7: rejects unknown reason with 400", async () => {
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "foo" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("T8: rejects without API key with 401", async () => {
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set({ "Content-Type": "application/json" })
+      .send({ orgId, amountCents: 2500, reason: "invite_welcome" });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("T9: rejects invalid orgId UUID with 400", async () => {
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId: "not-a-uuid", amountCents: 2500, reason: "invite_welcome" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-positive amountCents with 400", async () => {
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 0, reason: "invite_welcome" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("composes balance with paid topups and usage", async () => {
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("10000.0000000000");
+    fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "1234.5000000000",
+      as_of: "2026-05-27T00:00:00.000Z",
+    });
+
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_reward" });
+
+    expect(res.status).toBe(200);
+    // 10000 paid + 2500 grant − 1234.5 usage = 11265.5
+    expect(res.body.newBalanceCents).toBe("11265.5000000000");
+  });
+
+  it("returns 502 when stripe-service unavailable (balance compose fails after grant write)", async () => {
+    ssMocks.getCustomerByOrg.mockRejectedValue(new Error("stripe-service down"));
+
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_welcome" });
+
+    expect(res.status).toBe(502);
+
+    // Grant write must already have committed — retry will be idempotent.
+    const grants = await getPromosForOrg(orgId);
+    expect(grants).toHaveLength(1);
+  });
+
+  it("returns 502 when runs-service unavailable", async () => {
+    fetchRunsOrgUsageTotalSpy.mockRejectedValue(new Error("runs-service down"));
+
+    const res = await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_reward" });
+
+    expect(res.status).toBe(502);
+
+    const grants = await getPromosForOrg(orgId);
+    expect(grants).toHaveLength(1);
+  });
+
+  it("grant before /v1/accounts prevents welcome from being re-applied", async () => {
+    // Simulate api-service ordering: grant called first, then dashboard hits /v1/accounts.
+    await request(app)
+      .post("/internal/credits/grant")
+      .set(authHeaders())
+      .send({ orgId, amountCents: 2500, reason: "invite_welcome" });
+
+    const res = await request(app)
+      .get("/v1/accounts")
+      .set(getAuthHeaders(orgId));
+
+    expect(res.status).toBe(200);
+    expect(res.body.credited_cents).toBe("2500.0000000000");
+    // ensureCustomer must NOT fire — billing_accounts row already exists from the grant tx.
+    expect(ssMocks.ensureCustomer).not.toHaveBeenCalled();
+
+    const grants = await getPromosForOrg(orgId);
+    expect(grants).toHaveLength(1);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -75,6 +75,14 @@ beforeAll(async () => {
     ON CONFLICT ("code") DO NOTHING
   `;
 
+  // Seed platform-issued grant promo codes (matches migration 0017).
+  await sql`
+    INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")
+    VALUES ('invite_reward', 2500, NULL, NULL),
+           ('invite_welcome', 2500, NULL, NULL)
+    ON CONFLICT ("code") DO NOTHING
+  `;
+
   // Drop legacy tables that may linger.
   await sql`DROP TABLE IF EXISTS "customer_balance_transactions"`;
   await sql`DROP TABLE IF EXISTS "cbt_archive_pre104_usage"`;


### PR DESCRIPTION
## Summary

DIS-64 Wave 0.5 (invite-only gate + \$25/\$25 referral reward) — billing-service slice.

Adds `POST /internal/credits/grant` so api-service can grant \$25 to inviter and \$25 to invitee when an invitee claims an invite. Existing `/v1/promotion_codes/redeem` requires a pre-existing user-facing code and is the wrong shape for platform-issued grants.

## URL contract (locked)

```
POST /internal/credits/grant
  Auth:  x-api-key (no x-org-id header)
  Body:  { orgId: uuid, amountCents: int>0, reason: 'invite_reward' | 'invite_welcome' }
  Resp:  { ok: true, newBalanceCents: string }
  Errors:
    400  invalid body / unknown reason
    401  missing/bad api key
    502  stripe-service or runs-service unreachable (compose balance)
    500  invite promo code seed missing (migration 0017 not applied)
```

## Decision: Option A (new endpoint) over Option B (extend redeem)

- `redeem` hard-binds `localPromos.promoCodeId` NOT NULL → FK on `local_promo_codes`. Bypass forces nullable FK schema migration.
- `redeem` is `/v1/` (org-scoped, requires `x-org-id` header). Grant is `/internal/` (orgId in body) — matches existing `/internal/transfer-brand` convention.
- Response-shape mismatch (`{redeemed, amount_cents, local_credits_total_cents}` vs `{ok, newBalanceCents}`).

## \$2 welcome override

Existing \$2 welcome credit lives at `src/lib/account.ts:52` — `findOrCreateAccount` redeems `'welcome'` promo on the first billing call for an org.

When `reason='invite_welcome'`, the grant tx replaces the welcome row:
1. `INSERT INTO billing_accounts ON CONFLICT DO NOTHING` — ensures account row, blocks `findOrCreateAccount` welcome-redeem branch (which only fires when its own INSERT wins).
2. `DELETE FROM local_promos WHERE org_id=$1 AND promo_code_id=$welcomeId` — removes any \$2 welcome row already present.
3. `INSERT INTO local_promos (...invite_welcome...) ON CONFLICT DO NOTHING` — idempotent on (org_id, promo_code_id).

Both call orderings (grant-before-/v1/accounts and after) converge to \$25, not \$27. `invite_reward` is purely additive — no override.

## Idempotency

Existing UNIQUE (org_id, promo_code_id) index makes repeated calls with the same (orgId, reason) a no-op. No externalRef needed for this slice.

## Tests

`tests/integration/credits-grant.test.ts` covers:

- T1: virgin org `invite_welcome` → balance \$25
- T2: virgin org `invite_reward` → balance \$25
- T3: org with \$2 welcome → `invite_welcome` → balance \$25 (NOT \$27)
- T4: double `invite_welcome` → idempotent
- T5: double `invite_reward` → idempotent
- T6: org with \$2 welcome → `invite_reward` → balance \$27 (no override)
- T7: unknown reason → 400
- T8: missing api-key → 401
- T9: invalid orgId UUID → 400
- non-positive amountCents → 400
- balance composes paid topups + grant − usage
- stripe-service down → 502, grant write still committed
- runs-service down → 502, grant write still committed
- grant-before-/v1/accounts prevents welcome re-application

All 123 existing tests still green.

## Files

- `drizzle/0017_invite_promo_codes.sql` — seeds `invite_reward` + `invite_welcome` (\$2500 each, max_redemptions=NULL)
- `src/db/schema.ts` — constants `INVITE_REWARD_CODE`, `INVITE_WELCOME_CODE`, `INVITE_GRANT_AMOUNT_CENTS`, `PLATFORM_GRANT_REASONS`
- `src/lib/promos.ts` — `grantCredit()` helper with tx + override semantics
- `src/routes/credits.ts` — new route file
- `src/schemas.ts` — `CreditGrantRequestSchema` + Response + OpenAPI path
- `src/index.ts` + `tests/helpers/test-app.ts` — mount
- `tests/setup.ts` + `tests/helpers/test-db.ts` — seed + preserve invite codes
- `CLAUDE.md` — endpoints reference row
- `openapi.json` — regen

## Out of scope

- api-service orchestration (separate workspace per DIS-64 multi-repo plan)
- General-purpose platform grants (other `reason` values). Scope-cut; follow-up issue would either externalRef-key dedup or per-reason seeding.

Refs: DIS-64 (parent DIS-9 Shareability Master Plan).

## Test plan

- [x] `pnpm build` (typecheck) green
- [x] `pnpm test` — 123 tests pass (existing) + 14 new
- [ ] CI green on staging branch
- [ ] api-service consumer wire-up uses the locked contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)