### PR TITLE
hotfix: Retry stripe/runs HTTP on transient connect resets (Neon cold-start ECONNRESET)

### DIFF
--- a/src/lib/fetch-retry.ts
+++ b/src/lib/fetch-retry.ts
@@ -1,0 +1,72 @@
+/**
+ * Connect-phase retry for downstream HTTP calls (stripe-service, runs-service).
+ *
+ * Both siblings sit behind Neon scale-to-zero (DIS-153/155/157): idle compute
+ * suspends, and the FIRST request after a suspend can hit a compute still
+ * resuming (~1–7s). The TCP connection is reset / times out before the wake
+ * completes, so `fetch` rejects with `TypeError: fetch failed` whose `cause`
+ * carries the transient code — `ECONNRESET` (observed), `ETIMEDOUT`
+ * (Node-20 happy-eyeballs 250ms attempt window), or `ECONNREFUSED`.
+ *
+ * billing-service composes balance from a `Promise.all` of stripe + runs calls
+ * and FAILS LOUD (502) on any rejection — so a single transient reset blocks
+ * `customer_balance/authorize`, which blocks the caller's LLM run entirely.
+ *
+ * We retry ONLY a thrown (connect-phase) failure, never a completed HTTP
+ * response: an HTTP 5xx is a real answer the server already produced and may
+ * have side-effected on. A connect-phase rejection means the request never
+ * reached the server, so the retry is write-safe; mutating POSTs additionally
+ * carry an `Idempotency-Key`, so even a racy retry is safe.
+ */
+
+const TRANSIENT_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "EAI_AGAIN",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+const BACKOFF_MS = [250, 500, 1000];
+
+/**
+ * A transient network error from `fetch` is wrapped in `cause` (and for
+ * happy-eyeballs, an `AggregateError` with per-address sub-errors under
+ * `.errors`). Walk both chains, guarding against cycles.
+ */
+function isTransient(err: unknown): boolean {
+  const seen = new Set<unknown>();
+  const stack: unknown[] = [err];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    if (cur === null || typeof cur !== "object" || seen.has(cur)) continue;
+    seen.add(cur);
+    const code = (cur as { code?: unknown }).code;
+    if (typeof code === "string" && TRANSIENT_CODES.has(code)) return true;
+    const cause = (cur as { cause?: unknown }).cause;
+    if (cause !== undefined) stack.push(cause);
+    const errors = (cur as { errors?: unknown }).errors;
+    if (Array.isArray(errors)) stack.push(...errors);
+  }
+  return false;
+}
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * `fetch` with a connect-phase retry on transient network rejections.
+ * Drop-in replacement for `fetch(input, init)` — same signature, same return.
+ * A non-transient rejection (or exhausted retries) propagates unchanged.
+ */
+export async function fetchWithRetry(input: string, init?: RequestInit): Promise<Response> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fetch(input, init);
+    } catch (err) {
+      if (attempt >= BACKOFF_MS.length || !isTransient(err)) throw err;
+      await delay(BACKOFF_MS[attempt]);
+    }
+  }
+}

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -1,5 +1,7 @@
 /** Client for fetching canonical usage totals from runs-service. */
 
+import { fetchWithRetry } from "./fetch-retry.js";
+
 export interface RunsOrgUsageTotalResult {
   org_id: string;
   spent_cents: string;
@@ -29,7 +31,7 @@ export async function fetchRunsOrgUsageTotal(
     throw new Error("RUNS_SERVICE_URL and RUNS_SERVICE_API_KEY must be configured");
   }
 
-  const res = await fetch(
+  const res = await fetchWithRetry(
     `${config.url}/internal/org-usage-total?org_id=${encodeURIComponent(orgId)}`,
     {
       headers: {

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -10,6 +10,7 @@
  */
 
 import { Decimal } from "decimal.js";
+import { fetchWithRetry } from "./fetch-retry.js";
 
 export type IdentityHeaders = Record<string, string>;
 
@@ -133,7 +134,7 @@ async function call<T>(
   extraHeaders?: Record<string, string>
 ): Promise<T> {
   const { url, apiKey } = getConfig();
-  const res = await fetch(`${url}${path}`, {
+  const res = await fetchWithRetry(`${url}${path}`, {
     method,
     headers: buildHeaders(identity, apiKey, extraHeaders),
     body: body !== undefined ? JSON.stringify(body) : undefined,

--- a/tests/unit/fetch-retry.test.ts
+++ b/tests/unit/fetch-retry.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchWithRetry } from "../../src/lib/fetch-retry.js";
+
+/** Build the error shape Node's fetch throws for a connect-phase reset. */
+function fetchFailed(code: string): Error {
+  const cause = Object.assign(new Error(`read ${code}`), { code });
+  return Object.assign(new TypeError("fetch failed"), { cause });
+}
+
+/** happy-eyeballs AggregateError: code on the top error + per-address sub-errors. */
+function aggregateTimeout(): Error {
+  const sub = Object.assign(new Error("connect ETIMEDOUT"), { code: "ETIMEDOUT" });
+  const agg = Object.assign(new AggregateError([sub], "fetch failed"), {
+    code: "ETIMEDOUT",
+  });
+  return Object.assign(new TypeError("fetch failed"), { cause: agg });
+}
+
+function ok(): Response {
+  return new Response("ok", { status: 200 });
+}
+
+describe("fetchWithRetry", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("returns the response without retry on first success", async () => {
+    fetchMock.mockResolvedValue(ok());
+
+    const res = await fetchWithRetry("http://x/y");
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient ECONNRESET then succeeds", async () => {
+    fetchMock
+      .mockRejectedValueOnce(fetchFailed("ECONNRESET"))
+      .mockResolvedValueOnce(ok());
+
+    const p = fetchWithRetry("http://x/y");
+    await vi.runAllTimersAsync();
+    const res = await p;
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a happy-eyeballs AggregateError ETIMEDOUT", async () => {
+    fetchMock.mockRejectedValueOnce(aggregateTimeout()).mockResolvedValueOnce(ok());
+
+    const p = fetchWithRetry("http://x/y");
+    await vi.runAllTimersAsync();
+    const res = await p;
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after 3 retries (4 attempts) and rethrows the transient error", async () => {
+    fetchMock.mockRejectedValue(fetchFailed("ECONNREFUSED"));
+
+    const p = fetchWithRetry("http://x/y");
+    const assertion = expect(p).rejects.toThrow("fetch failed");
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("does NOT retry a non-transient error", async () => {
+    const boom = Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error("certificate expired"), { code: "CERT_HAS_EXPIRED" }),
+    });
+    fetchMock.mockRejectedValue(boom);
+
+    await expect(fetchWithRetry("http://x/y")).rejects.toThrow("fetch failed");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry a completed HTTP 5xx response (real answer, may have side-effected)", async () => {
+    fetchMock.mockResolvedValue(new Response("oops", { status: 502 }));
+
+    const res = await fetchWithRetry("http://x/y");
+
+    expect(res.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Automated by release.sh