### PR TITLE
feat(checkout): no-charge setup-mode card capture on POST /v1/checkout-sessions

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -223,6 +223,13 @@
             "type": "string",
             "format": "uri"
           },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "payment",
+              "setup"
+            ]
+          },
           "topup_amount_cents": {
             "type": "integer",
             "minimum": 0,
@@ -231,8 +238,7 @@
         },
         "required": [
           "success_url",
-          "cancel_url",
-          "topup_amount_cents"
+          "cancel_url"
         ]
       },
       "AuthorizeResponse": {
@@ -1061,7 +1067,7 @@
     "/v1/checkout-sessions": {
       "post": {
         "summary": "Create Stripe Checkout session via stripe-service",
-        "description": "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service.",
+        "description": "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. mode='payment' (default) charges topup_amount_cents and persists it as the auto-topup amount. mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written.",
         "parameters": [
           {
             "schema": {

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -279,12 +279,14 @@ export interface CheckoutLineItem {
 
 export interface CheckoutSessionBody {
   mode: "payment" | "subscription" | "setup";
-  line_items: CheckoutLineItem[];
+  /** Required for payment mode; omitted for setup mode (no charge). */
+  line_items?: CheckoutLineItem[];
   success_url: string;
   cancel_url: string;
   customer: string;
   metadata: Record<string, string>;
-  payment_intent_data: {
+  /** Payment-mode charge config; omitted for setup mode (no PaymentIntent created). */
+  payment_intent_data?: {
     metadata: Record<string, string>;
     setup_future_usage?: "off_session" | "on_session";
   };

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -5,6 +5,7 @@ import { billingAccounts } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { CreateCheckoutRequestSchema } from "../schemas.js";
 import { createCheckoutSession, getCustomerByOrg } from "../lib/stripe-service-client.js";
+import type { CheckoutSessionBody } from "../lib/stripe-service-client.js";
 import { findOrCreateAccount } from "../lib/account.js";
 import { traceEvent } from "../lib/trace-event.js";
 
@@ -27,8 +28,16 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
       return;
     }
     const { success_url, cancel_url, topup_amount_cents } = parsed.data;
+    const isSetup = parsed.data.mode === "setup";
 
-    traceEvent(runId, { service: "billing-service", event: "checkout.start", data: { topup_amount_cents } }, req.headers);
+    // Payment-mode (absent mode or "payment") requires an explicit amount. Fail loud
+    // rather than defaulting — a payment checkout with no amount is a malformed request.
+    if (!isSetup && topup_amount_cents === undefined) {
+      res.status(400).json({ error: "topup_amount_cents is required for payment-mode checkout" });
+      return;
+    }
+
+    traceEvent(runId, { service: "billing-service", event: "checkout.start", data: { mode: isSetup ? "setup" : "payment", topup_amount_cents } }, req.headers);
 
     await findOrCreateAccount(orgId, userId, wfHeaders);
 
@@ -42,40 +51,62 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
     let session;
     try {
       const customer = await getCustomerByOrg(identity);
-      session = await createCheckoutSession(identity, {
-        mode: "payment",
-        line_items: [
-          {
-            price_data: {
-              currency: CHECKOUT_CURRENCY,
-              product_data: { name: CHECKOUT_PRODUCT_NAME },
-              unit_amount: topup_amount_cents,
-            },
-            quantity: 1,
-          },
-        ],
-        success_url,
-        cancel_url,
-        customer: customer.id,
-        metadata: { org_id: orgId },
-        payment_intent_data: {
+      let body: CheckoutSessionBody;
+      if (isSetup) {
+        // No-charge card capture: saves a reusable off-session card (Stripe
+        // setup-mode SetupIntent defaults to usage=off_session) so the org can
+        // enable auto-topup later. No line_items, no payment_intent_data.
+        body = {
+          mode: "setup",
+          success_url,
+          cancel_url,
+          customer: customer.id,
           metadata: { org_id: orgId },
-          setup_future_usage: "off_session",
-        },
-      });
+        };
+      } else {
+        // payment mode — topup_amount_cents is guaranteed present by the 400 guard
+        // above (non-setup + undefined already returned). The `!` reflects that proven
+        // invariant; it is not a fallback.
+        body = {
+          mode: "payment",
+          line_items: [
+            {
+              price_data: {
+                currency: CHECKOUT_CURRENCY,
+                product_data: { name: CHECKOUT_PRODUCT_NAME },
+                unit_amount: topup_amount_cents!,
+              },
+              quantity: 1,
+            },
+          ],
+          success_url,
+          cancel_url,
+          customer: customer.id,
+          metadata: { org_id: orgId },
+          payment_intent_data: {
+            metadata: { org_id: orgId },
+            setup_future_usage: "off_session",
+          },
+        };
+      }
+      session = await createCheckoutSession(identity, body);
     } catch (err) {
       console.error("[billing-service] stripe-service createCheckoutSession failed:", err);
       res.status(502).json({ error: "Failed to create checkout session via stripe-service" });
       return;
     }
 
-    await db
-      .update(billingAccounts)
-      .set({
-        topupAmountCents: topup_amount_cents,
-        updatedAt: new Date(),
-      })
-      .where(eq(billingAccounts.orgId, orgId));
+    // Payment-mode persists the chosen top-up amount as the org's auto-topup amount.
+    // Setup-mode is a pure card capture — it must NOT write any topup amount.
+    if (!isSetup) {
+      await db
+        .update(billingAccounts)
+        .set({
+          topupAmountCents: topup_amount_cents,
+          updatedAt: new Date(),
+        })
+        .where(eq(billingAccounts.orgId, orgId));
+    }
 
     traceEvent(runId, { service: "billing-service", event: "checkout.done", data: { session_id: session.session_id } }, req.headers);
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -94,7 +94,17 @@ export const CreateCheckoutRequestSchema = z
   .object({
     success_url: z.string().url(),
     cancel_url: z.string().url(),
-    topup_amount_cents: z.number().int().positive(),
+    /**
+     * Checkout flavor. Absent or "payment" → charge `topup_amount_cents` (unchanged
+     * behavior). "setup" → no-charge Stripe Checkout that saves a reusable off-session
+     * card so the org can enable auto-topup without buying credits.
+     */
+    mode: z.enum(["payment", "setup"]).optional(),
+    /**
+     * Required for payment-mode (validated in the route — fail loud with 400 when
+     * absent). Omitted for setup-mode (no charge).
+     */
+    topup_amount_cents: z.number().int().positive().optional(),
   })
   .openapi("CreateCheckoutRequest");
 
@@ -390,7 +400,10 @@ registry.registerPath({
   method: "post",
   path: "/v1/checkout-sessions",
   summary: "Create Stripe Checkout session via stripe-service",
-  description: "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service.",
+  description:
+    "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. " +
+    "mode='payment' (default) charges topup_amount_cents and persists it as the auto-topup amount. " +
+    "mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written.",
   request: {
     headers: protectedHeaders,
     body: {

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import request from "supertest";
+import { eq } from "drizzle-orm";
 import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
 import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
 import { setupStripeMocks } from "../helpers/mock-stripe.js";
+import { db } from "../../src/db/index.js";
+import { billingAccounts } from "../../src/db/schema.js";
 
 describe("POST /v1/checkout-sessions", () => {
   const app = createTestApp();
@@ -131,5 +134,81 @@ describe("POST /v1/checkout-sessions", () => {
       .send({});
 
     expect(res.status).toBe(400);
+  });
+
+  // --- Setup-mode ($0 card capture) ---
+
+  it("setup-mode: creates a no-charge setup session with no amount", async () => {
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/pay/cs_setup",
+      session_id: "cs_setup",
+    });
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        mode: "setup",
+        success_url: "https://example.com/success",
+        cancel_url: "https://example.com/cancel",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      url: "https://checkout.stripe.com/pay/cs_setup",
+      session_id: "cs_setup",
+    });
+    expect(ssMocks.createCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({ "x-org-id": orgId }),
+      {
+        mode: "setup",
+        success_url: "https://example.com/success",
+        cancel_url: "https://example.com/cancel",
+        customer: "cus_mock_123",
+        metadata: { org_id: orgId },
+      }
+    );
+    // No charge fields on a setup session.
+    const sentBody = ssMocks.createCheckoutSession.mock.calls[0][1];
+    expect(sentBody).not.toHaveProperty("line_items");
+    expect(sentBody).not.toHaveProperty("payment_intent_data");
+  });
+
+  it("setup-mode: does NOT write a topup amount to the account", async () => {
+    await insertTestAccount({ orgId, topupAmountCents: 7777 });
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        mode: "setup",
+        success_url: "https://example.com/success",
+        cancel_url: "https://example.com/cancel",
+      });
+
+    expect(res.status).toBe(200);
+    const [account] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId));
+    expect(account.topupAmountCents).toBe(7777);
+  });
+
+  it("setup-mode: returns 502 when stripe-service fails (no charge fallback)", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.createCheckoutSession.mockRejectedValue(new Error("SS down"));
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        mode: "setup",
+        success_url: "https://example.com/success",
+        cancel_url: "https://example.com/cancel",
+      });
+
+    expect(res.status).toBe(502);
+    // Never falls back to a charge.
+    expect(ssMocks.createPaymentIntent).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What
Extend `POST /v1/checkout-sessions` with optional `mode: "payment" | "setup"` (default `payment`).

- `mode: "setup"` → no-charge Stripe Checkout (setup mode) via stripe-service that saves a reusable **off-session** card. No `line_items`, no `payment_intent_data`, no topup amount written to `billing_accounts`. Powers a $0 "save card" flow so the dashboard can enable auto-topup (requires a PM on file) without buying credits.
- absent / `mode: "payment"` → **unchanged** charge flow + topup write. Response `{ url, session_id }` unchanged.
- `topup_amount_cents` now optional: required for payment mode (fail-loud **400** if absent), omitted for setup mode.

## Tests
- setup-mode: session created with no amount; setup body sent (no `line_items` / `payment_intent_data`); **no** DB topup write
- setup-mode stripe-service failure → **502**, never falls back to a charge
- payment-mode regressions unchanged
- 135/135 green; OpenAPI regenerated (`mode` optional enum + `topup_amount_cents` optional)

## ⚠️ Deployment ordering
stripe-service setup-mode Checkout is landing in parallel. This route is **dormant**: no caller sends `mode:"setup"` until the dashboard ships, and a premature setup call fails loud (502, no charge fallback). Zero blast radius to existing payment-mode traffic — safe to ship prod-direct ahead of stripe-service per the additive-gateway convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)