### PR TITLE
hotfix: Gate auto-reload on attached card PM, not Stripe default PM (fixes silent no-reload + insufficient-credits crash)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Billing never duplicates Stripe state and never persists run-level usage rows.
 
 - Customer fetch is **org-implicit** via `GET /v1/customers?limit=1` (resolved server-side from `x-org-id`). No `stripe_customer_id` is stored in billing.
 - Balance is derived from the Stripe customer object: `balance_cents = -customer.balance` (sign-flip, Stripe convention is `balance > 0` = customer owes).
-- `has_payment_method` is derived from `customer.invoice_settings.default_payment_method != null`.
+- `has_payment_method` is derived from whether the customer has ≥1 attached **card** PM (`hasAttachedCardPm` → `GET /v1/payment_methods?customer=cus_X&type=card`). It deliberately does **not** read `customer.invoice_settings.default_payment_method`: Stripe leaves the default null after a normal `setup_future_usage` checkout and refuses to charge Link/wallet default PMs off_session, so a default-PM check blocks reloads for orgs that in fact have a chargeable card. This mirrors exactly what `reload.ts` charges (first attached card). The same `hasAttachedCardPm` gate fronts auto-reload in `authorize` + `usage_apply` and the `PATCH /v1/accounts/auto_topup` PM requirement. Fail-loud: a stripe-service error propagates (502); only an empty card list → false.
 - Reload is composed billing-side via `POST /v1/payment_intents` with `confirm:true, off_session:true` + `Idempotency-Key` header. Stripe status flattened to `{succeeded|failed}` in `src/lib/reload.ts`.
 - Balance transactions list uses the org-implicit `GET /v1/balance_transactions` (no customer id needed).
 
@@ -84,7 +84,7 @@ The same CSV convention applies to the `x-brand-id` header forwarded by workflow
   "balance_cents": "16910.7042000000",       // credited_cents − usage_cents; USE THIS for depletion/budget gates
   "topup_amount_cents": 2500,                // auto-topup amount
   "topup_threshold_cents": 500,              // auto-topup triggers when balance_cents < threshold
-  "has_payment_method": true,                // derived from customer.invoice_settings.default_payment_method != null
+  "has_payment_method": true,                // ≥1 attached card PM (GET /v1/payment_methods?type=card); NOT invoice_settings.default_payment_method
   "has_auto_topup": true,
   "created_at": "...",
   "updated_at": "..."
@@ -94,11 +94,12 @@ The same CSV convention applies to the `x-brand-id` header forwarded by workflow
 All three credited/usage/balance endpoints fail loud (502) when runs-service or stripe-service is unreachable.
 
 Composition (`src/routes/accounts.ts:composeAccountFunds`):
-1. `getCustomerByOrg(identity)` → Stripe customer (for `id` and `default_payment_method`)
+1. `getCustomerByOrg(identity)` → Stripe customer (for `id`)
 2. `sumSucceededTopupsForCustomer(identity, customer.id)` → paginates `GET /v1/payment_intents?customer=cus_X` and sums `amount_received` where `status='succeeded'`
 3. `sumLocalPromoCreditsForOrg(orgId)` → SUM `local_promos.amount_cents`
 4. `fetchRunsOrgUsageTotal(orgId, identity)` → runs-service `spent_cents`
-5. `credited_cents = paid_topups + local_credits` ; `balance_cents = credited_cents − usage`
+5. `hasAttachedCardPm(identity, customer.id)` → `has_payment_method` (≥1 attached card PM)
+6. `credited_cents = paid_topups + local_credits` ; `balance_cents = credited_cents − usage`
 
 ### `GET /public/stats/billing`
 

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -343,6 +343,28 @@ export async function updateCustomer(
 
 // --- Derivations from Stripe customer ---
 
-export function deriveHasPaymentMethod(customer: StripeCustomer): boolean {
-  return Boolean(customer.invoice_settings?.default_payment_method);
+/**
+ * True iff the org's Stripe customer has at least one attached CARD payment method.
+ *
+ * This is the chargeable-PM definition shared by the reload gates (authorize /
+ * usage_apply) and the public `has_payment_method` surface. It MUST mirror what
+ * `reload.ts` actually charges — the first attached card from
+ * `GET /v1/payment_methods?type=card`.
+ *
+ * Deliberately NOT keyed on `customer.invoice_settings.default_payment_method`:
+ * Stripe leaves that null after a normal `setup_future_usage` checkout, and refuses
+ * to charge Link / wallet default PMs off_session. A default-PM gate therefore blocks
+ * auto-reloads for customers who in fact have a chargeable card attached (the bug
+ * this replaces — gate read `default_payment_method`, charge read the card list).
+ *
+ * Fail-loud: a stripe-service error (404 customer-not-in-mirror, timeout, 5xx) is
+ * propagated by `listPaymentMethods`. ONLY an empty card list returns false — an
+ * error is never collapsed into "no payment method".
+ */
+export async function hasAttachedCardPm(
+  identity: IdentityHeaders,
+  customerId: string
+): Promise<boolean> {
+  const methods = await listPaymentMethods(identity, { customer: customerId, type: "card" });
+  return methods.data.length > 0;
 }

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -11,7 +11,7 @@ import { sumLocalPromoCreditsForOrg } from "../lib/promos.js";
 import {
   getCustomerByOrg,
   sumSucceededTopupsForCustomer,
-  deriveHasPaymentMethod,
+  hasAttachedCardPm,
 } from "../lib/stripe-service-client.js";
 
 const router = Router();
@@ -41,10 +41,11 @@ async function composeAccountFunds(
   hasPaymentMethod: boolean;
 }> {
   const customer = await getCustomerByOrg(identity);
-  const [paidTopups, localCredits, runsUsage] = await Promise.all([
+  const [paidTopups, localCredits, runsUsage, hasCardPm] = await Promise.all([
     sumSucceededTopupsForCustomer(identity, customer.id),
     sumLocalPromoCreditsForOrg(orgId),
     fetchRunsOrgUsageTotal(orgId, identity),
+    hasAttachedCardPm(identity, customer.id),
   ]);
   const creditedCents = addCents(paidTopups, localCredits);
   const balanceCents = subCents(creditedCents, runsUsage.spent_cents);
@@ -52,7 +53,7 @@ async function composeAccountFunds(
     creditedCents,
     usageCents: runsUsage.spent_cents,
     balanceCents,
-    hasPaymentMethod: deriveHasPaymentMethod(customer),
+    hasPaymentMethod: hasCardPm,
   };
 }
 
@@ -165,16 +166,17 @@ router.patch("/v1/accounts/auto_topup", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    let customer;
+    let hasCardPm: boolean;
     try {
-      customer = await getCustomerByOrg(identity);
+      const customer = await getCustomerByOrg(identity);
+      hasCardPm = await hasAttachedCardPm(identity, customer.id);
     } catch (err) {
       console.error("[billing-service] Failed to fetch customer for PM check:", err);
       res.status(502).json({ error: "Failed to query payment method status" });
       return;
     }
 
-    if (!deriveHasPaymentMethod(customer)) {
+    if (!hasCardPm) {
       res.status(400).json({
         error: "Payment method required. Create a checkout session first.",
       });

--- a/src/routes/customer_balance.ts
+++ b/src/routes/customer_balance.ts
@@ -13,7 +13,7 @@ import { sumLocalPromoCreditsForOrg } from "../lib/promos.js";
 import {
   getCustomerByOrg,
   sumSucceededTopupsForCustomer,
-  deriveHasPaymentMethod,
+  hasAttachedCardPm,
   type StripeCustomer,
 } from "../lib/stripe-service-client.js";
 import { reloadViaPaymentIntent } from "../lib/reload.js";
@@ -62,6 +62,7 @@ function withTimeout<T>(ms: number, p: Promise<T>): Promise<T> {
 
 interface BalanceSnapshot {
   customer: StripeCustomer;
+  hasCardPm: boolean;
   creditedCents: string;
   usageCents: string;
   balanceCents: string;
@@ -72,14 +73,15 @@ async function computeBalance(
   identity: Record<string, string>
 ): Promise<BalanceSnapshot> {
   const customer = await getCustomerByOrg(identity);
-  const [paidTopups, localCredits, runsUsage] = await Promise.all([
+  const [paidTopups, localCredits, runsUsage, hasCardPm] = await Promise.all([
     sumSucceededTopupsForCustomer(identity, customer.id),
     sumLocalPromoCreditsForOrg(orgId),
     fetchRunsOrgUsageTotal(orgId, identity),
+    hasAttachedCardPm(identity, customer.id),
   ]);
   const creditedCents = addCents(paidTopups, localCredits);
   const balanceCents = subCents(creditedCents, runsUsage.spent_cents);
-  return { customer, creditedCents, usageCents: runsUsage.spent_cents, balanceCents };
+  return { customer, hasCardPm, creditedCents, usageCents: runsUsage.spent_cents, balanceCents };
 }
 
 router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res) => {
@@ -144,7 +146,7 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
       return;
     }
 
-    if (!deriveHasPaymentMethod(snapshot.customer)) {
+    if (!snapshot.hasCardPm) {
       sendEmail({ eventType: "credits-depleted", orgId, userId, runId, workflowHeaders: wfHeaders });
       res.json({
         sufficient: false,
@@ -252,7 +254,7 @@ router.post("/v1/customer_balance/usage_apply", requireOrgHeaders, async (req, r
 
     const customer = await getCustomerByOrg(identity);
 
-    if (!deriveHasPaymentMethod(customer)) {
+    if (!(await hasAttachedCardPm(identity, customer.id))) {
       res.status(202).json({ acknowledged: true, topup_triggered: false });
       return;
     }

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -10,6 +10,7 @@ export interface StripeServiceMocks {
   getPaymentIntent: ReturnType<typeof vi.fn>;
   listPaymentIntents: ReturnType<typeof vi.fn>;
   listPaymentMethods: ReturnType<typeof vi.fn>;
+  hasAttachedCardPm: ReturnType<typeof vi.fn>;
   sumSucceededTopupsForCustomer: ReturnType<typeof vi.fn>;
   listCustomersByMetadata: ReturnType<typeof vi.fn>;
   updateCustomer: ReturnType<typeof vi.fn>;
@@ -79,6 +80,7 @@ export function setupStripeMocks(): StripeServiceMocks {
       ],
       has_more: false,
     }),
+    hasAttachedCardPm: vi.fn().mockResolvedValue(true),
     sumSucceededTopupsForCustomer: vi.fn().mockResolvedValue("0.0000000000"),
     createCheckoutSession: vi.fn().mockResolvedValue({
       url: "https://checkout.stripe.com/pay/cs_mock",
@@ -114,6 +116,7 @@ export function setupStripeMocks(): StripeServiceMocks {
   vi.spyOn(ssClient, "getPaymentIntent").mockImplementation(mocks.getPaymentIntent);
   vi.spyOn(ssClient, "listPaymentIntents").mockImplementation(mocks.listPaymentIntents);
   vi.spyOn(ssClient, "listPaymentMethods").mockImplementation(mocks.listPaymentMethods);
+  vi.spyOn(ssClient, "hasAttachedCardPm").mockImplementation(mocks.hasAttachedCardPm);
   vi.spyOn(ssClient, "sumSucceededTopupsForCustomer").mockImplementation(
     mocks.sumSucceededTopupsForCustomer
   );

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -5,6 +5,7 @@ import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js
 import {
   setupStripeMocks,
   customerWithDefaultPM,
+  customerWithoutPM,
 } from "../helpers/mock-stripe.js";
 
 describe("Accounts endpoints", () => {
@@ -37,6 +38,8 @@ describe("Accounts endpoints", () => {
 
   describe("GET /v1/accounts", () => {
     it("auto-creates a billing account with welcome promo redemption", async () => {
+      ssMocks.hasAttachedCardPm.mockResolvedValue(false);
+
       const res = await request(app)
         .get("/v1/accounts")
         .set(getAuthHeaders(orgId));
@@ -89,9 +92,11 @@ describe("Accounts endpoints", () => {
       expect(res.body.balance_cents).toBe("-308.0000000000");
     });
 
-    it("derives has_payment_method from invoice_settings.default_payment_method", async () => {
+    it("derives has_payment_method from attached card PMs (ignores default_payment_method)", async () => {
       await insertTestAccount({ orgId });
-      ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+      // No default PM set, but a card is attached → has_payment_method must be true.
+      ssMocks.getCustomerByOrg.mockResolvedValue(customerWithoutPM());
+      ssMocks.hasAttachedCardPm.mockResolvedValue(true);
 
       const res = await request(app)
         .get("/v1/accounts")
@@ -241,7 +246,7 @@ describe("Accounts endpoints", () => {
 
     it("rejects when SS reports no payment method", async () => {
       await insertTestAccount({ orgId });
-      // default mock has invoice_settings.default_payment_method = null
+      ssMocks.hasAttachedCardPm.mockResolvedValue(false);
 
       const res = await request(app)
         .patch("/v1/accounts/auto_topup")

--- a/tests/integration/authorize-runs-total.test.ts
+++ b/tests/integration/authorize-runs-total.test.ts
@@ -104,6 +104,56 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(1000);
   });
 
+  it("insufficient + topup + card attached but no default PM → fires reload (regression)", async () => {
+    await insertTestAccount({ orgId, topupAmountCents: 1000 });
+    // Customer has NO default_payment_method, but a card is attached. The gate now
+    // keys on the attached card (hasAttachedCardPm), not invoice_settings.default.
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM({ invoice_settings: { default_payment_method: null } }));
+    ssMocks.hasAttachedCardPm.mockResolvedValue(true);
+    ssMocks.sumSucceededTopupsForCustomer
+      .mockResolvedValueOnce("0.0000000000")
+      .mockResolvedValueOnce("1000.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(getAuthHeaders(orgId, userId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sufficient).toBe(true);
+    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(1000);
+  });
+
+  it("insufficient + topup + no card attached → graceful sufficient:false, no reload", async () => {
+    await insertTestAccount({ orgId, topupAmountCents: 1000 });
+    ssMocks.hasAttachedCardPm.mockResolvedValue(false);
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(getAuthHeaders(orgId, userId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sufficient).toBe(false);
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("PM lookup errors (stripe-service down) → 502, never silent no-PM", async () => {
+    await insertTestAccount({ orgId, topupAmountCents: 1000 });
+    ssMocks.hasAttachedCardPm.mockRejectedValue(new Error("stripe-service down"));
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(getAuthHeaders(orgId, userId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(502);
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
   it("reload status=failed → sufficient:false", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
     ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());

--- a/tests/integration/usage-apply.test.ts
+++ b/tests/integration/usage-apply.test.ts
@@ -63,13 +63,34 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
     expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
   });
 
-  it("does not topup when PM missing", async () => {
+  it("triggers reload when card attached but no default PM (regression)", async () => {
     await insertTestAccount({
       orgId,
       topupAmountCents: 1000,
       topupThresholdCents: 500,
     });
-    // default mock customer has no PM
+    // Customer has no default_payment_method, but a card is attached.
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM({ invoice_settings: { default_payment_method: null } }));
+    ssMocks.hasAttachedCardPm.mockResolvedValue(true);
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("600.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/usage_apply")
+      .set(getAuthHeaders(orgId, userId))
+      .send({ spent_total_cents: "200.0000000000" });
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ acknowledged: true, topup_triggered: true });
+    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not topup when no card attached", async () => {
+    await insertTestAccount({
+      orgId,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    ssMocks.hasAttachedCardPm.mockResolvedValue(false);
     ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("100.0000000000");
 
     const res = await request(app)

--- a/tests/unit/stripe-service-client.test.ts
+++ b/tests/unit/stripe-service-client.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   sumSucceededTopupsForCustomer,
+  hasAttachedCardPm,
   type StripePaymentIntent,
   type StripePaymentIntentList,
+  type StripePaymentMethod,
 } from "../../src/lib/stripe-service-client.js";
 
 function pi(
@@ -147,5 +149,57 @@ describe("sumSucceededTopupsForCustomer", () => {
     const total = await sumSucceededTopupsForCustomer({}, "cus_test");
 
     expect(total).toBe("55200.0000000000");
+  });
+});
+
+describe("hasAttachedCardPm", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function pmListBody(data: StripePaymentMethod[]) {
+    return { object: "list", url: "/v1/payment_methods", data, has_more: false };
+  }
+
+  it("returns true when a card payment method is attached", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(pmListBody([{ id: "pm_1", object: "payment_method", type: "card" }]))
+    );
+
+    expect(await hasAttachedCardPm({}, "cus_test")).toBe(true);
+  });
+
+  it("returns false when no payment methods are attached", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(pmListBody([])));
+
+    expect(await hasAttachedCardPm({}, "cus_test")).toBe(false);
+  });
+
+  it("requests only card-type payment methods for the customer", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(pmListBody([])));
+
+    await hasAttachedCardPm({}, "cus_test");
+
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain("/v1/payment_methods");
+    expect(url).toContain("customer=cus_test");
+    expect(url).toContain("type=card");
+  });
+
+  it("propagates stripe-service errors — never collapses to false (fail-loud)", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("not found", { status: 404, headers: { "content-type": "text/plain" } })
+    );
+
+    await expect(hasAttachedCardPm({}, "cus_test")).rejects.toThrow(
+      /stripe-service GET \/v1\/payment_methods.*failed: 404/
+    );
   });
 });


### PR DESCRIPTION
Automated by release.sh