### PR TITLE
fix(checkout): send currency for setup sessions

### DIFF
--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -279,6 +279,8 @@ export interface CheckoutLineItem {
 
 export interface CheckoutSessionBody {
   mode: "payment" | "subscription" | "setup";
+  /** Required by Stripe for setup mode when payment_method_types is omitted. */
+  currency?: string;
   /** Required for payment mode; omitted for setup mode (no charge). */
   line_items?: CheckoutLineItem[];
   success_url: string;

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -58,6 +58,7 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
         // enable auto-topup later. No line_items, no payment_intent_data.
         body = {
           mode: "setup",
+          currency: CHECKOUT_CURRENCY,
           success_url,
           cancel_url,
           customer: customer.id,

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -162,6 +162,7 @@ describe("POST /v1/checkout-sessions", () => {
       expect.objectContaining({ "x-org-id": orgId }),
       {
         mode: "setup",
+        currency: "usd",
         success_url: "https://example.com/success",
         cancel_url: "https://example.com/cancel",
         customer: "cus_mock_123",


### PR DESCRIPTION
## Summary
- Add top-level `currency: "usd"` to setup-mode checkout session bodies sent from billing-service to stripe-service.
- Keep setup-mode no-charge behavior unchanged: no `line_items`, no `payment_intent_data`, and no `topupAmountCents` write.
- Keep payment-mode top-up behavior unchanged, including `price_data.currency: "usd"`.

## Production Error
Dashboard recurring-campaign auto-topup card capture is failing with:

`{"error":"Failed to create checkout session via stripe-service"}`

Billing-service logs show stripe-service createCheckoutSession failing with Stripe 400: `Missing required param: currency` around the billing-service checkout route createCheckoutSession call.

## Verification
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm vitest run tests/integration/checkout.test.ts` - 8 passed
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm test:integration` - 93 passed
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm build` - passed