### PR TITLE
chore: sync hotfix v0.28.3 to staging (resolved)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,9 @@ When reconciling or computing real cost: `WHERE rc.status='actual' AND rc.cost_s
 
 ## Local promos (`local_promos` table)
 
-The only persistent ledger billing-service owns. One row per (org, promo_code) — `UNIQUE (org_id, promo_code_id)`. Welcome trial = `code='welcome'` ($25 grant; seeded @$2 by migration 0016, bumped to $25 by 0018). Other codes are admin-managed.
+The only persistent ledger billing-service owns. One row per (org, promo_code) — `UNIQUE (org_id, promo_code_id)`. Welcome trial = `code='welcome'` ($2 grant; seeded @$2 by migration 0016, bumped to $25 by 0018, reverted to $2 by 0019). Other codes are admin-managed.
+
+**Changing the welcome amount = 4 sites in lockstep (tests do NOT run drizzle migrations — they hand-build schema + seed in `tests/setup.ts`):** (1) `drizzle/NNNN_*.sql` migration row + journal entry, (2) `WELCOME_PROMO_AMOUNT_CENTS` in `src/db/schema.ts` + its comment, (3) the `local_promo_codes` welcome seed in `tests/setup.ts`, (4) the welcome-amount assertions in `tests/integration/{promo,accounts}.test.ts`. Miss (3)/(4) and the suite goes red (or worse, silently asserts the old amount). The `INVITE_GRANT_AMOUNT_CENTS` / `invite_welcome` / `invite_reward` path is independent — leave it at 2500.
 
 `amount_cents` is positive (these are credits). `numeric(16,10)` — Drizzle returns it as a JS string. Use Decimal.js (via `src/lib/cents.ts` helpers) for arithmetic; never cast to Number for math.
 

--- a/drizzle/0019_welcome_amount_200.sql
+++ b/drizzle/0019_welcome_amount_200.sql
@@ -1,0 +1,14 @@
+-- Revert the welcome trial gift from $25 (2500¢) back to $2 (200¢).
+--
+-- distribute.you landing + dashboard messaging is reframed (separate PR) to
+-- "50 free emails" with no dollar figure shown, so the welcome credit drops
+-- back to $2. redeemPromoCode('welcome') (lib/account.ts findOrCreateAccount)
+-- reads local_promo_codes.amount_cents at redeem time, so updating this row
+-- makes all NEW redemptions grant $2. Exact reverse of migration 0018.
+--
+-- No backfill: orgs that already redeemed the $25 welcome keep their existing
+-- local_promos row (new signups only). Does NOT touch the referral/invite
+-- grant path (INVITE_GRANT_AMOUNT_CENTS stays 2500).
+--
+-- Idempotent: single-row UPDATE keyed on a unique code, re-running is a no-op.
+UPDATE "local_promo_codes" SET "amount_cents" = 200 WHERE "code" = 'welcome';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1789639200000,
       "tag": "0018_welcome_amount_2500",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1789725600000,
+      "tag": "0019_welcome_amount_200",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -89,10 +89,11 @@ export type LocalPromo = typeof localPromos.$inferSelect;
 export type NewLocalPromo = typeof localPromos.$inferInsert;
 
 export const WELCOME_PROMO_CODE = "welcome";
-// $25 welcome trial gift. Source of truth for live redemptions is the
+// $2 welcome trial gift. Source of truth for live redemptions is the
 // local_promo_codes row (seeded by migration 0016 @200, bumped to 2500 by
-// migration 0018); this constant documents the canonical amount.
-export const WELCOME_PROMO_AMOUNT_CENTS = 2500;
+// migration 0018, reverted to 200 by migration 0019); this constant documents
+// the canonical amount.
+export const WELCOME_PROMO_AMOUNT_CENTS = 200;
 
 // Platform-issued grant codes (DIS-64 Wave 0.5 invite-only gate).
 // Backed by migration 0017. The invite_welcome grant replaces (not stacks)

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -46,10 +46,10 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.org_id).toBe(orgId);
-      // SS paid = 0, local welcome = 2500, usage = 0 → credited 2500, balance 2500.
-      expect(res.body.credited_cents).toBe("2500.0000000000");
+      // SS paid = 0, local welcome = 200, usage = 0 → credited 200, balance 200.
+      expect(res.body.credited_cents).toBe("200.0000000000");
       expect(res.body.usage_cents).toBe("0.0000000000");
-      expect(res.body.balance_cents).toBe("2500.0000000000");
+      expect(res.body.balance_cents).toBe("200.0000000000");
       expect(res.body.has_payment_method).toBe(false);
       expect(res.body.has_auto_topup).toBe(false);
       expect(ssMocks.ensureCustomer).toHaveBeenCalled();

--- a/tests/integration/promo.test.ts
+++ b/tests/integration/promo.test.ts
@@ -56,14 +56,14 @@ describe("Promotion code endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.redeemed).toBe(true);
-      // welcome 2500 + promo 1000 = 3500.
-      expect(res.body.local_credits_total_cents).toBe("3500.0000000000");
+      // welcome 200 + promo 1000 = 1200.
+      expect(res.body.local_credits_total_cents).toBe("1200.0000000000");
     });
 
-    it("auto-created welcome trial gift is $25 (2500)", async () => {
+    it("auto-created welcome trial gift is $2 (200)", async () => {
       // Redeem a tiny promo on a virgin org → findOrCreateAccount auto-redeems
-      // welcome first, then the requested promo. welcome 2500 + tiny 1 = 2501,
-      // pinning the welcome grant at exactly 2500.
+      // welcome first, then the requested promo. welcome 200 + tiny 1 = 201,
+      // pinning the welcome grant at exactly 200.
       await insertTestPromoCode({ code: "tiny", amountCents: 1 });
 
       const res = await request(app)
@@ -72,7 +72,7 @@ describe("Promotion code endpoints", () => {
         .send({ code: "tiny" });
 
       expect(res.status).toBe(200);
-      expect(res.body.local_credits_total_cents).toBe("2501.0000000000");
+      expect(res.body.local_credits_total_cents).toBe("201.0000000000");
     });
 
     it("returns 400 for invalid promo code", async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -68,12 +68,13 @@ beforeAll(async () => {
   await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_local_promos_org_promo" ON "local_promos" ("org_id", "promo_code_id")`;
   await sql`CREATE INDEX IF NOT EXISTS "idx_local_promos_org" ON "local_promos" ("org_id")`;
 
-  // Seed welcome promo code (matches migration 0016 + 0018 bump to 2500).
-  // DO UPDATE (not DO NOTHING) so a stale local DB seeded at the old 200 gets
-  // bumped to 2500 on re-run — keeps welcome-amount assertions deterministic.
+  // Seed welcome promo code (matches migration 0016 @200 + 0019 revert to 200,
+  // reversing the 0018 bump to 2500).
+  // DO UPDATE (not DO NOTHING) so a stale local DB seeded at the old 2500 gets
+  // reverted to 200 on re-run — keeps welcome-amount assertions deterministic.
   await sql`
     INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")
-    VALUES ('welcome', 2500, NULL, NULL)
+    VALUES ('welcome', 200, NULL, NULL)
     ON CONFLICT ("code") DO UPDATE SET "amount_cents" = EXCLUDED."amount_cents"
   `;
 


### PR DESCRIPTION
Resolves the conflicting auto-sync PR #153. Merges main (welcome gift revert $25→$2, v0.28.3) into staging.

Conflicts resolved (both branches shipped an independent migration numbered 0019):
- **`drizzle/meta/_journal.json`**: kept BOTH entries (`0019_welcome_amount_200` + staging's `0019_credit_depletion_episodes`), each given a `when` strictly greater than the prior 1789725600000. Each branch already recorded one 0019 at that timestamp; bumping both above it makes the not-yet-applied migration pass the `when > max` boot gate on its branch, and forces one idempotent re-apply of the already-applied one (both SQLs are `IF NOT EXISTS` / single-row UPDATE — safe).
- **`tests/setup.ts`**: kept dunning table creation (staging) + welcome $2 seed (main).
- `src/db/schema.ts`, `CLAUDE.md`: auto-merged (both sides' additions kept).

Build + 145 tests green.