### PR TITLE
feat(brand-budget): per-brand daily budget store + serve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,19 @@ Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed liv
 | `POST` | `/internal/credits/grant` | platform-issued grant — body `{orgId, amountCents, reason: invite_reward\|invite_welcome}` → `{ok, newBalanceCents}`. Idempotent on `(orgId, reason)`. `invite_welcome` replaces the existing `$25` welcome row. Used by api-service invite claim handler (DIS-64). |
 | `POST` | `/internal/dunning/tick` | run one out-of-credit dunning pass (ops/manual). Same pass runs on the in-process hourly scheduler. → `{processed, recovered, followup3dSent, followup10dSent}`. |
 | `GET` | `/internal/campaigns/:campaignId/affordability` | READ-ONLY pre-flight gate (campaign-service). → `{affordable, balanceCents, lastRequiredCents, hasHistory}`. ZERO side effects. See "Campaign affordability gate" below. |
+| `GET` | `/internal/brands/:brandId/daily-budget` | READ a brand's current daily budget (campaign-service, api-key only, no user). → `{brandId, dailyBudgetCents, updatedAt}`; unset brand → `dailyBudgetCents:null, updatedAt:null`. See "Per-brand daily budget" below. |
+| `PATCH` | `/v1/brands/:brandId/daily-budget` | SET/UPDATE a brand's daily budget (user via gateway, org headers). body `{dailyBudgetCents}` (non-negative; 0 = pause). → `{brandId, orgId, dailyBudgetCents, updatedAt}`. |
+
+## Per-brand daily budget (pacing ceiling — NOT affordability)
+
+Each brand carries exactly ONE current **daily budget** — the per-day spend ceiling for that brand's active work. A scalar, mutable: changing it re-paces future work on campaign-service's next loop. This is an **allocation / pacing** concept ("how much should THIS brand spend per day"), DISTINCT from the org credit balance/affordability ("can the org pay right now") — the two never mix. billing-service only **stores + serves** this value; **enforcement** (summing today's spend vs the ceiling, stop-when-exceeded) is **campaign-service's job**.
+
+**State:** one table, `brand_daily_budgets` (migration `0022`, hand-journaled) — `brand_id` PK, `org_id`, `daily_budget_cents numeric(16,10)`, `updated_at`. One row per brand, upserted in place (`ON CONFLICT (brand_id) DO UPDATE`). `src/lib/brand-budgets.ts` owns the upsert + read. Mirrors the per-campaign `campaign_authorize_costs` single-row pattern.
+
+- **Read** (`GET /internal/brands/:brandId/daily-budget`, `src/routes/brand_budgets.ts`, **api-key only — no user context**): campaign-service calls this per loop on a scheduler, keyed by brandId. No row → `dailyBudgetCents:null` (a legitimate unset state, distinct from an explicit `0` pause). 400 on a non-UUID brandId.
+- **Write** (`PATCH /v1/brands/:brandId/daily-budget`, requireOrgHeaders): the user via the gateway. `org_id` captured from `x-org-id` for provenance; value keyed by brandId. `dailyBudgetCents` validated via `parseNonNegativeCents` (allows 0, rejects negative; fractional cents OK). A subsequent read reflects the latest write.
+
+**Follow-ups (other repos, not built here):** api-service gateway proxy for the user `PATCH`; campaign-service reads the internal `GET` per loop + enforces; dashboard UI to set it.
 
 ## Campaign affordability gate (read-only pre-flight)
 

--- a/drizzle/0022_brand_daily_budgets.sql
+++ b/drizzle/0022_brand_daily_budgets.sql
@@ -1,0 +1,14 @@
+-- Per-brand daily-budget store (per-day spend ceiling / pacing).
+-- One row per brand holding the brand's CURRENT daily spend ceiling, upserted
+-- in place. This is an allocation / pacing ceiling — a SEPARATE concept from the
+-- org credit balance/affordability (unchanged). billing-service stores + serves
+-- this value; enforcement (summing today's spend vs the ceiling) is
+-- campaign-service's job. Read by GET /internal/brands/:brandId/daily-budget
+-- (campaign-service, api-key only), set by PATCH /v1/brands/:brandId/daily-budget
+-- (the user, via the gateway). Idempotent: safe to re-run on partial apply.
+CREATE TABLE IF NOT EXISTS "brand_daily_budgets" (
+  "brand_id" uuid PRIMARY KEY NOT NULL,
+  "org_id" uuid NOT NULL,
+  "daily_budget_cents" numeric(16,10) NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1790071200000,
       "tag": "0021_campaign_authorize_costs",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1790157600000,
+      "tag": "0022_brand_daily_budgets",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -471,6 +471,71 @@
           "hasHistory"
         ]
       },
+      "ReadBrandDailyBudget": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "dailyBudgetCents": {
+            "type": "string",
+            "nullable": true
+          },
+          "updatedAt": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "brandId",
+          "dailyBudgetCents",
+          "updatedAt"
+        ]
+      },
+      "BrandDailyBudget": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "dailyBudgetCents": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "brandId",
+          "orgId",
+          "dailyBudgetCents",
+          "updatedAt"
+        ]
+      },
+      "SetBrandDailyBudgetRequest": {
+        "type": "object",
+        "properties": {
+          "dailyBudgetCents": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "required": [
+          "dailyBudgetCents"
+        ]
+      },
       "TransferBrandTableResult": {
         "type": "object",
         "properties": {
@@ -1842,6 +1907,173 @@
           },
           "502": {
             "description": "stripe-service or runs-service unavailable (balance compose failed)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/brands/{brandId}/daily-budget": {
+      "get": {
+        "summary": "Read a brand's current daily budget (per-day spend ceiling)",
+        "description": "Returns the brand's current daily spend ceiling, keyed by brandId. User-less service-to-service read (x-api-key only) — campaign-service calls this once per loop on a scheduler. A brand with no configured budget returns dailyBudgetCents: null (a legitimate unset state; the consumer decides how to handle it). billing-service only stores + serves this value; enforcement is campaign-service's job.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Brand daily budget (dailyBudgetCents null when unset)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadBrandDailyBudget"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "brandId is not a valid UUID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{brandId}/daily-budget": {
+      "patch": {
+        "summary": "Set / update a brand's daily budget (per-day spend ceiling)",
+        "description": "Sets the brand's daily spend ceiling. One mutable scalar per brand, upserted in place — a subsequent read reflects the latest write. dailyBudgetCents is non-negative (0 = explicit pause). This is an allocation / pacing ceiling, a SEPARATE concept from org credit balance/affordability (which is unchanged). org_id is captured from x-org-id for provenance.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetBrandDailyBudgetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated brand daily budget",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandDailyBudget"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid brandId or dailyBudgetCents",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -191,6 +191,32 @@ export const campaignAuthorizeCosts = pgTable("campaign_authorize_costs", {
 export type CampaignAuthorizeCost = typeof campaignAuthorizeCosts.$inferSelect;
 export type NewCampaignAuthorizeCost = typeof campaignAuthorizeCosts.$inferInsert;
 
+// brand_daily_budgets: per-brand daily spend ceiling (allocation / pacing).
+// ONE current scalar per brand, mutable, upserted in place (PK = brand_id).
+// This is a PACING ceiling ("how much should THIS brand spend per day"), a
+// SEPARATE concept from org credit balance/affordability ("can the org pay").
+// billing-service only STORES + SERVES this value — enforcement (summing
+// today's spend vs the ceiling, stop-when-exceeded) is campaign-service's job.
+// Read by the user-less `GET /internal/brands/:brandId/daily-budget` (campaign-
+// service, api-key only — no user context). Set/updated by the user via
+// `PATCH /v1/brands/:brandId/daily-budget`. org_id is provenance (captured from
+// the setter's x-org-id); the read keys on brand_id alone. No row → unset
+// (the read returns dailyBudgetCents:null) — distinct from an explicit 0 (pause).
+export const brandDailyBudgets = pgTable("brand_daily_budgets", {
+  brandId: uuid("brand_id").primaryKey(),
+  orgId: uuid("org_id").notNull(),
+  dailyBudgetCents: numeric("daily_budget_cents", {
+    precision: FRACTIONAL_PRECISION,
+    scale: FRACTIONAL_SCALE,
+  }).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export type BrandDailyBudget = typeof brandDailyBudgets.$inferSelect;
+export type NewBrandDailyBudget = typeof brandDailyBudgets.$inferInsert;
+
 // Dunning eventTypes — byte-equal to the templates registered by the dashboard
 // app (distribute.you#1420). LOCKED contract; do not rename.
 export const DUNNING_EVENT_T0 = "credit-depleted";

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import promotionCodesRoutes from "./routes/promotion_codes.js";
 import internalRoutes from "./routes/internal.js";
 import creditsRoutes from "./routes/credits.js";
 import promoCodesRoutes from "./routes/promo_codes.js";
+import brandBudgetsRoutes from "./routes/brand_budgets.js";
 import { requireApiKey } from "./middleware/auth.js";
 import { startDunningScheduler } from "./lib/dunning-scheduler.js";
 
@@ -46,6 +47,7 @@ app.use(requireApiKey);
 app.use(internalRoutes);
 app.use(creditsRoutes);
 app.use(promoCodesRoutes);
+app.use(brandBudgetsRoutes);
 app.use(accountsRoutes);
 app.use(customerBalanceRoutes);
 app.use(checkoutRoutes);

--- a/src/lib/brand-budgets.ts
+++ b/src/lib/brand-budgets.ts
@@ -1,0 +1,55 @@
+/**
+ * Per-brand daily-budget store — the brand's current daily spend ceiling.
+ *
+ * ONE mutable scalar per brand (PK = brand_id), upserted in place. This is an
+ * allocation / pacing ceiling, NOT the org credit balance/affordability — see
+ * the table comment in db/schema.ts. billing-service only stores + serves this
+ * value; campaign-service reads it and enforces the cap.
+ *
+ * Fail-loud: any DB error propagates (no swallow).
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { brandDailyBudgets, type BrandDailyBudget } from "../db/schema.js";
+
+/**
+ * Set / update a brand's daily budget. One row per brand (PK), upserted in
+ * place. `dailyBudgetCents` is a canonical fixed-scale cents string.
+ */
+export async function upsertBrandDailyBudget(
+  brandId: string,
+  orgId: string,
+  dailyBudgetCents: string
+): Promise<BrandDailyBudget> {
+  const [row] = await db
+    .insert(brandDailyBudgets)
+    .values({
+      brandId,
+      orgId,
+      dailyBudgetCents,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: brandDailyBudgets.brandId,
+      set: {
+        orgId,
+        dailyBudgetCents,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+  return row;
+}
+
+/** Read a brand's stored daily budget, or null if none set. */
+export async function getBrandDailyBudget(
+  brandId: string
+): Promise<BrandDailyBudget | null> {
+  const [row] = await db
+    .select()
+    .from(brandDailyBudgets)
+    .where(eq(brandDailyBudgets.brandId, brandId))
+    .limit(1);
+  return row ?? null;
+}

--- a/src/routes/brand_budgets.ts
+++ b/src/routes/brand_budgets.ts
@@ -1,0 +1,85 @@
+import { Router } from "express";
+import { requireOrgHeaders } from "../middleware/auth.js";
+import { SetBrandDailyBudgetRequestSchema } from "../schemas.js";
+import { parseNonNegativeCents } from "../lib/cents.js";
+import {
+  getBrandDailyBudget,
+  upsertBrandDailyBudget,
+} from "../lib/brand-budgets.js";
+
+const router = Router();
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// GET /internal/brands/:brandId/daily-budget — read a brand's current daily
+// budget (the per-day spend ceiling for that brand's active work).
+//
+// Auth: x-api-key (service-to-service). NO user context — campaign-service calls
+// this per loop on a scheduler, keyed by brandId only.
+// Resp: { brandId, dailyBudgetCents, updatedAt }. Unset brand → dailyBudgetCents
+// and updatedAt are null (a brand with no configured budget is a legitimate
+// state; the consumer decides what to do with it). 400 on a non-UUID brandId.
+router.get("/internal/brands/:brandId/daily-budget", async (req, res) => {
+  const { brandId } = req.params;
+  if (!UUID_RE.test(brandId)) {
+    res.status(400).json({ error: "brandId must be a valid UUID" });
+    return;
+  }
+
+  const stored = await getBrandDailyBudget(brandId);
+  res.json({
+    brandId,
+    dailyBudgetCents: stored ? stored.dailyBudgetCents : null,
+    updatedAt: stored ? stored.updatedAt.toISOString() : null,
+  });
+});
+
+// PATCH /v1/brands/:brandId/daily-budget — set / update a brand's daily budget.
+//
+// Auth: x-api-key + org headers (the user, via the gateway). org_id is captured
+// from x-org-id for provenance; the value is keyed by brandId.
+// Body: { dailyBudgetCents } — non-negative (0 = explicit pause; null/unset is a
+// separate state expressed by never setting a row). Fractional cents allowed.
+// Resp: { brandId, orgId, dailyBudgetCents, updatedAt } | 400 invalid.
+router.patch(
+  "/v1/brands/:brandId/daily-budget",
+  requireOrgHeaders,
+  async (req, res) => {
+    const { brandId } = req.params;
+    if (!UUID_RE.test(brandId)) {
+      res.status(400).json({ error: "brandId must be a valid UUID" });
+      return;
+    }
+
+    const parsed = SetBrandDailyBudgetRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0].message });
+      return;
+    }
+
+    let dailyBudgetCents: string;
+    try {
+      dailyBudgetCents = parseNonNegativeCents(parsed.data.dailyBudgetCents);
+    } catch (err) {
+      res.status(400).json({
+        error: err instanceof Error ? err.message : "invalid dailyBudgetCents",
+      });
+      return;
+    }
+
+    const orgId = req.headers["x-org-id"] as string;
+    const row = await upsertBrandDailyBudget(brandId, orgId, dailyBudgetCents);
+    console.log(
+      `[billing-service] brand daily budget set: brand=${brandId} org=${orgId} budget=${dailyBudgetCents}`
+    );
+    res.json({
+      brandId: row.brandId,
+      orgId: row.orgId,
+      dailyBudgetCents: row.dailyBudgetCents,
+      updatedAt: row.updatedAt.toISOString(),
+    });
+  }
+);
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -240,6 +240,39 @@ export const CampaignAffordabilitySchema = z
   })
   .openapi("CampaignAffordability");
 
+// --- Brand daily budget (per-brand spend ceiling / pacing) ---
+
+export const SetBrandDailyBudgetRequestSchema = z
+  .object({
+    /**
+     * The per-day spend ceiling for this brand, in cents. Non-negative
+     * (0 = explicit pause). Accepts a number or decimal string; stored at
+     * numeric(16,10) precision.
+     */
+    dailyBudgetCents: z.union([z.string(), z.number()]),
+  })
+  .openapi("SetBrandDailyBudgetRequest");
+
+export const BrandDailyBudgetSchema = z
+  .object({
+    brandId: z.string().uuid(),
+    orgId: z.string().uuid(),
+    /** Current daily spend ceiling, decimal string (numeric(16,10)). */
+    dailyBudgetCents: CentsStringSchema,
+    updatedAt: z.string(),
+  })
+  .openapi("BrandDailyBudget");
+
+export const ReadBrandDailyBudgetSchema = z
+  .object({
+    brandId: z.string().uuid(),
+    /** Current daily spend ceiling; null when no budget has been set. */
+    dailyBudgetCents: CentsStringSchema.nullable(),
+    /** Last-set timestamp; null when no budget has been set. */
+    updatedAt: z.string().nullable(),
+  })
+  .openapi("ReadBrandDailyBudget");
+
 // --- Public Stats ---
 
 export const BillingGrowthRowSchema = z
@@ -687,6 +720,63 @@ registry.registerPath({
     },
     502: {
       description: "stripe-service or runs-service unavailable (balance compose failed)",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/internal/brands/{brandId}/daily-budget",
+  summary: "Read a brand's current daily budget (per-day spend ceiling)",
+  description:
+    "Returns the brand's current daily spend ceiling, keyed by brandId. User-less " +
+    "service-to-service read (x-api-key only) — campaign-service calls this once per " +
+    "loop on a scheduler. A brand with no configured budget returns dailyBudgetCents: " +
+    "null (a legitimate unset state; the consumer decides how to handle it). " +
+    "billing-service only stores + serves this value; enforcement is campaign-service's job.",
+  request: {
+    headers: internalHeaders,
+    params: z.object({ brandId: z.string().uuid() }),
+  },
+  responses: {
+    200: {
+      description: "Brand daily budget (dailyBudgetCents null when unset)",
+      content: { "application/json": { schema: ReadBrandDailyBudgetSchema } },
+    },
+    400: {
+      description: "brandId is not a valid UUID",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/v1/brands/{brandId}/daily-budget",
+  summary: "Set / update a brand's daily budget (per-day spend ceiling)",
+  description:
+    "Sets the brand's daily spend ceiling. One mutable scalar per brand, upserted in " +
+    "place — a subsequent read reflects the latest write. dailyBudgetCents is " +
+    "non-negative (0 = explicit pause). This is an allocation / pacing ceiling, a " +
+    "SEPARATE concept from org credit balance/affordability (which is unchanged). " +
+    "org_id is captured from x-org-id for provenance.",
+  request: {
+    headers: protectedHeaders,
+    params: z.object({ brandId: z.string().uuid() }),
+    body: {
+      content: {
+        "application/json": { schema: SetBrandDailyBudgetRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated brand daily budget",
+      content: { "application/json": { schema: BrandDailyBudgetSchema } },
+    },
+    400: {
+      description: "Invalid brandId or dailyBudgetCents",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -10,6 +10,7 @@ import promotionCodesRoutes from "../../src/routes/promotion_codes.js";
 import internalRoutes from "../../src/routes/internal.js";
 import creditsRoutes from "../../src/routes/credits.js";
 import promoCodesRoutes from "../../src/routes/promo_codes.js";
+import brandBudgetsRoutes from "../../src/routes/brand_budgets.js";
 import { requireApiKey } from "../../src/middleware/auth.js";
 
 export function createTestApp() {
@@ -24,6 +25,7 @@ export function createTestApp() {
   app.use(internalRoutes);
   app.use(creditsRoutes);
   app.use(promoCodesRoutes);
+  app.use(brandBudgetsRoutes);
   app.use(accountsRoutes);
   app.use(customerBalanceRoutes);
   app.use(checkoutRoutes);

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -6,6 +6,7 @@ import {
   localPromos,
   creditDepletionEpisodes,
   campaignAuthorizeCosts,
+  brandDailyBudgets,
   WELCOME_PROMO_CODE,
   INVITE_REWARD_CODE,
   INVITE_WELCOME_CODE,
@@ -22,6 +23,7 @@ const SEEDED_PROMO_CODES = [
 export async function cleanTestData() {
   await db.delete(creditDepletionEpisodes);
   await db.delete(campaignAuthorizeCosts);
+  await db.delete(brandDailyBudgets);
   await db.delete(localPromos);
   await db.delete(billingAccounts);
   // Keep seeded codes (welcome + invite_reward + invite_welcome); remove any

--- a/tests/integration/brand-daily-budget.test.ts
+++ b/tests/integration/brand-daily-budget.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import { cleanTestData, closeDb } from "../helpers/test-db.js";
+
+const orgId = "00000000-0000-0000-0000-00000000b201";
+const userId = "00000000-0000-0000-0000-00000000b299";
+const runId = "00000000-0000-0000-0000-00000000baaa";
+const brandId = "00000000-0000-0000-0000-0000000bd601";
+const otherBrandId = "00000000-0000-0000-0000-0000000bd999";
+
+const apiKeyHeaders = { "X-API-Key": "test-api-key" };
+
+function readPath(id: string) {
+  return `/internal/brands/${id}/daily-budget`;
+}
+function setPath(id: string) {
+  return `/v1/brands/${id}/daily-budget`;
+}
+
+describe("brand daily budget (store + serve)", () => {
+  const app = createTestApp();
+  const authHeaders = getAuthHeaders(orgId, userId, runId);
+
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("PATCH sets a brand's daily budget → 200 echo", async () => {
+    const res = await request(app)
+      .patch(setPath(brandId))
+      .set(authHeaders)
+      .send({ dailyBudgetCents: 2500 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      brandId,
+      orgId,
+      dailyBudgetCents: "2500.0000000000",
+      updatedAt: expect.any(String),
+    });
+  });
+
+  it("internal read reflects the latest write", async () => {
+    await request(app)
+      .patch(setPath(brandId))
+      .set(authHeaders)
+      .send({ dailyBudgetCents: 2500 });
+
+    const res = await request(app).get(readPath(brandId)).set(apiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      brandId,
+      dailyBudgetCents: "2500.0000000000",
+      updatedAt: expect.any(String),
+    });
+  });
+
+  it("a second write updates in place; read reflects the latest", async () => {
+    await request(app)
+      .patch(setPath(brandId))
+      .set(authHeaders)
+      .send({ dailyBudgetCents: 2500 });
+    await request(app)
+      .patch(setPath(brandId))
+      .set(authHeaders)
+      .send({ dailyBudgetCents: 9900 });
+
+    const res = await request(app).get(readPath(brandId)).set(apiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    expect(res.body.dailyBudgetCents).toBe("9900.0000000000");
+  });
+
+  it("unset brand → 200 with null budget", async () => {
+    const res = await request(app).get(readPath(otherBrandId)).set(apiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      brandId: otherBrandId,
+      dailyBudgetCents: null,
+      updatedAt: null,
+    });
+  });
+
+  it("allows 0 (explicit pause)", async () => {
+    const res = await request(app)
+      .patch(setPath(brandId))
+      .set(authHeaders)
+      .send({ dailyBudgetCents: 0 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.dailyBudgetCents).toBe("0.0000000000");
+  });
+
+  it("rejects a negative budget with 400", async () => {
+    const res = await request(app)
+      .patch(setPath(brandId))
+      .set(authHeaders)
+      .send({ dailyBudgetCents: -1 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a missing dailyBudgetCents with 400", async () => {
+    const res = await request(app)
+      .patch(setPath(brandId))
+      .set(authHeaders)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-UUID brandId on PATCH with 400", async () => {
+    const res = await request(app)
+      .patch(setPath("not-a-uuid"))
+      .set(authHeaders)
+      .send({ dailyBudgetCents: 2500 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-UUID brandId on GET with 400", async () => {
+    const res = await request(app).get(readPath("not-a-uuid")).set(apiKeyHeaders);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("internal read requires service auth (401 without x-api-key)", async () => {
+    const res = await request(app).get(readPath(brandId));
+    expect(res.status).toBe(401);
+  });
+
+  it("PATCH requires org headers (400 without x-org-id)", async () => {
+    const res = await request(app)
+      .patch(setPath(brandId))
+      .set(apiKeyHeaders)
+      .send({ dailyBudgetCents: 2500 });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -111,6 +111,16 @@ beforeAll(async () => {
     )
   `;
 
+  // brand_daily_budgets (per-brand daily spend ceiling, migration 0022).
+  await sql`
+    CREATE TABLE IF NOT EXISTS "brand_daily_budgets" (
+      "brand_id" uuid PRIMARY KEY NOT NULL,
+      "org_id" uuid NOT NULL,
+      "daily_budget_cents" numeric(16,10) NOT NULL,
+      "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+    )
+  `;
+
   // Seed platform-issued grant promo codes (matches migration 0017).
   await sql`
     INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")


### PR DESCRIPTION
## TL;DR
Adds ONE mutable per-brand **daily budget** (the per-day spend ceiling). Like a thermostat setting — billing-service stores the number and serves it back; it does NOT watch spend (no enforcement — that's campaign-service's job). Org credit balance/affordability/authorize unchanged.

## What
- **New table** `brand_daily_budgets` (migration `0022`, hand-journaled): one scalar per brand — `brand_id` PK, `org_id`, `daily_budget_cents numeric(16,10)`, `updated_at`. Upserted in place. Mirrors the per-campaign `campaign_authorize_costs` single-row pattern.
- **`GET /internal/brands/:brandId/daily-budget`** — api-key only, **no user context** (campaign-service reads per loop, keyed by brandId). Unset brand → `{dailyBudgetCents:null, updatedAt:null}` (distinct from an explicit `0` pause). 400 on non-UUID brandId.
- **`PATCH /v1/brands/:brandId/daily-budget`** — user via gateway (org headers). Body `{dailyBudgetCents}`, non-negative (`0` = pause), fractional cents OK. `org_id` captured from `x-org-id` for provenance. Subsequent read reflects latest write.
- `src/lib/brand-budgets.ts` upsert+read; OpenAPI regenerated; CLAUDE.md documented.

## Why it's a separate value
This is an **allocation / pacing** ceiling ("how much should THIS brand spend per day"), a DIFFERENT concept from affordability ("can the org pay right now"). Not folded into balance/authorize. Per the product-owner placement decision, the per-brand daily spend ceiling lives in billing-service.

## Out of scope (campaign-service / other repos)
- Enforcement (summing today's spend vs ceiling, stop-when-exceeded) — campaign-service reads this value and enforces.
- api-service gateway proxy for the user `PATCH`; campaign-service internal reader; dashboard UI. Surfaced as follow-up issues.

## Tests
`tests/integration/brand-daily-budget.test.ts` — 11 cases: set→read, update-in-place, unset→null, 0-pause, negative→400, missing field→400, non-UUID→400 (both verbs), 401 no-api-key, 400 no-org-headers. Full suite green (186 passed). No new env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)