### PR TITLE
fix(affordability): pass x-user-id to stripe-service in balance compute (prod 502)

### DIFF
--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -195,9 +195,15 @@ router.get("/internal/campaigns/:campaignId/affordability", async (req, res) => 
     return;
   }
 
+  // Customer is org-implicit (1:1 org↔customer); the user-id value is irrelevant
+  // to the lookup, but stripe-service's header validation REQUIRES x-user-id to
+  // be present (else 400). Carry the internal sentinel user-id alongside x-org-id.
   let snapshot;
   try {
-    snapshot = await computeBalance(stored.orgId, { "x-org-id": stored.orgId });
+    snapshot = await computeBalance(stored.orgId, {
+      "x-org-id": stored.orgId,
+      ...INTERNAL_IDENTITY,
+    });
   } catch (err) {
     console.error(
       `[billing-service] affordability: balance compose failed for campaign ${campaignId} (org ${stored.orgId}):`,

--- a/tests/integration/campaign-affordability.test.ts
+++ b/tests/integration/campaign-affordability.test.ts
@@ -83,6 +83,16 @@ describe("GET /internal/campaigns/:campaignId/affordability (read-only gate)", (
       lastRequiredCents: "10.0000000000",
       hasHistory: true,
     });
+    // Regression: stripe-service requires x-user-id on GET /v1/customers; the
+    // identity built from the stored row MUST carry it (else prod 400 → 502).
+    expect(ssMocks.getCustomerByOrg).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "x-org-id": orgId,
+        "x-user-id": expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+        ),
+      })
+    );
   });
 
   it("stored cost, live balance < lastRequired → affordable=false", async () => {


### PR DESCRIPTION
## Prod bug

`GET /internal/campaigns/:campaignId/affordability` (shipped v0.31.0) built its `computeBalance` identity as `{ "x-org-id": stored.orgId }` only. stripe-service `GET /v1/customers` **requires `x-user-id`** and 400s without it — so every **with-history** affordability check 502'd in prod:

```
stripe-service GET /v1/customers?limit=1 failed: 400 {"error":"Missing required header: x-user-id"}
```

(Local test masked it — `getCustomerByOrg` was mocked, so the header requirement never executed.)

## Fix

Customer is **org-implicit** (1:1 org↔customer) — the user-id *value* is irrelevant to the lookup; stripe-service only requires the header be *present*. Carry the existing `INTERNAL_IDENTITY` sentinel user-id alongside `x-org-id` (same pattern `transfer-brand` already uses for stripe calls). **No migration** — fixes every existing `campaign_authorize_costs` row immediately.

## Test

Regression assertion: `getCustomerByOrg` must receive an identity carrying both `x-org-id` AND a UUID `x-user-id` (fails on the old `{x-org-id}`-only identity). 175 tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)