### PR TITLE
docs(billing): document hand-authored migration + journal convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,16 @@
 # billing-service — repo conventions
 
+## Migrations are hand-authored AND hand-journaled — the journal is the apply-gate
+
+This repo does NOT use `drizzle-kit generate`. `drizzle/meta/` snapshots stop at `0007`; every migration from `0008` onward is hand-written SQL, and `drizzle/meta/_journal.json` is maintained by hand. The boot migrator (`drizzle-orm/postgres-js/migrator` in `src/index.ts`, run before `app.listen()`) applies **only migrations listed in `_journal.json`** — a `drizzle/NNNN_*.sql` file with **no journal entry is silently skipped at boot and never runs in prod.**
+
+When adding a migration:
+1. Write `drizzle/NNNN_<name>.sql` (idempotent — `IF NOT EXISTS` / `ON CONFLICT` / single-row `UPDATE`).
+2. Add a matching `_journal.json` entry with `when` **strictly greater than the previous entry's `when`** (the migrator gates on `when > last_applied.created_at`; the `idx`/filename number is cosmetic, drizzle reads by `tag`).
+3. Verify on a Neon temp branch off production: run the real `migrate()` and confirm the row count / column change, plus that no unintended rows moved.
+
+**Known live trap:** `0017_invite_promo_codes.sql` is unjournaled → it **never ran in prod**, so `invite_reward`/`invite_welcome` codes are absent and `POST /internal/credits/grant` throws `GrantPromoCodeMissingError` in prod (DIS-64 latent bug). Don't copy the "just drop a .sql file" pattern — always journal. (`0018` bumped the welcome gift to $25 and IS journaled.)
+
 ## Vocabulary (Stripe-aligned)
 
 Naming follows Stripe Topups + Refunds APIs. When in doubt, search Stripe docs for the same term.


### PR DESCRIPTION
Adds a `## Migrations` section to repo `CLAUDE.md`: migrations are hand-authored and hand-journaled, and the boot migrator applies **only journaled** migrations — an unjournaled `.sql` is silently skipped (live trap: `0017` never ran in prod, leaving DIS-64 invite codes unseeded).

Doc-only. Follow-up to #140 (welcome $25), which surfaced the convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)