### PR TITLE
docs(billing): correct Link-not-chargeable claim (card OR link)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Billing never duplicates Stripe state and never persists run-level usage rows.
 
 - Customer fetch is **org-implicit** via `GET /v1/customers?limit=1` (resolved server-side from `x-org-id`). No `stripe_customer_id` is stored in billing.
 - Balance is derived from the Stripe customer object: `balance_cents = -customer.balance` (sign-flip, Stripe convention is `balance > 0` = customer owes).
-- `has_payment_method` is derived from whether the customer has ≥1 attached **card** PM (`hasAttachedCardPm` → `GET /v1/payment_methods?customer=cus_X&type=card`). It deliberately does **not** read `customer.invoice_settings.default_payment_method`: Stripe leaves the default null after a normal `setup_future_usage` checkout and refuses to charge Link/wallet default PMs off_session, so a default-PM check blocks reloads for orgs that in fact have a chargeable card. This mirrors exactly what `reload.ts` charges (first attached card). The same `hasAttachedCardPm` gate fronts auto-reload in `authorize` + `usage_apply` and the `PATCH /v1/accounts/auto_topup` PM requirement. Fail-loud: a stripe-service error propagates (502); only an empty card list → false.
+- `has_payment_method` is derived from whether the customer has ≥1 attached **chargeable** PM — a `card` **or** a `link` PM (`hasAttachedCardPm` → `GET /v1/payment_methods?type=card`, then `type=link` if no card). **Link PMs ARE chargeable off_session** when passed as an explicit `payment_method` id (Stripe documents `off_session:true, confirm:true` on a saved `type:link` PM exactly like a card — https://docs.stripe.com/payments/link/save-and-reuse). A normal Checkout setup-mode flow offers card+link and saves `type:link` for Link-enabled emails, so a **card-only gate wrongly reported "no payment method"** for those orgs and 400'd `PATCH /v1/accounts/auto_topup` forever (v0.29.1 fix, GH #162). It deliberately does **not** read `customer.invoice_settings.default_payment_method`: Stripe leaves it null after `setup_future_usage`, AND the **default-PM *fallback* path** (PI with no explicit `payment_method`) genuinely fails for Link (the original DIS-43 400) — but that is the fallback, not an explicit link-PM charge. We list PMs by type and pass an explicit id instead. This mirrors exactly what `reload.ts` charges (first card, then link fallback). The same `hasAttachedCardPm` gate fronts auto-reload in `authorize` + `usage_apply` and the `PATCH /v1/accounts/auto_topup` PM requirement. Fail-loud: a stripe-service error propagates (502); only an empty card AND link list → false.
 - Reload is composed billing-side via `POST /v1/payment_intents` with `confirm:true, off_session:true` + `Idempotency-Key` header. Stripe status flattened to `{succeeded|failed}` in `src/lib/reload.ts`.
 - Balance transactions list uses the org-implicit `GET /v1/balance_transactions` (no customer id needed).
 
@@ -101,7 +101,7 @@ The same CSV convention applies to the `x-brand-id` header forwarded by workflow
   "balance_cents": "16910.7042000000",       // credited_cents − usage_cents; USE THIS for depletion/budget gates
   "topup_amount_cents": 2500,                // auto-topup amount
   "topup_threshold_cents": 500,              // auto-topup triggers when balance_cents < threshold
-  "has_payment_method": true,                // ≥1 attached card PM (GET /v1/payment_methods?type=card); NOT invoice_settings.default_payment_method
+  "has_payment_method": true,                // ≥1 chargeable PM: card OR link (GET /v1/payment_methods?type=card, then type=link); NOT invoice_settings.default_payment_method
   "has_auto_topup": true,
   "created_at": "...",
   "updated_at": "..."
@@ -115,7 +115,7 @@ Composition (`src/routes/accounts.ts:composeAccountFunds`):
 2. `sumSucceededTopupsForCustomer(identity, customer.id)` → paginates `GET /v1/payment_intents?customer=cus_X` and sums `amount_received` where `status='succeeded'`
 3. `sumLocalPromoCreditsForOrg(orgId)` → SUM `local_promos.amount_cents`
 4. `fetchRunsOrgUsageTotal(orgId, identity)` → runs-service `spent_cents`
-5. `hasAttachedCardPm(identity, customer.id)` → `has_payment_method` (≥1 attached card PM)
+5. `hasAttachedCardPm(identity, customer.id)` → `has_payment_method` (≥1 chargeable PM: card or link)
 6. `credited_cents = paid_topups + local_credits` ; `balance_cents = credited_cents − usage`
 
 ### `GET /public/stats/billing`

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -207,9 +207,12 @@ export async function listPaymentIntents(
  * List a customer's attached PaymentMethods via stripe-service.
  * Live passthrough to Stripe `paymentMethods.list({ customer, type? })`.
  *
- * Used by reload.ts to pick an explicit `payment_method` for off_session PIs
- * instead of relying on `customer.invoice_settings.default_payment_method`
- * (which may be a Link / wallet PM Stripe refuses to charge off_session).
+ * Used by reload.ts + hasAttachedCardPm to pick an explicit `payment_method`
+ * (card, then link fallback) for off_session PIs instead of relying on
+ * `customer.invoice_settings.default_payment_method`. Note: a saved `type:link`
+ * PM IS chargeable off_session when passed as an explicit id (Stripe docs:
+ * payments/link/save-and-reuse); only the *default-PM fallback* path fails for
+ * Link, which is why we pass an explicit id rather than read the default.
  */
 export async function listPaymentMethods(
   identity: IdentityHeaders,


### PR DESCRIPTION
Doc-only follow-up to v0.29.1 (GH #162). Corrects the now-false "Stripe refuses to charge Link/wallet PMs off_session" claim in `CLAUDE.md` (3 spots) + the `listPaymentMethods` source comment — leaving it would re-introduce the card-only bug.

Clarifies the real distinction: the **default-PM fallback** path genuinely fails for Link (original DIS-43 400), but an **explicit link-PM charge** off_session succeeds (Stripe docs: payments/link/save-and-reuse). The gate + reload now pass an explicit id (card first, link fallback).

No code behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)