### PR TITLE
fix(billing): bump welcome trial gift $2 → $25 (2500¢)

### DIFF
--- a/drizzle/0018_welcome_amount_2500.sql
+++ b/drizzle/0018_welcome_amount_2500.sql
@@ -1,0 +1,12 @@
+-- Bump the welcome trial gift from $2 (200¢) to $25 (2500¢).
+--
+-- distribute.you landing pages advertise "$25 welcome credits", but new signups
+-- received only $2. redeemPromoCode('welcome') (lib/account.ts findOrCreateAccount)
+-- reads local_promo_codes.amount_cents at redeem time, so bumping this row makes
+-- all NEW redemptions grant $25.
+--
+-- No backfill: orgs that already redeemed the $2 welcome keep their existing
+-- $2 local_promos row (new signups only).
+--
+-- Idempotent: single-row UPDATE keyed on a unique code, re-running is a no-op.
+UPDATE "local_promo_codes" SET "amount_cents" = 2500 WHERE "code" = 'welcome';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1789552800000,
       "tag": "0016_drop_cbt_create_local_promos",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1789639200000,
+      "tag": "0018_welcome_amount_2500",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -89,11 +89,14 @@ export type LocalPromo = typeof localPromos.$inferSelect;
 export type NewLocalPromo = typeof localPromos.$inferInsert;
 
 export const WELCOME_PROMO_CODE = "welcome";
-export const WELCOME_PROMO_AMOUNT_CENTS = 200;
+// $25 welcome trial gift. Source of truth for live redemptions is the
+// local_promo_codes row (seeded by migration 0016 @200, bumped to 2500 by
+// migration 0018); this constant documents the canonical amount.
+export const WELCOME_PROMO_AMOUNT_CENTS = 2500;
 
 // Platform-issued grant codes (DIS-64 Wave 0.5 invite-only gate).
 // Backed by migration 0017. The invite_welcome grant replaces (not stacks)
-// the $2 welcome row at grant time — see lib/promos.ts grantCredit.
+// the welcome row at grant time — see lib/promos.ts grantCredit.
 export const INVITE_REWARD_CODE = "invite_reward";
 export const INVITE_WELCOME_CODE = "invite_welcome";
 export const INVITE_GRANT_AMOUNT_CENTS = 2500;

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -46,10 +46,10 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.org_id).toBe(orgId);
-      // SS paid = 0, local welcome = 200, usage = 0 → credited 200, balance 200.
-      expect(res.body.credited_cents).toBe("200.0000000000");
+      // SS paid = 0, local welcome = 2500, usage = 0 → credited 2500, balance 2500.
+      expect(res.body.credited_cents).toBe("2500.0000000000");
       expect(res.body.usage_cents).toBe("0.0000000000");
-      expect(res.body.balance_cents).toBe("200.0000000000");
+      expect(res.body.balance_cents).toBe("2500.0000000000");
       expect(res.body.has_payment_method).toBe(false);
       expect(res.body.has_auto_topup).toBe(false);
       expect(ssMocks.ensureCustomer).toHaveBeenCalled();

--- a/tests/integration/promo.test.ts
+++ b/tests/integration/promo.test.ts
@@ -56,8 +56,23 @@ describe("Promotion code endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.redeemed).toBe(true);
-      // welcome 200 + promo 1000 = 1200.
-      expect(res.body.local_credits_total_cents).toBe("1200.0000000000");
+      // welcome 2500 + promo 1000 = 3500.
+      expect(res.body.local_credits_total_cents).toBe("3500.0000000000");
+    });
+
+    it("auto-created welcome trial gift is $25 (2500)", async () => {
+      // Redeem a tiny promo on a virgin org → findOrCreateAccount auto-redeems
+      // welcome first, then the requested promo. welcome 2500 + tiny 1 = 2501,
+      // pinning the welcome grant at exactly 2500.
+      await insertTestPromoCode({ code: "tiny", amountCents: 1 });
+
+      const res = await request(app)
+        .post("/v1/promotion_codes/redeem")
+        .set(getAuthHeaders(orgId))
+        .send({ code: "tiny" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.local_credits_total_cents).toBe("2501.0000000000");
     });
 
     it("returns 400 for invalid promo code", async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -68,11 +68,13 @@ beforeAll(async () => {
   await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_local_promos_org_promo" ON "local_promos" ("org_id", "promo_code_id")`;
   await sql`CREATE INDEX IF NOT EXISTS "idx_local_promos_org" ON "local_promos" ("org_id")`;
 
-  // Seed welcome promo code (matches migration 0016).
+  // Seed welcome promo code (matches migration 0016 + 0018 bump to 2500).
+  // DO UPDATE (not DO NOTHING) so a stale local DB seeded at the old 200 gets
+  // bumped to 2500 on re-run — keeps welcome-amount assertions deterministic.
   await sql`
     INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")
-    VALUES ('welcome', 200, NULL, NULL)
-    ON CONFLICT ("code") DO NOTHING
+    VALUES ('welcome', 2500, NULL, NULL)
+    ON CONFLICT ("code") DO UPDATE SET "amount_cents" = EXCLUDED."amount_cents"
   `;
 
   // Seed platform-issued grant promo codes (matches migration 0017).


### PR DESCRIPTION
## What

New signups now receive a **\$25** welcome credit (2500¢), not \$2. distribute.you landing pages advertise "\$25 welcome credits" but new orgs were getting \$2.

`redeemPromoCode('welcome')` (lib/account.ts `findOrCreateAccount`) reads `local_promo_codes.amount_cents` at redeem time, so the live prod row is the source of truth.

## Changes
| File | Change |
|------|--------|
| `drizzle/0018_welcome_amount_2500.sql` | `UPDATE local_promo_codes SET amount_cents=2500 WHERE code='welcome'` (idempotent) |
| `drizzle/meta/_journal.json` | **journal 0018** so the boot migrator actually applies it |
| `src/db/schema.ts` | `WELCOME_PROMO_AMOUNT_CENTS` 200 → 2500 (canonical amount) |
| `tests/setup.ts` | seed welcome at 2500 (`DO UPDATE` for deterministic re-runs) |
| `tests/integration/{accounts,promo}.test.ts` | assert welcome = \$25 |

## ⚠️ Why the journal edit matters
This repo hand-authors migrations and maintains `_journal.json` by hand (drizzle snapshots stop at 0007). The boot migrator (`drizzle-orm/postgres-js/migrator`) applies **only journaled** migrations — a bare `.sql` is silently skipped. Confirmed: `0017_invite_promo_codes.sql` is unjournaled and **never ran in prod** (invite codes absent). 0018 is journaled so it actually applies.

## No backfill
The 26 orgs that already redeemed the \$2 welcome keep their existing \$2 `local_promos` row. New signups only.

## Verification
- ✅ Full suite green (132 tests).
- ✅ Ran the real boot `migrate()` against a **prod-copy Neon branch**: `welcome` row 200 → **2500**; all **26** existing `local_promos` unchanged (@200, zero flipped to 2500); exactly **1** migration (0018) applied.

## Follow-up (separate)
DIS-64 invite codes (`invite_reward`/`invite_welcome`) were never seeded in prod because `0017` is unjournaled → `POST /internal/credits/grant` currently throws in prod. Tracked separately, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)