### PR TITLE
feat(affordability): read-only per-campaign affordability pre-flight gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,19 @@ Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed liv
 | `POST` | `/v1/promotion_codes/redeem` | redeem promo code → insert `local_promos` row |
 | `POST` | `/internal/credits/grant` | platform-issued grant — body `{orgId, amountCents, reason: invite_reward\|invite_welcome}` → `{ok, newBalanceCents}`. Idempotent on `(orgId, reason)`. `invite_welcome` replaces the existing `$25` welcome row. Used by api-service invite claim handler (DIS-64). |
 | `POST` | `/internal/dunning/tick` | run one out-of-credit dunning pass (ops/manual). Same pass runs on the in-process hourly scheduler. → `{processed, recovered, followup3dSent, followup10dSent}`. |
+| `GET` | `/internal/campaigns/:campaignId/affordability` | READ-ONLY pre-flight gate (campaign-service). → `{affordable, balanceCents, lastRequiredCents, hasHistory}`. ZERO side effects. See "Campaign affordability gate" below. |
+
+## Campaign affordability gate (read-only pre-flight)
+
+Stops a credit "retry storm": an out-of-credit org's recurring campaign was re-triggered every minute by campaign-service, each run doing paid Apollo enrichment then 402-ing at the LLM step. campaign-service now asks billing "can this org afford another run of campaign X?" BEFORE dispatching — billing answers live, per-campaign, **without charging or reloading**.
+
+**Cost estimate (no up-front truth).** The run's cost isn't known before the run. We use the `required_cents` of the **LAST authorize attempt for that campaign** as the estimate — a campaign re-runs the same workflow, so cost is ~constant. The estimate is upserted in `POST /v1/customer_balance/authorize`: when `x-campaign-id` is present, `upsertCampaignAuthorizeCost(campaignId, orgId, requiredCents)` runs right after `requiredCents` resolves, on **both sufficient and insufficient** outcomes (it's the cost of the last attempted run). Absent `x-campaign-id` (dashboard chats) → skipped; never fails the authorize. Fail-loud on a write error. Does NOT touch the reload / depletion / response-shape flow.
+
+**State:** one table, `campaign_authorize_costs` (migration `0021`, hand-journaled) — `campaign_id` PK, `org_id`, `last_authorize_required_cents numeric(16,10)`, `updated_at`. One row per campaign, upserted in place (`ON CONFLICT (campaign_id) DO UPDATE`). `src/lib/campaign-costs.ts` owns the upsert + read.
+
+**`GET /internal/campaigns/:campaignId/affordability`** (`src/routes/internal.ts`, service-auth, READ-ONLY — no charge, no reload, no episode mutation):
+- No stored cost → `{affordable:true, balanceCents:"0", lastRequiredCents:null, hasHistory:false}` (first-run default — a brand-new campaign runs once to establish its cost; the org isn't resolvable without a stored row, hence `balanceCents:"0"`).
+- Stored cost → live balance via `computeBalance` (identity `{x-org-id: stored.orgId}`); `affordable = balanceCents >= lastRequiredCents`, `hasHistory:true`. Fail-loud 502 if stripe/runs unreachable. 400 on non-UUID `campaignId`.
 
 ## Out-of-credit dunning engine (issue #147)
 

--- a/drizzle/0021_campaign_authorize_costs.sql
+++ b/drizzle/0021_campaign_authorize_costs.sql
@@ -1,0 +1,12 @@
+-- Per-campaign authorize-cost estimate (campaign affordability pre-flight gate).
+-- One row per campaign holding the required_cents of the most recent authorize
+-- attempt for that campaign (upserted on both sufficient and insufficient
+-- outcomes). Read by GET /internal/campaigns/:campaignId/affordability so
+-- campaign-service can skip re-triggering a run an out-of-credit org cannot
+-- afford. Idempotent: safe to re-run on partial apply.
+CREATE TABLE IF NOT EXISTS "campaign_authorize_costs" (
+  "campaign_id" uuid PRIMARY KEY NOT NULL,
+  "org_id" uuid NOT NULL,
+  "last_authorize_required_cents" numeric(16,10) NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1789984800000,
       "tag": "0020_episode_credited_at_open",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1790071200000,
+      "tag": "0021_campaign_authorize_costs",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -447,6 +447,30 @@
           "followup10dSent"
         ]
       },
+      "CampaignAffordability": {
+        "type": "object",
+        "properties": {
+          "affordable": {
+            "type": "boolean"
+          },
+          "balanceCents": {
+            "type": "string"
+          },
+          "lastRequiredCents": {
+            "type": "string",
+            "nullable": true
+          },
+          "hasHistory": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "affordable",
+          "balanceCents",
+          "lastRequiredCents",
+          "hasHistory"
+        ]
+      },
       "TransferBrandTableResult": {
         "type": "object",
         "properties": {
@@ -1761,6 +1785,63 @@
           },
           "502": {
             "description": "Tick failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/campaigns/{campaignId}/affordability": {
+      "get": {
+        "summary": "Read-only pre-flight: can this org afford another run of campaign X?",
+        "description": "Answers campaign-service's affordability question WITHOUT charging or reloading. Zero side effects — no charge, no reload, no depletion-episode mutation. Estimates the next run's cost as the required_cents of the campaign's LAST authorize attempt (a campaign re-runs the same workflow → ~constant cost). hasHistory=false (no authorize recorded yet) → affordable=true so a brand-new campaign can run once to establish its cost. Otherwise affordable = live balance >= lastRequiredCents.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "campaignId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Affordability verdict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampaignAffordability"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "campaignId is not a valid UUID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "stripe-service or runs-service unavailable (balance compose failed)",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -168,6 +168,29 @@ export const creditDepletionEpisodes = pgTable(
 export type CreditDepletionEpisode = typeof creditDepletionEpisodes.$inferSelect;
 export type NewCreditDepletionEpisode = typeof creditDepletionEpisodes.$inferInsert;
 
+// campaign_authorize_costs: per-campaign estimate of the next run's cost.
+// One row per campaign — the `required_cents` resolved by the MOST RECENT
+// authorize attempt for that campaign (upserted on BOTH sufficient and
+// insufficient outcomes). A campaign re-runs the same workflow, so the last
+// attempt's cost is the best estimate of the next run's cost. Read by the
+// read-only `GET /internal/campaigns/:campaignId/affordability` pre-flight gate
+// (campaign-service consumes it to skip re-triggering a run an out-of-credit org
+// cannot afford). No row → no history → first-run-affordable default.
+export const campaignAuthorizeCosts = pgTable("campaign_authorize_costs", {
+  campaignId: uuid("campaign_id").primaryKey(),
+  orgId: uuid("org_id").notNull(),
+  lastAuthorizeRequiredCents: numeric("last_authorize_required_cents", {
+    precision: FRACTIONAL_PRECISION,
+    scale: FRACTIONAL_SCALE,
+  }).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export type CampaignAuthorizeCost = typeof campaignAuthorizeCosts.$inferSelect;
+export type NewCampaignAuthorizeCost = typeof campaignAuthorizeCosts.$inferInsert;
+
 // Dunning eventTypes — byte-equal to the templates registered by the dashboard
 // app (distribute.you#1420). LOCKED contract; do not rename.
 export const DUNNING_EVENT_T0 = "credit-depleted";

--- a/src/lib/campaign-costs.ts
+++ b/src/lib/campaign-costs.ts
@@ -1,0 +1,56 @@
+/**
+ * Per-campaign authorize-cost tracking — feeds the read-only affordability gate.
+ *
+ * The required_cents resolved by the most recent authorize attempt for a
+ * campaign is the best up-front estimate of its next run's cost (a campaign
+ * re-runs the same workflow → ~constant cost). We upsert it on EVERY authorize
+ * that carries an x-campaign-id, on both sufficient and insufficient outcomes.
+ *
+ * Fail-loud: any DB error propagates (no swallow).
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import {
+  campaignAuthorizeCosts,
+  type CampaignAuthorizeCost,
+} from "../db/schema.js";
+
+/**
+ * Record the resolved required_cents of the latest authorize attempt for a
+ * campaign. One row per campaign (PK), upserted in place.
+ */
+export async function upsertCampaignAuthorizeCost(
+  campaignId: string,
+  orgId: string,
+  requiredCents: string
+): Promise<void> {
+  await db
+    .insert(campaignAuthorizeCosts)
+    .values({
+      campaignId,
+      orgId,
+      lastAuthorizeRequiredCents: requiredCents,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: campaignAuthorizeCosts.campaignId,
+      set: {
+        orgId,
+        lastAuthorizeRequiredCents: requiredCents,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+/** Read the stored authorize cost for a campaign, or null if none recorded. */
+export async function getCampaignAuthorizeCost(
+  campaignId: string
+): Promise<CampaignAuthorizeCost | null> {
+  const [row] = await db
+    .select()
+    .from(campaignAuthorizeCosts)
+    .where(eq(campaignAuthorizeCosts.campaignId, campaignId))
+    .limit(1);
+  return row ?? null;
+}

--- a/src/routes/customer_balance.ts
+++ b/src/routes/customer_balance.ts
@@ -15,6 +15,7 @@ import {
   hasAttachedCardPm,
 } from "../lib/stripe-service-client.js";
 import { computeBalance } from "../lib/balance.js";
+import { upsertCampaignAuthorizeCost } from "../lib/campaign-costs.js";
 import { openDepletionEpisodeIfDepleted } from "../lib/dunning.js";
 import { reloadViaPaymentIntent } from "../lib/reload.js";
 import { coalesceReload } from "../lib/reload-coalescer.js";
@@ -89,6 +90,16 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
     }
 
     traceEvent(runId, { service: "billing-service", event: "customer_balance.authorize.resolved", data: { required_cents: requiredCents } }, req.headers);
+
+    // Record this campaign's latest authorize cost (best estimate of its next
+    // run's cost) for the read-only affordability pre-flight gate. Upserted on
+    // both sufficient and insufficient outcomes; skipped for non-campaign
+    // authorizes (no x-campaign-id, e.g. dashboard chats). Fail-loud — a write
+    // failure surfaces, never silently drops the estimate. Does not touch the
+    // reload / depletion control flow below.
+    if (wf.campaignId) {
+      await upsertCampaignAuthorizeCost(wf.campaignId, orgId, requiredCents);
+    }
 
     const account = await findOrCreateAccount(orgId, userId, wfHeaders);
 

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -8,6 +8,9 @@ import {
   type StripeCustomer,
 } from "../lib/stripe-service-client.js";
 import { runDunningTick } from "../lib/dunning.js";
+import { getCampaignAuthorizeCost } from "../lib/campaign-costs.js";
+import { computeBalance } from "../lib/balance.js";
+import { gte as gteCents } from "../lib/cents.js";
 
 const router = Router();
 
@@ -15,6 +18,9 @@ const SS_LIST_PAGE_LIMIT = 100;
 const INTERNAL_IDENTITY: Record<string, string> = {
   "x-user-id": "00000000-0000-0000-0000-000000000000",
 };
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Parse a Stripe customer's `metadata.brand_id` value. We store it as a
@@ -151,6 +157,62 @@ router.post("/internal/transfer-brand", async (req, res) => {
       { tableName: "local_promos", count: localCount },
       { tableName: "stripe_service_customers", count: ssCount },
     ],
+  });
+});
+
+// GET /internal/campaigns/:campaignId/affordability
+//
+// Read-only pre-flight gate for campaign-service: "can this org afford another
+// run of campaign X right now?". ZERO side effects — no charge, no reload, no
+// depletion-episode mutation. The cost estimate is the required_cents of the
+// LAST authorize attempt for the campaign (stored by the authorize route); a
+// campaign re-runs the same workflow → ~constant cost.
+//
+//   - No stored cost (hasHistory=false) → affordable=true (first-run default:
+//     a brand-new campaign runs once to establish its cost). balanceCents is
+//     "0" because the org isn't resolvable without a stored row.
+//   - else affordable = (live balance >= lastRequiredCents).
+//
+// Fail-loud: a balance-compose failure surfaces as 502.
+const ZERO_CENTS = "0.0000000000";
+
+router.get("/internal/campaigns/:campaignId/affordability", async (req, res) => {
+  const { campaignId } = req.params;
+  if (!UUID_RE.test(campaignId)) {
+    res.status(400).json({ error: "campaignId must be a valid UUID" });
+    return;
+  }
+
+  const stored = await getCampaignAuthorizeCost(campaignId);
+
+  if (!stored) {
+    res.json({
+      affordable: true,
+      balanceCents: ZERO_CENTS,
+      lastRequiredCents: null,
+      hasHistory: false,
+    });
+    return;
+  }
+
+  let snapshot;
+  try {
+    snapshot = await computeBalance(stored.orgId, { "x-org-id": stored.orgId });
+  } catch (err) {
+    console.error(
+      `[billing-service] affordability: balance compose failed for campaign ${campaignId} (org ${stored.orgId}):`,
+      err
+    );
+    res.status(502).json({ error: "Failed to compute balance" });
+    return;
+  }
+
+  const lastRequiredCents = stored.lastAuthorizeRequiredCents;
+  res.json({
+    affordable: gteCents(snapshot.balanceCents, lastRequiredCents),
+    balanceCents: snapshot.balanceCents,
+    lastRequiredCents,
+    hasHistory: true,
   });
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -225,6 +225,21 @@ export const DunningTickResponseSchema = z
   })
   .openapi("DunningTickResponse");
 
+// --- Campaign affordability (read-only pre-flight gate) ---
+
+export const CampaignAffordabilitySchema = z
+  .object({
+    /** true when hasHistory=false (first-run default) OR balance >= lastRequired. */
+    affordable: z.boolean(),
+    /** Live balance (credited − usage), decimal string. "0" when hasHistory=false. */
+    balanceCents: CentsStringSchema,
+    /** Stored required_cents of the last authorize for this campaign; null if none. */
+    lastRequiredCents: CentsStringSchema.nullable(),
+    /** false when no authorize was ever recorded for this campaign. */
+    hasHistory: z.boolean(),
+  })
+  .openapi("CampaignAffordability");
+
 // --- Public Stats ---
 
 export const BillingGrowthRowSchema = z
@@ -641,6 +656,37 @@ registry.registerPath({
     },
     502: {
       description: "Tick failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/internal/campaigns/{campaignId}/affordability",
+  summary: "Read-only pre-flight: can this org afford another run of campaign X?",
+  description:
+    "Answers campaign-service's affordability question WITHOUT charging or reloading. " +
+    "Zero side effects — no charge, no reload, no depletion-episode mutation. " +
+    "Estimates the next run's cost as the required_cents of the campaign's LAST authorize " +
+    "attempt (a campaign re-runs the same workflow → ~constant cost). " +
+    "hasHistory=false (no authorize recorded yet) → affordable=true so a brand-new campaign " +
+    "can run once to establish its cost. Otherwise affordable = live balance >= lastRequiredCents.",
+  request: {
+    headers: internalHeaders,
+    params: z.object({ campaignId: z.string().uuid() }),
+  },
+  responses: {
+    200: {
+      description: "Affordability verdict",
+      content: { "application/json": { schema: CampaignAffordabilitySchema } },
+    },
+    400: {
+      description: "campaignId is not a valid UUID",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "stripe-service or runs-service unavailable (balance compose failed)",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -5,10 +5,12 @@ import {
   localPromoCodes,
   localPromos,
   creditDepletionEpisodes,
+  campaignAuthorizeCosts,
   WELCOME_PROMO_CODE,
   INVITE_REWARD_CODE,
   INVITE_WELCOME_CODE,
   type CreditDepletionEpisode,
+  type CampaignAuthorizeCost,
 } from "../../src/db/schema.js";
 
 const SEEDED_PROMO_CODES = [
@@ -19,6 +21,7 @@ const SEEDED_PROMO_CODES = [
 
 export async function cleanTestData() {
   await db.delete(creditDepletionEpisodes);
+  await db.delete(campaignAuthorizeCosts);
   await db.delete(localPromos);
   await db.delete(billingAccounts);
   // Keep seeded codes (welcome + invite_reward + invite_welcome); remove any
@@ -126,6 +129,33 @@ export async function insertTestPromoGrant(data: {
       amountCents: String(data.amountCents),
       promoCodeId: code.id,
       description: data.description ?? null,
+    })
+    .returning();
+  return row;
+}
+
+export async function getCampaignCost(
+  campaignId: string
+): Promise<CampaignAuthorizeCost | null> {
+  const [row] = await db
+    .select()
+    .from(campaignAuthorizeCosts)
+    .where(eq(campaignAuthorizeCosts.campaignId, campaignId))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function insertTestCampaignCost(data: {
+  campaignId: string;
+  orgId: string;
+  lastAuthorizeRequiredCents: string;
+}): Promise<CampaignAuthorizeCost> {
+  const [row] = await db
+    .insert(campaignAuthorizeCosts)
+    .values({
+      campaignId: data.campaignId,
+      orgId: data.orgId,
+      lastAuthorizeRequiredCents: data.lastAuthorizeRequiredCents,
     })
     .returning();
   return row;

--- a/tests/integration/authorize-campaign-cost.test.ts
+++ b/tests/integration/authorize-campaign-cost.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import {
+  cleanTestData,
+  insertTestAccount,
+  getCampaignCost,
+  closeDb,
+} from "../helpers/test-db.js";
+import { setupStripeMocks } from "../helpers/mock-stripe.js";
+
+const orgId = "00000000-0000-0000-0000-00000000c101";
+const userId = "00000000-0000-0000-0000-000000000099";
+const campaignId = "00000000-0000-0000-0000-0000000ca501";
+
+const authorizeBody = {
+  items: [{ costName: "anthropic-sonnet-4-5-tokens-input", quantity: 1000 }],
+  description: "campaign-cost upsert test",
+};
+
+function campaignHeaders() {
+  return { ...getAuthHeaders(orgId, userId), "x-campaign-id": campaignId };
+}
+
+describe("authorize upserts campaign_authorize_costs when x-campaign-id present", () => {
+  const app = createTestApp();
+  let ssMocks: ReturnType<typeof setupStripeMocks>;
+  let setRequired: (cents: string) => void;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    ssMocks = setupStripeMocks();
+    await cleanTestData();
+
+    const costsClient = await import("../../src/lib/costs-client.js");
+    let required = "10.0000000000";
+    setRequired = (cents: string) => {
+      required = cents;
+    };
+    vi.spyOn(costsClient, "resolveRequiredCents").mockImplementation(
+      async () => required
+    );
+
+    const runsClient = await import("../../src/lib/runs-client.js");
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "0.0000000000",
+      as_of: "2026-06-14T00:00:00.000Z",
+    });
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("sufficient outcome → upserts the resolved required_cents with org_id", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("1000.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(campaignHeaders())
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sufficient).toBe(true);
+
+    const row = await getCampaignCost(campaignId);
+    expect(row).not.toBeNull();
+    expect(row?.orgId).toBe(orgId);
+    expect(row?.lastAuthorizeRequiredCents).toBe("10.0000000000");
+  });
+
+  it("insufficient outcome (no topup config) → still upserts the required_cents", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(campaignHeaders())
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sufficient).toBe(false);
+
+    const row = await getCampaignCost(campaignId);
+    expect(row).not.toBeNull();
+    expect(row?.lastAuthorizeRequiredCents).toBe("10.0000000000");
+  });
+
+  it("no x-campaign-id → no upsert (non-campaign authorize)", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("1000.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(getAuthHeaders(orgId, userId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    const row = await getCampaignCost(campaignId);
+    expect(row).toBeNull();
+  });
+
+  it("re-run with a new required_cents → upserts in place (latest wins)", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("1000.0000000000");
+
+    setRequired("10.0000000000");
+    await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(campaignHeaders())
+      .send(authorizeBody);
+
+    setRequired("25.5000000000");
+    await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(campaignHeaders())
+      .send(authorizeBody);
+
+    const row = await getCampaignCost(campaignId);
+    expect(row?.lastAuthorizeRequiredCents).toBe("25.5000000000");
+  });
+});

--- a/tests/integration/campaign-affordability.test.ts
+++ b/tests/integration/campaign-affordability.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { createTestApp } from "../helpers/test-app.js";
+import {
+  cleanTestData,
+  insertTestCampaignCost,
+  listEpisodes,
+  closeDb,
+} from "../helpers/test-db.js";
+import { setupStripeMocks, customerWithEmail } from "../helpers/mock-stripe.js";
+
+const orgId = "00000000-0000-0000-0000-00000000c201";
+const campaignId = "00000000-0000-0000-0000-0000000ca601";
+const unknownCampaignId = "00000000-0000-0000-0000-0000000ca999";
+
+const apiKeyHeaders = { "X-API-Key": "test-api-key" };
+
+function affordabilityPath(id: string) {
+  return `/internal/campaigns/${id}/affordability`;
+}
+
+describe("GET /internal/campaigns/:campaignId/affordability (read-only gate)", () => {
+  const app = createTestApp();
+  let ssMocks: ReturnType<typeof setupStripeMocks>;
+  let setUsage: (cents: string) => void;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    ssMocks = setupStripeMocks();
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithEmail("founder@acme.test"));
+    await cleanTestData();
+
+    const runsClient = await import("../../src/lib/runs-client.js");
+    let usage = "0.0000000000";
+    setUsage = (cents: string) => {
+      usage = cents;
+    };
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(async () => ({
+      org_id: orgId,
+      spent_cents: usage,
+      as_of: "2026-06-14T00:00:00.000Z",
+    }));
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("no stored cost → first-run default affordable=true, hasHistory=false", async () => {
+    const res = await request(app)
+      .get(affordabilityPath(unknownCampaignId))
+      .set(apiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      affordable: true,
+      balanceCents: "0.0000000000",
+      lastRequiredCents: null,
+      hasHistory: false,
+    });
+    // Read-only: no downstream balance compose for an unknown campaign.
+    expect(ssMocks.getCustomerByOrg).not.toHaveBeenCalled();
+  });
+
+  it("stored cost, live balance >= lastRequired → affordable=true, hasHistory=true", async () => {
+    await insertTestCampaignCost({
+      campaignId,
+      orgId,
+      lastAuthorizeRequiredCents: "10.0000000000",
+    });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("100.0000000000");
+    setUsage("40.0000000000"); // balance = 100 − 40 = 60 >= 10
+
+    const res = await request(app)
+      .get(affordabilityPath(campaignId))
+      .set(apiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      affordable: true,
+      balanceCents: "60.0000000000",
+      lastRequiredCents: "10.0000000000",
+      hasHistory: true,
+    });
+  });
+
+  it("stored cost, live balance < lastRequired → affordable=false", async () => {
+    await insertTestCampaignCost({
+      campaignId,
+      orgId,
+      lastAuthorizeRequiredCents: "50.0000000000",
+    });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("100.0000000000");
+    setUsage("90.0000000000"); // balance = 100 − 90 = 10 < 50
+
+    const res = await request(app)
+      .get(affordabilityPath(campaignId))
+      .set(apiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    expect(res.body.affordable).toBe(false);
+    expect(res.body.balanceCents).toBe("10.0000000000");
+    expect(res.body.lastRequiredCents).toBe("50.0000000000");
+    expect(res.body.hasHistory).toBe(true);
+  });
+
+  it("is read-only: never reloads or opens a depletion episode even when depleted", async () => {
+    await insertTestCampaignCost({
+      campaignId,
+      orgId,
+      lastAuthorizeRequiredCents: "50.0000000000",
+    });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+    setUsage("100.0000000000"); // balance = −100, depleted
+
+    const res = await request(app)
+      .get(affordabilityPath(campaignId))
+      .set(apiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    expect(res.body.affordable).toBe(false);
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(await listEpisodes(orgId)).toHaveLength(0);
+  });
+
+  it("fails loud (502) when runs-service is unreachable and history exists", async () => {
+    await insertTestCampaignCost({
+      campaignId,
+      orgId,
+      lastAuthorizeRequiredCents: "10.0000000000",
+    });
+    const runsClient = await import("../../src/lib/runs-client.js");
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockRejectedValue(
+      new Error("runs-service down")
+    );
+
+    const res = await request(app)
+      .get(affordabilityPath(campaignId))
+      .set(apiKeyHeaders);
+
+    expect(res.status).toBe(502);
+  });
+
+  it("rejects a non-UUID campaignId with 400", async () => {
+    const res = await request(app)
+      .get(affordabilityPath("not-a-uuid"))
+      .set(apiKeyHeaders);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("requires service auth (401 without x-api-key)", async () => {
+    const res = await request(app).get(affordabilityPath(campaignId));
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -101,6 +101,16 @@ beforeAll(async () => {
     ON CONFLICT ("code") DO UPDATE SET "amount_cents" = EXCLUDED."amount_cents"
   `;
 
+  // campaign_authorize_costs (per-campaign affordability estimate, migration 0021).
+  await sql`
+    CREATE TABLE IF NOT EXISTS "campaign_authorize_costs" (
+      "campaign_id" uuid PRIMARY KEY NOT NULL,
+      "org_id" uuid NOT NULL,
+      "last_authorize_required_cents" numeric(16,10) NOT NULL,
+      "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+    )
+  `;
+
   // Seed platform-issued grant promo codes (matches migration 0017).
   await sql`
     INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")


### PR DESCRIPTION
## Why

Stops a credit **retry storm**: an out-of-credit org's recurring campaign was re-triggered every minute by campaign-service, each run doing paid Apollo enrichment then 402-ing at the LLM step (`/complete` authorize → insufficient credits) — red logs, 3× windmill retries, wasted spend. campaign-service now asks billing **"can this org afford another run of campaign X right now?"** before dispatching. This is the billing-service half.

## What

Answer truthfully, live, per-campaign — **without charging or reloading**.

- **New table `campaign_authorize_costs`** (migration `0021`, hand-journaled): `campaign_id` PK, `org_id`, `last_authorize_required_cents numeric(16,10)`, `updated_at`. One row per campaign holding the `required_cents` of its **last authorize attempt** — the best up-front estimate of the next run's cost (a campaign re-runs the same workflow → ~constant cost). `src/lib/campaign-costs.ts`.
- **`POST /v1/customer_balance/authorize`** upserts the estimate when `x-campaign-id` is present, on **both sufficient and insufficient** outcomes, right after `requiredCents` resolves. Absent `x-campaign-id` (dashboard chats) → skipped; never fails the authorize. Fail-loud on a write error. **Does NOT touch** the reload / depletion-episode / dunning control flow or the response shape.
- **`GET /internal/campaigns/:campaignId/affordability`** (service-auth, **READ-ONLY** — no charge, no reload, no episode mutation):
  - No stored cost → `{affordable:true, balanceCents:"0", lastRequiredCents:null, hasHistory:false}` (first-run default — a brand-new campaign runs once to establish its cost; org isn't resolvable without a stored row).
  - Stored cost → live balance via existing `computeBalance`; `affordable = balanceCents >= lastRequiredCents`, `hasHistory:true`. Fail-loud 502 if stripe/runs unreachable. 400 on non-UUID `campaignId`.

## Locked contract (campaign-service consumes byte-equal)

```
GET /internal/campaigns/:campaignId/affordability   auth: x-api-key
200 → { affordable: boolean, balanceCents: string, lastRequiredCents: string|null, hasHistory: boolean }
```

## Tests (11 new, 175 total green)

- Upsert-on-authorize: sufficient + insufficient + absent-campaignId-skips + re-run-updates-in-place.
- Affordability endpoint: first-run default true, balance≥/<lastRequired, read-only (no reload, no episode), 502 fail-loud when runs down, 400 non-UUID, 401 without api-key.

## No new env vars

Reuses `STRIPE_SERVICE_*`, `RUNS_SERVICE_*`, `BILLING_SERVICE_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)