### PR TITLE
feat(brand-subscription): per-brand daily subscription wiring + $25 welcome gift (4-key dedup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,11 @@ Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed liv
 | `GET` | `/internal/campaigns/:campaignId/affordability` | READ-ONLY pre-flight gate (campaign-service). → `{affordable, balanceCents, lastRequiredCents, hasHistory}`. ZERO side effects. See "Campaign affordability gate" below. |
 | `GET` | `/internal/brands/:brandId/daily-budget` | READ a brand's current daily budget (campaign-service, api-key only, no user). → `{brandId, dailyBudgetCents, updatedAt}`; unset brand → `dailyBudgetCents:null, updatedAt:null`. See "Per-brand daily budget" below. |
 | `PATCH` | `/v1/brands/:brandId/daily-budget` | SET/UPDATE a brand's daily budget (user via gateway, org headers). body `{dailyBudgetCents}` (non-negative; 0 = pause). → `{brandId, orgId, dailyBudgetCents, updatedAt}`. |
+| `POST` | `/v1/brands/:brandId/subscription` | Onboard a brand at a chosen daily amount (user via gateway). body `{dailyAmountCents}` (positive int). Creates the daily Stripe subscription (stripe-service) + sets daily-budget = amount. → `{brandId, orgId, subscriptionId, status, dailyAmountCents, dailyBudgetCents}`. |
+| `PATCH` | `/v1/brands/:brandId/subscription` | Change the daily amount. Updates the Stripe subscription amount AND the daily-budget together. body `{dailyAmountCents}`. → same shape. |
+| `POST` | `/v1/brands/:brandId/subscription/pause` | Brand dry → pause Stripe collection + set daily-budget `0`. → `{brandId, orgId, status, dailyBudgetCents}`. |
+| `POST` | `/v1/brands/:brandId/subscription/resume` | Reverse pause → resume collection + restore daily-budget to the subscription amount (read back from stripe-service). → `{brandId, orgId, status, dailyAmountCents, dailyBudgetCents}`. |
+| `POST` | `/internal/brands/:brandId/subscription/card-confirmed` | stripe-service signal (Stripe webhook → SS → here) on card add/confirm. Grants the one-time **$25** welcome gift, deduped 4-key. api-key only; body `{orgId, userId, cardFingerprint}`. → `{ok, granted, amountCents, newBalanceCents}`. |
 
 ## Per-brand daily budget (pacing ceiling — NOT affordability)
 
@@ -182,6 +187,27 @@ Each brand carries exactly ONE current **daily budget** — the per-day spend ce
 - **Write** (`PATCH /v1/brands/:brandId/daily-budget`, requireOrgHeaders): the user via the gateway. `org_id` captured from `x-org-id` for provenance; value keyed by brandId. `dailyBudgetCents` validated via `parseNonNegativeCents` (allows 0, rejects negative; fractional cents OK). A subsequent read reflects the latest write.
 
 **Follow-ups (other repos, not built here):** api-service gateway proxy for the user `PATCH`; campaign-service reads the internal `GET` per loop + enforces; dashboard UI to set it.
+
+## Per-brand daily subscription wiring + $25 welcome gift
+
+A founder onboards a brand at a chosen daily amount (presets $25/$125/$625/day, custom min $1/day). Stripe bills that amount DAILY per brand. billing is the **conductor**: it never touches Stripe (the subscription object + webhooks live in **stripe-service**), it calls stripe-service's by-brand passthrough and keeps **three dials in lock-step** — the Stripe subscription amount, the brand daily-budget (`brand_daily_budgets`, `0`=pause), and the pause/resume state.
+
+**No billing-stored subscription id/amount** (CLAUDE.md: never duplicate Stripe state). stripe-service resolves the subscription by **brand metadata**; resume reads the amount back from stripe-service to restore the budget. `src/lib/subscription-service-client.ts` calls the LOCKED contract (same `STRIPE_SERVICE_URL` + `X-API-Key`, byte-equal both sides):
+- `POST /internal/subscriptions/by-brand/:brandId` body `{orgId, userId, dailyAmountCents}` (org/user/brand stored in subscription metadata).
+- `PATCH /internal/subscriptions/by-brand/:brandId` body `{dailyAmountCents}`.
+- `POST /internal/subscriptions/by-brand/:brandId/{pause,resume}` (resume returns `dailyAmountCents`).
+
+**`src/routes/brand_subscriptions.ts`** owns the 4 user-facing lifecycle routes (`requireOrgHeaders`) + the internal card-confirmed receiver. Each lifecycle op = stripe-service call + `upsertBrandDailyBudget` in one handler, fail-loud `502` on any stripe-service error (explicit try/catch → 502; this service has NO global async error middleware — match `accounts.ts`).
+
+**Paid daily invoice → credit is AUTOMATIC, no receiver.** A daily subscription invoice settles as a Stripe `payment_intent` on the customer → already summed by `sumSucceededTopupsForOrg` into `credited`. So there is deliberately **no invoice-paid receiver** (would double-count). Brand attribution is metadata-only; org balance has no brand dimension.
+
+**$25 welcome gift — 4-key un-farmable grant (`src/lib/brand-welcome.ts` + `welcome_credit_claims`, migration 0023).** Granted once on card-confirmed, deduped across **org_id, user_id, brand_id, AND card_fingerprint** — a prior claim on ANY key → `granted:false, $0`. Each key has its OWN unique index, so the grant is a plain INSERT the DB rejects (`23505`) when any key was already claimed (race-safe, no SELECT-then-insert window). card_fingerprint is the un-spoofable key (supplied by stripe-service from the confirmed PM). The money is a `local_promos` row under the **new** `brand_welcome` code ($2500, seeded by 0023) — DISTINCT from the org-level `welcome` $2 code (0019), do NOT conflate. `local_promo_id` back-references the credit. `newBalanceCents` recomputed via `computeBalance(orgId)`; fail-loud `502` if compose fails after a committed grant (grant is idempotent — caller may retry).
+
+**Per-brand spend gate (DEFERRED, not built here):** the authorize/affordability gate stays ORG-level. If brand-scoped funding needs brand-scoped spend, that belongs at the source (runs-service `GET /internal/brand-usage-total?brand_id=`), NOT synthesized client-side — filed as a runs-service follow-up.
+
+**Cross-repo dependencies (must ship before this is live):** stripe-service (the by-brand subscription passthrough + Stripe webhooks → the card-confirmed callback + card-fingerprint exposure) and runs-service (per-brand spend, deferred). The user routes 502-if-called until stripe-service ships; the card-confirmed receiver just isn't called. No new env vars (reuses `STRIPE_SERVICE_*`, `RUNS_SERVICE_*`, `BILLING_SERVICE_API_KEY`).
+
+**Follow-ups (other repos):** stripe-service subscription passthrough + webhooks; api-service gateway proxy for the 4 user routes; dashboard onboarding UI (preset picker, `daysFree = floor(25/daily)`).
 
 ## Campaign affordability gate (read-only pre-flight)
 

--- a/drizzle/0023_brand_welcome_claims.sql
+++ b/drizzle/0023_brand_welcome_claims.sql
@@ -1,0 +1,30 @@
+-- Per-brand subscription welcome gift — the one-time $25 free credit.
+--
+-- welcome_credit_claims is the 4-key suppression ledger: one row per SUCCESSFUL
+-- grant. The gift is un-farmable — a prior claim on ANY of org_id / user_id /
+-- brand_id / card_fingerprint yields $0 next time. Each key has its OWN unique
+-- index, so the grant is a plain INSERT the DB rejects (23505) when any key was
+-- already claimed (race-safe, no SELECT-then-insert window). The money itself is
+-- a local_promos row under the 'brand_welcome' code; local_promo_id references it.
+--
+-- Idempotent: safe to re-run on partial apply.
+CREATE TABLE IF NOT EXISTS "welcome_credit_claims" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL,
+  "user_id" uuid NOT NULL,
+  "brand_id" uuid NOT NULL,
+  "card_fingerprint" text NOT NULL,
+  "amount_cents" numeric(16,10) NOT NULL,
+  "local_promo_id" uuid,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_welcome_claims_org" ON "welcome_credit_claims" ("org_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_welcome_claims_user" ON "welcome_credit_claims" ("user_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_welcome_claims_brand" ON "welcome_credit_claims" ("brand_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_welcome_claims_card" ON "welcome_credit_claims" ("card_fingerprint");
+
+-- Seed the per-brand welcome promo code (the money side of the gift). $25 = 2500.
+-- Independent of the org-level 'welcome' code (which stays at $2 per 0019).
+INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")
+VALUES ('brand_welcome', 2500, NULL, NULL)
+ON CONFLICT ("code") DO NOTHING;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1790157600000,
       "tag": "0022_brand_daily_budgets",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1790244000000,
+      "tag": "0023_brand_welcome_claims",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -536,6 +536,154 @@
           "dailyBudgetCents"
         ]
       },
+      "BrandSubscriptionResponse": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "subscriptionId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "dailyAmountCents": {
+            "type": "integer"
+          },
+          "dailyBudgetCents": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "brandId",
+          "orgId",
+          "subscriptionId",
+          "status",
+          "dailyAmountCents",
+          "dailyBudgetCents"
+        ]
+      },
+      "SubscriptionAmountRequest": {
+        "type": "object",
+        "properties": {
+          "dailyAmountCents": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          }
+        },
+        "required": [
+          "dailyAmountCents"
+        ]
+      },
+      "BrandSubscriptionPauseResponse": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "dailyBudgetCents": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "brandId",
+          "orgId",
+          "status",
+          "dailyBudgetCents"
+        ]
+      },
+      "BrandSubscriptionResumeResponse": {
+        "type": "object",
+        "properties": {
+          "brandId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "dailyAmountCents": {
+            "type": "integer"
+          },
+          "dailyBudgetCents": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "brandId",
+          "orgId",
+          "status",
+          "dailyAmountCents",
+          "dailyBudgetCents"
+        ]
+      },
+      "CardConfirmedResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "granted": {
+            "type": "boolean"
+          },
+          "amountCents": {
+            "type": "string"
+          },
+          "newBalanceCents": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok",
+          "granted",
+          "amountCents",
+          "newBalanceCents"
+        ]
+      },
+      "CardConfirmedRequest": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cardFingerprint": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "orgId",
+          "userId",
+          "cardFingerprint"
+        ]
+      },
       "TransferBrandTableResult": {
         "type": "object",
         "properties": {
@@ -2074,6 +2222,572 @@
           },
           "400": {
             "description": "Invalid brandId or dailyBudgetCents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{brandId}/subscription": {
+      "post": {
+        "summary": "Onboard a brand at a chosen daily subscription amount",
+        "description": "Creates the brand's recurring daily Stripe subscription (via stripe-service) AND sets the brand daily-budget = the chosen amount. The $25 welcome gift is NOT granted here — it fires asynchronously on the card-confirmed signal.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscriptionAmountRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Subscription created + budget set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandSubscriptionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid brandId or dailyAmountCents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "stripe-service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Change the brand's daily subscription amount",
+        "description": "Updates the Stripe subscription amount AND the brand daily-budget together (one logical operation).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscriptionAmountRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Amount updated + budget synced",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandSubscriptionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid brandId or dailyAmountCents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "stripe-service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{brandId}/subscription/pause": {
+      "post": {
+        "summary": "Pause the brand subscription (brand went dry)",
+        "description": "Pauses Stripe collection AND sets the brand daily-budget to 0 (the existing pause sentinel).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paused + budget set to 0",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandSubscriptionPauseResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid brandId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "stripe-service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/brands/{brandId}/subscription/resume": {
+      "post": {
+        "summary": "Resume the brand subscription",
+        "description": "Resumes Stripe collection AND restores the brand daily-budget to the subscription's amount (read back from stripe-service).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resumed + budget restored",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrandSubscriptionResumeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid brandId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "stripe-service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/brands/{brandId}/subscription/card-confirmed": {
+      "post": {
+        "summary": "Grant the one-time $25 brand welcome gift (4-key deduped)",
+        "description": "Called by stripe-service when the subscription's card is added/confirmed (Stripe webhook → stripe-service → here). Grants $25 once, deduped across org_id / user_id / brand_id / card_fingerprint — a prior claim on ANY key yields granted:false, $0. Service-auth only (orgId/userId in the body, resolved from subscription metadata by stripe-service).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "brandId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CardConfirmedRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Grant evaluated (granted true/false)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CardConfirmedResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid brandId or body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Grant applied but balance compose failed",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -217,6 +217,51 @@ export const brandDailyBudgets = pgTable("brand_daily_budgets", {
 export type BrandDailyBudget = typeof brandDailyBudgets.$inferSelect;
 export type NewBrandDailyBudget = typeof brandDailyBudgets.$inferInsert;
 
+// Per-brand subscription welcome gift — the one-time $25 free credit granted
+// when a brand's daily subscription gets a confirmed card. Distinct from the
+// org-level `welcome` $2 promo code (migration 0019 reverted that to 200) — this
+// is the per-brand subscription onboarding gift, seeded as code='brand_welcome'
+// @2500 by migration 0023. Independent path; do NOT conflate with `welcome`.
+export const BRAND_WELCOME_CODE = "brand_welcome";
+export const BRAND_WELCOME_AMOUNT_CENTS = 2500;
+
+// welcome_credit_claims: the 4-key suppression ledger for the per-brand $25 gift.
+// One row per SUCCESSFUL grant. The gift is un-farmable: a prior claim on ANY of
+// the four keys (org_id, user_id, brand_id, card_fingerprint) yields $0 on the
+// next attempt. Each key carries its OWN unique index, so the grant is a plain
+// INSERT that the DB rejects (23505) when any key was already claimed — race-safe
+// without a SELECT-then-insert window. card_fingerprint is the un-spoofable key
+// (the same physical card cannot re-claim under a fresh org/user/brand). The
+// money itself is a `local_promos` row (so it composes into balance) under the
+// `brand_welcome` code; `local_promo_id` back-references it. Migration 0023.
+export const welcomeCreditClaims = pgTable(
+  "welcome_credit_claims",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id").notNull(),
+    userId: uuid("user_id").notNull(),
+    brandId: uuid("brand_id").notNull(),
+    cardFingerprint: text("card_fingerprint").notNull(),
+    amountCents: numeric("amount_cents", {
+      precision: FRACTIONAL_PRECISION,
+      scale: FRACTIONAL_SCALE,
+    }).notNull(),
+    localPromoId: uuid("local_promo_id"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("idx_welcome_claims_org").on(table.orgId),
+    uniqueIndex("idx_welcome_claims_user").on(table.userId),
+    uniqueIndex("idx_welcome_claims_brand").on(table.brandId),
+    uniqueIndex("idx_welcome_claims_card").on(table.cardFingerprint),
+  ]
+);
+
+export type WelcomeCreditClaim = typeof welcomeCreditClaims.$inferSelect;
+export type NewWelcomeCreditClaim = typeof welcomeCreditClaims.$inferInsert;
+
 // Dunning eventTypes — byte-equal to the templates registered by the dashboard
 // app (distribute.you#1420). LOCKED contract; do not rename.
 export const DUNNING_EVENT_T0 = "credit-depleted";

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import internalRoutes from "./routes/internal.js";
 import creditsRoutes from "./routes/credits.js";
 import promoCodesRoutes from "./routes/promo_codes.js";
 import brandBudgetsRoutes from "./routes/brand_budgets.js";
+import brandSubscriptionsRoutes from "./routes/brand_subscriptions.js";
 import { requireApiKey } from "./middleware/auth.js";
 import { startDunningScheduler } from "./lib/dunning-scheduler.js";
 
@@ -48,6 +49,7 @@ app.use(internalRoutes);
 app.use(creditsRoutes);
 app.use(promoCodesRoutes);
 app.use(brandBudgetsRoutes);
+app.use(brandSubscriptionsRoutes);
 app.use(accountsRoutes);
 app.use(customerBalanceRoutes);
 app.use(checkoutRoutes);

--- a/src/lib/brand-welcome.ts
+++ b/src/lib/brand-welcome.ts
@@ -1,0 +1,123 @@
+/**
+ * Per-brand $25 welcome gift — 4-key un-farmable grant.
+ *
+ * Granted once when a brand's daily subscription gets a confirmed card. Deduped
+ * across FOUR independent keys — org_id, user_id, brand_id, card_fingerprint — so
+ * a prior claim on ANY of them yields $0. Each key carries its own UNIQUE index
+ * on welcome_credit_claims, so the grant is a plain INSERT the DB rejects (23505)
+ * when any key was already claimed: race-safe, no SELECT-then-insert window.
+ * card_fingerprint is the un-spoofable key (same physical card can't re-claim
+ * under a fresh org/user/brand).
+ *
+ * The money is a `local_promos` row under the `brand_welcome` code (so it composes
+ * into balance like any promo); the claim row back-references it via local_promo_id.
+ *
+ * Fail-loud: a missing seed code, or any DB error other than the dedup 23505,
+ * propagates.
+ */
+
+import { or, eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import {
+  localPromoCodes,
+  localPromos,
+  welcomeCreditClaims,
+  BRAND_WELCOME_CODE,
+} from "../db/schema.js";
+
+export class BrandWelcomeCodeMissingError extends Error {
+  constructor() {
+    super(
+      `brand welcome promo code seed missing: ${BRAND_WELCOME_CODE} (run migration 0023)`
+    );
+  }
+}
+
+export interface BrandWelcomeParams {
+  orgId: string;
+  userId: string;
+  brandId: string;
+  cardFingerprint: string;
+}
+
+export interface BrandWelcomeResult {
+  granted: boolean;
+  /** Granted amount as a numeric(16,10) string; "0.0000000000" when suppressed. */
+  amountCents: string;
+  localPromoId: string | null;
+}
+
+const ZERO = "0.0000000000";
+
+/**
+ * Grant the per-brand $25 welcome gift IFF none of the four keys was ever claimed.
+ * Returns { granted:false, amountCents:"0..." } when any key already claimed.
+ */
+export async function grantBrandWelcomeIfEligible(
+  params: BrandWelcomeParams
+): Promise<BrandWelcomeResult> {
+  const { orgId, userId, brandId, cardFingerprint } = params;
+
+  const [code] = await db
+    .select()
+    .from(localPromoCodes)
+    .where(eq(localPromoCodes.code, BRAND_WELCOME_CODE))
+    .limit(1);
+  if (!code) throw new BrandWelcomeCodeMissingError();
+
+  // Fast-path dedup: any of the four keys already claimed → suppress.
+  const [existing] = await db
+    .select({ id: welcomeCreditClaims.id })
+    .from(welcomeCreditClaims)
+    .where(
+      or(
+        eq(welcomeCreditClaims.orgId, orgId),
+        eq(welcomeCreditClaims.userId, userId),
+        eq(welcomeCreditClaims.brandId, brandId),
+        eq(welcomeCreditClaims.cardFingerprint, cardFingerprint)
+      )
+    )
+    .limit(1);
+  if (existing) return { granted: false, amountCents: ZERO, localPromoId: null };
+
+  const amountCents = String(code.amountCents);
+
+  try {
+    return await db.transaction(async (tx) => {
+      // The four unique indexes are the race backstop: a concurrent claim that
+      // slipped past the fast-path SELECT aborts this INSERT with 23505.
+      const [claim] = await tx
+        .insert(welcomeCreditClaims)
+        .values({ orgId, userId, brandId, cardFingerprint, amountCents })
+        .returning();
+
+      // The credit itself — composes into balance via sumLocalPromoCreditsForOrg.
+      const [promo] = await tx
+        .insert(localPromos)
+        .values({
+          orgId,
+          userId,
+          amountCents,
+          promoCodeId: code.id,
+          brandIds: [brandId],
+          description: `Brand welcome gift: $${(code.amountCents / 100).toFixed(2)}`,
+        })
+        .returning();
+
+      await tx
+        .update(welcomeCreditClaims)
+        .set({ localPromoId: promo.id })
+        .where(eq(welcomeCreditClaims.id, claim.id));
+
+      // promo.amountCents is the canonical numeric(16,10) string ("2500.0000000000").
+      return { granted: true, amountCents: promo.amountCents, localPromoId: promo.id };
+    });
+  } catch (err) {
+    // 23505 from either the 4-key claim or the (org,promo) local_promos index =
+    // already claimed (lost the race) → suppress, do not double-grant.
+    if ((err as { code?: string }).code === "23505") {
+      return { granted: false, amountCents: ZERO, localPromoId: null };
+    }
+    throw err;
+  }
+}

--- a/src/lib/subscription-service-client.ts
+++ b/src/lib/subscription-service-client.ts
@@ -1,0 +1,94 @@
+/**
+ * HTTP client for stripe-service's per-brand subscription passthrough.
+ *
+ * The recurring daily Stripe subscription is owned + plumbed by stripe-service
+ * (create / update-amount / pause / resume, plus the Stripe webhooks). billing
+ * never touches Stripe directly — it calls these by-brand primitives and keeps
+ * the brand daily-budget in sync. The subscription is resolved server-side by
+ * brand metadata (mirrors getCustomerByOrg's org-implicit resolution), so billing
+ * stores NO Stripe subscription id (CLAUDE.md: never duplicate Stripe state).
+ *
+ * Same base + auth as stripe-service-client (STRIPE_SERVICE_URL + X-API-Key).
+ * Fail-loud: every non-2xx throws.
+ *
+ * LOCKED contract (billing ↔ stripe-service), byte-equal both sides:
+ *   POST   /internal/subscriptions/by-brand/:brandId          {orgId,userId,dailyAmountCents}
+ *   PATCH  /internal/subscriptions/by-brand/:brandId          {dailyAmountCents}
+ *   POST   /internal/subscriptions/by-brand/:brandId/pause
+ *   POST   /internal/subscriptions/by-brand/:brandId/resume
+ */
+
+import { fetchWithRetry } from "./fetch-retry.js";
+
+export interface BrandSubscription {
+  subscriptionId: string;
+  status: string;
+  /** The recurring per-day amount in integer cents. Absent on pause responses. */
+  dailyAmountCents?: number;
+  brandId: string;
+}
+
+function getConfig() {
+  const url = process.env.STRIPE_SERVICE_URL;
+  const apiKey = process.env.STRIPE_SERVICE_API_KEY;
+  if (!url || !apiKey) {
+    throw new Error(
+      "STRIPE_SERVICE_URL and STRIPE_SERVICE_API_KEY must be configured"
+    );
+  }
+  return { url, apiKey };
+}
+
+async function call<T>(
+  method: "POST" | "PATCH",
+  path: string,
+  body?: unknown
+): Promise<T> {
+  const { url, apiKey } = getConfig();
+  const res = await fetchWithRetry(`${url}${path}`, {
+    method,
+    headers: { "x-api-key": apiKey, "content-type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(
+      `stripe-service ${method} ${path} failed: ${res.status} ${text}`
+    );
+  }
+  return (await res.json()) as T;
+}
+
+function base(brandId: string): string {
+  return `/internal/subscriptions/by-brand/${encodeURIComponent(brandId)}`;
+}
+
+/** Create the brand's recurring daily subscription. Idempotent server-side. */
+export async function createBrandSubscription(
+  brandId: string,
+  body: { orgId: string; userId: string; dailyAmountCents: number }
+): Promise<BrandSubscription> {
+  return call("POST", base(brandId), body);
+}
+
+/** Update the brand subscription's recurring amount. */
+export async function updateBrandSubscriptionAmount(
+  brandId: string,
+  dailyAmountCents: number
+): Promise<BrandSubscription> {
+  return call("PATCH", base(brandId), { dailyAmountCents });
+}
+
+/** Pause collection on the brand subscription (brand went dry). */
+export async function pauseBrandSubscription(
+  brandId: string
+): Promise<BrandSubscription> {
+  return call("POST", `${base(brandId)}/pause`);
+}
+
+/** Resume collection; the response carries the restored daily amount. */
+export async function resumeBrandSubscription(
+  brandId: string
+): Promise<BrandSubscription> {
+  return call("POST", `${base(brandId)}/resume`);
+}

--- a/src/routes/brand_subscriptions.ts
+++ b/src/routes/brand_subscriptions.ts
@@ -1,0 +1,284 @@
+/**
+ * Per-brand daily subscription wiring.
+ *
+ * billing is the conductor: it tells stripe-service to create / change-amount /
+ * pause / resume the brand's recurring daily subscription, and keeps the brand
+ * daily-budget (brand_daily_budgets) in lock-step — one logical operation per
+ * lifecycle event. It also receives the card-confirmed signal from stripe-service
+ * (Stripe webhook → stripe-service → here) and grants the one-time $25 welcome
+ * gift, deduped across 4 keys.
+ *
+ * Three dials kept in sync per brand:
+ *   1. Stripe subscription amount  (owned by stripe-service; billing calls it)
+ *   2. brand daily-budget ceiling  (billing-owned; 0 = pause)
+ *   3. pause/resume collection state
+ *
+ * The $25 grant fires on card-confirmed (async), NOT at onboarding — a brand can
+ * be onboarded before the card is confirmed.
+ *
+ * Fail-loud throughout: a stripe-service error propagates (502 via the async
+ * error handler); a balance-compose error after a committed grant returns 502.
+ */
+
+import { Router } from "express";
+import { requireOrgHeaders } from "../middleware/auth.js";
+import {
+  SubscriptionAmountRequestSchema,
+  CardConfirmedRequestSchema,
+} from "../schemas.js";
+import { upsertBrandDailyBudget } from "../lib/brand-budgets.js";
+import {
+  createBrandSubscription,
+  updateBrandSubscriptionAmount,
+  pauseBrandSubscription,
+  resumeBrandSubscription,
+} from "../lib/subscription-service-client.js";
+import {
+  grantBrandWelcomeIfEligible,
+  BrandWelcomeCodeMissingError,
+} from "../lib/brand-welcome.js";
+import { computeBalance } from "../lib/balance.js";
+
+const router = Router();
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// POST /v1/brands/:brandId/subscription — onboard a brand at a chosen daily
+// amount. Creates the recurring daily subscription (stripe-service) AND sets the
+// brand daily-budget = the chosen amount. The $25 gift is NOT granted here — it
+// fires on the card-confirmed signal.
+router.post(
+  "/v1/brands/:brandId/subscription",
+  requireOrgHeaders,
+  async (req, res) => {
+    const { brandId } = req.params;
+    if (!UUID_RE.test(brandId)) {
+      res.status(400).json({ error: "brandId must be a valid UUID" });
+      return;
+    }
+    const parsed = SubscriptionAmountRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0].message });
+      return;
+    }
+    const { dailyAmountCents } = parsed.data;
+    const orgId = req.headers["x-org-id"] as string;
+    const userId = req.headers["x-user-id"] as string;
+
+    try {
+      const sub = await createBrandSubscription(brandId, {
+        orgId,
+        userId,
+        dailyAmountCents,
+      });
+      const budget = await upsertBrandDailyBudget(
+        brandId,
+        orgId,
+        String(dailyAmountCents)
+      );
+      console.log(
+        `[billing-service] brand subscription onboarded: brand=${brandId} org=${orgId} amount=${dailyAmountCents} sub=${sub.subscriptionId}`
+      );
+      res.json({
+        brandId,
+        orgId,
+        subscriptionId: sub.subscriptionId,
+        status: sub.status,
+        dailyAmountCents,
+        dailyBudgetCents: budget.dailyBudgetCents,
+      });
+    } catch (err) {
+      console.error("[billing-service] brand subscription onboard failed:", err);
+      res.status(502).json({ error: "Failed to create brand subscription" });
+    }
+  }
+);
+
+// PATCH /v1/brands/:brandId/subscription — change the daily amount. Updates the
+// Stripe subscription amount AND the brand daily-budget together.
+router.patch(
+  "/v1/brands/:brandId/subscription",
+  requireOrgHeaders,
+  async (req, res) => {
+    const { brandId } = req.params;
+    if (!UUID_RE.test(brandId)) {
+      res.status(400).json({ error: "brandId must be a valid UUID" });
+      return;
+    }
+    const parsed = SubscriptionAmountRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0].message });
+      return;
+    }
+    const { dailyAmountCents } = parsed.data;
+    const orgId = req.headers["x-org-id"] as string;
+
+    try {
+      const sub = await updateBrandSubscriptionAmount(brandId, dailyAmountCents);
+      const budget = await upsertBrandDailyBudget(
+        brandId,
+        orgId,
+        String(dailyAmountCents)
+      );
+      console.log(
+        `[billing-service] brand subscription amount changed: brand=${brandId} org=${orgId} amount=${dailyAmountCents}`
+      );
+      res.json({
+        brandId,
+        orgId,
+        subscriptionId: sub.subscriptionId,
+        status: sub.status,
+        dailyAmountCents,
+        dailyBudgetCents: budget.dailyBudgetCents,
+      });
+    } catch (err) {
+      console.error("[billing-service] brand subscription amount change failed:", err);
+      res.status(502).json({ error: "Failed to update brand subscription" });
+    }
+  }
+);
+
+// POST /v1/brands/:brandId/subscription/pause — brand went dry. Pauses Stripe
+// collection AND sets the brand daily-budget to 0 (the existing pause sentinel).
+router.post(
+  "/v1/brands/:brandId/subscription/pause",
+  requireOrgHeaders,
+  async (req, res) => {
+    const { brandId } = req.params;
+    if (!UUID_RE.test(brandId)) {
+      res.status(400).json({ error: "brandId must be a valid UUID" });
+      return;
+    }
+    const orgId = req.headers["x-org-id"] as string;
+
+    try {
+      const sub = await pauseBrandSubscription(brandId);
+      const budget = await upsertBrandDailyBudget(brandId, orgId, "0");
+      console.log(
+        `[billing-service] brand subscription paused: brand=${brandId} org=${orgId}`
+      );
+      res.json({
+        brandId,
+        orgId,
+        status: sub.status,
+        dailyBudgetCents: budget.dailyBudgetCents,
+      });
+    } catch (err) {
+      console.error("[billing-service] brand subscription pause failed:", err);
+      res.status(502).json({ error: "Failed to pause brand subscription" });
+    }
+  }
+);
+
+// POST /v1/brands/:brandId/subscription/resume — reverse the pause. Resumes Stripe
+// collection AND restores the brand daily-budget to the subscription's amount
+// (read back from stripe-service — billing stores no amount of its own).
+router.post(
+  "/v1/brands/:brandId/subscription/resume",
+  requireOrgHeaders,
+  async (req, res) => {
+    const { brandId } = req.params;
+    if (!UUID_RE.test(brandId)) {
+      res.status(400).json({ error: "brandId must be a valid UUID" });
+      return;
+    }
+    const orgId = req.headers["x-org-id"] as string;
+
+    try {
+      const sub = await resumeBrandSubscription(brandId);
+      if (typeof sub.dailyAmountCents !== "number") {
+        throw new Error(
+          `stripe-service resume returned no dailyAmountCents for brand ${brandId}`
+        );
+      }
+      const budget = await upsertBrandDailyBudget(
+        brandId,
+        orgId,
+        String(sub.dailyAmountCents)
+      );
+      console.log(
+        `[billing-service] brand subscription resumed: brand=${brandId} org=${orgId} amount=${sub.dailyAmountCents}`
+      );
+      res.json({
+        brandId,
+        orgId,
+        status: sub.status,
+        dailyAmountCents: sub.dailyAmountCents,
+        dailyBudgetCents: budget.dailyBudgetCents,
+      });
+    } catch (err) {
+      console.error("[billing-service] brand subscription resume failed:", err);
+      res.status(502).json({ error: "Failed to resume brand subscription" });
+    }
+  }
+);
+
+// POST /internal/brands/:brandId/subscription/card-confirmed — stripe-service
+// calls this (Stripe webhook → stripe-service → here) when the subscription's
+// card is added/confirmed. Grants the one-time $25 welcome gift, deduped across
+// org_id / user_id / brand_id / card_fingerprint. Service-auth only (no user
+// context — the user/org come from the body, resolved from subscription metadata
+// by stripe-service).
+router.post(
+  "/internal/brands/:brandId/subscription/card-confirmed",
+  async (req, res) => {
+    const { brandId } = req.params;
+    if (!UUID_RE.test(brandId)) {
+      res.status(400).json({ error: "brandId must be a valid UUID" });
+      return;
+    }
+    const parsed = CardConfirmedRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0].message });
+      return;
+    }
+    const { orgId, userId, cardFingerprint } = parsed.data;
+
+    let result;
+    try {
+      result = await grantBrandWelcomeIfEligible({
+        orgId,
+        userId,
+        brandId,
+        cardFingerprint,
+      });
+    } catch (err) {
+      if (err instanceof BrandWelcomeCodeMissingError) {
+        console.error("[billing-service] card-confirmed seed missing:", err);
+        res.status(500).json({ error: err.message });
+        return;
+      }
+      console.error("[billing-service] card-confirmed grant failed:", err);
+      res.status(500).json({ error: "Failed to grant brand welcome" });
+      return;
+    }
+
+    let newBalanceCents: string;
+    try {
+      const snapshot = await computeBalance(orgId);
+      newBalanceCents = snapshot.balanceCents;
+    } catch (err) {
+      console.error(
+        "[billing-service] card-confirmed compose balance failed:",
+        err
+      );
+      res
+        .status(502)
+        .json({ error: "Grant applied but failed to compose new balance" });
+      return;
+    }
+
+    console.log(
+      `[billing-service] brand welcome card-confirmed: brand=${brandId} org=${orgId} granted=${result.granted} amount=${result.amountCents}`
+    );
+    res.json({
+      ok: true as const,
+      granted: result.granted,
+      amountCents: result.amountCents,
+      newBalanceCents,
+    });
+  }
+);
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -273,6 +273,68 @@ export const ReadBrandDailyBudgetSchema = z
   })
   .openapi("ReadBrandDailyBudget");
 
+// --- Per-brand daily subscription wiring ---
+
+export const SubscriptionAmountRequestSchema = z
+  .object({
+    /** Chosen per-day subscription amount in integer cents (min $1/day). */
+    dailyAmountCents: z.number().int().positive(),
+  })
+  .openapi("SubscriptionAmountRequest");
+
+export const BrandSubscriptionResponseSchema = z
+  .object({
+    brandId: z.string().uuid(),
+    orgId: z.string().uuid(),
+    subscriptionId: z.string(),
+    status: z.string(),
+    dailyAmountCents: z.number().int(),
+    /** Brand daily-budget after the sync (numeric(16,10) string). */
+    dailyBudgetCents: CentsStringSchema,
+  })
+  .openapi("BrandSubscriptionResponse");
+
+export const BrandSubscriptionPauseResponseSchema = z
+  .object({
+    brandId: z.string().uuid(),
+    orgId: z.string().uuid(),
+    status: z.string(),
+    /** "0.0000000000" after pause; the restored amount after resume. */
+    dailyBudgetCents: CentsStringSchema,
+  })
+  .openapi("BrandSubscriptionPauseResponse");
+
+export const BrandSubscriptionResumeResponseSchema = z
+  .object({
+    brandId: z.string().uuid(),
+    orgId: z.string().uuid(),
+    status: z.string(),
+    dailyAmountCents: z.number().int(),
+    dailyBudgetCents: CentsStringSchema,
+  })
+  .openapi("BrandSubscriptionResumeResponse");
+
+export const CardConfirmedRequestSchema = z
+  .object({
+    orgId: z.string().uuid(),
+    userId: z.string().uuid(),
+    /** Stripe card fingerprint — the un-spoofable dedup key. */
+    cardFingerprint: z.string().min(1),
+  })
+  .openapi("CardConfirmedRequest");
+
+export const CardConfirmedResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    /** false when any of the 4 keys (org/user/brand/card) already claimed. */
+    granted: z.boolean(),
+    /** Granted amount as a numeric(16,10) string; "0.0000000000" when suppressed. */
+    amountCents: CentsStringSchema,
+    /** Spendable balance after the grant. */
+    newBalanceCents: CentsStringSchema,
+  })
+  .openapi("CardConfirmedResponse");
+
 // --- Public Stats ---
 
 export const BillingGrowthRowSchema = z
@@ -777,6 +839,172 @@ registry.registerPath({
     },
     400: {
       description: "Invalid brandId or dailyBudgetCents",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+const brandIdParam = z.object({ brandId: z.string().uuid() });
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/brands/{brandId}/subscription",
+  summary: "Onboard a brand at a chosen daily subscription amount",
+  description:
+    "Creates the brand's recurring daily Stripe subscription (via stripe-service) " +
+    "AND sets the brand daily-budget = the chosen amount. The $25 welcome gift is " +
+    "NOT granted here — it fires asynchronously on the card-confirmed signal.",
+  request: {
+    headers: protectedHeaders,
+    params: brandIdParam,
+    body: {
+      content: {
+        "application/json": { schema: SubscriptionAmountRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Subscription created + budget set",
+      content: {
+        "application/json": { schema: BrandSubscriptionResponseSchema },
+      },
+    },
+    400: {
+      description: "Invalid brandId or dailyAmountCents",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "stripe-service unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/v1/brands/{brandId}/subscription",
+  summary: "Change the brand's daily subscription amount",
+  description:
+    "Updates the Stripe subscription amount AND the brand daily-budget together " +
+    "(one logical operation).",
+  request: {
+    headers: protectedHeaders,
+    params: brandIdParam,
+    body: {
+      content: {
+        "application/json": { schema: SubscriptionAmountRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Amount updated + budget synced",
+      content: {
+        "application/json": { schema: BrandSubscriptionResponseSchema },
+      },
+    },
+    400: {
+      description: "Invalid brandId or dailyAmountCents",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "stripe-service unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/brands/{brandId}/subscription/pause",
+  summary: "Pause the brand subscription (brand went dry)",
+  description:
+    "Pauses Stripe collection AND sets the brand daily-budget to 0 (the existing " +
+    "pause sentinel).",
+  request: {
+    headers: protectedHeaders,
+    params: brandIdParam,
+  },
+  responses: {
+    200: {
+      description: "Paused + budget set to 0",
+      content: {
+        "application/json": { schema: BrandSubscriptionPauseResponseSchema },
+      },
+    },
+    400: {
+      description: "Invalid brandId",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "stripe-service unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/brands/{brandId}/subscription/resume",
+  summary: "Resume the brand subscription",
+  description:
+    "Resumes Stripe collection AND restores the brand daily-budget to the " +
+    "subscription's amount (read back from stripe-service).",
+  request: {
+    headers: protectedHeaders,
+    params: brandIdParam,
+  },
+  responses: {
+    200: {
+      description: "Resumed + budget restored",
+      content: {
+        "application/json": { schema: BrandSubscriptionResumeResponseSchema },
+      },
+    },
+    400: {
+      description: "Invalid brandId",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "stripe-service unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/internal/brands/{brandId}/subscription/card-confirmed",
+  summary: "Grant the one-time $25 brand welcome gift (4-key deduped)",
+  description:
+    "Called by stripe-service when the subscription's card is added/confirmed " +
+    "(Stripe webhook → stripe-service → here). Grants $25 once, deduped across " +
+    "org_id / user_id / brand_id / card_fingerprint — a prior claim on ANY key " +
+    "yields granted:false, $0. Service-auth only (orgId/userId in the body, " +
+    "resolved from subscription metadata by stripe-service).",
+  request: {
+    headers: internalHeaders,
+    params: brandIdParam,
+    body: {
+      content: {
+        "application/json": { schema: CardConfirmedRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Grant evaluated (granted true/false)",
+      content: {
+        "application/json": { schema: CardConfirmedResponseSchema },
+      },
+    },
+    400: {
+      description: "Invalid brandId or body",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "Grant applied but balance compose failed",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -11,6 +11,7 @@ import internalRoutes from "../../src/routes/internal.js";
 import creditsRoutes from "../../src/routes/credits.js";
 import promoCodesRoutes from "../../src/routes/promo_codes.js";
 import brandBudgetsRoutes from "../../src/routes/brand_budgets.js";
+import brandSubscriptionsRoutes from "../../src/routes/brand_subscriptions.js";
 import { requireApiKey } from "../../src/middleware/auth.js";
 
 export function createTestApp() {
@@ -26,6 +27,7 @@ export function createTestApp() {
   app.use(creditsRoutes);
   app.use(promoCodesRoutes);
   app.use(brandBudgetsRoutes);
+  app.use(brandSubscriptionsRoutes);
   app.use(accountsRoutes);
   app.use(customerBalanceRoutes);
   app.use(checkoutRoutes);

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -7,9 +7,11 @@ import {
   creditDepletionEpisodes,
   campaignAuthorizeCosts,
   brandDailyBudgets,
+  welcomeCreditClaims,
   WELCOME_PROMO_CODE,
   INVITE_REWARD_CODE,
   INVITE_WELCOME_CODE,
+  BRAND_WELCOME_CODE,
   type CreditDepletionEpisode,
   type CampaignAuthorizeCost,
 } from "../../src/db/schema.js";
@@ -18,12 +20,14 @@ const SEEDED_PROMO_CODES = [
   WELCOME_PROMO_CODE,
   INVITE_REWARD_CODE,
   INVITE_WELCOME_CODE,
+  BRAND_WELCOME_CODE,
 ];
 
 export async function cleanTestData() {
   await db.delete(creditDepletionEpisodes);
   await db.delete(campaignAuthorizeCosts);
   await db.delete(brandDailyBudgets);
+  await db.delete(welcomeCreditClaims);
   await db.delete(localPromos);
   await db.delete(billingAccounts);
   // Keep seeded codes (welcome + invite_reward + invite_welcome); remove any

--- a/tests/integration/brand-subscription.test.ts
+++ b/tests/integration/brand-subscription.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import { cleanTestData, closeDb } from "../helpers/test-db.js";
+import { setupStripeMocks } from "../helpers/mock-stripe.js";
+import { db } from "../../src/db/index.js";
+import {
+  brandDailyBudgets,
+  localPromos,
+  welcomeCreditClaims,
+  localPromoCodes,
+  BRAND_WELCOME_CODE,
+} from "../../src/db/schema.js";
+import * as subClient from "../../src/lib/subscription-service-client.js";
+
+const orgId = "11111111-0000-4000-8000-000000000001";
+const userId = "22222222-0000-4000-8000-000000000001";
+const runId = "00000000-0000-0000-0000-00000000baaa";
+const brandId = "33333333-0000-4000-8000-000000000001";
+
+const apiKeyHeaders = { "X-API-Key": "test-api-key" };
+
+function subPath(id: string) {
+  return `/v1/brands/${id}/subscription`;
+}
+function cardConfirmedPath(id: string) {
+  return `/internal/brands/${id}/subscription/card-confirmed`;
+}
+
+async function readBudget(id: string): Promise<string | null> {
+  const [row] = await db
+    .select()
+    .from(brandDailyBudgets)
+    .where(eq(brandDailyBudgets.brandId, id))
+    .limit(1);
+  return row ? row.dailyBudgetCents : null;
+}
+
+describe("per-brand daily subscription wiring", () => {
+  const app = createTestApp();
+  const authHeaders = getAuthHeaders(orgId, userId, runId);
+
+  let createSpy: ReturnType<typeof vi.fn>;
+  let updateSpy: ReturnType<typeof vi.fn>;
+  let pauseSpy: ReturnType<typeof vi.fn>;
+  let resumeSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    setupStripeMocks();
+    await cleanTestData();
+
+    // runs-client mock — computeBalance reads it on the card-confirmed path.
+    const runsClient = await import("../../src/lib/runs-client.js");
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "0.0000000000",
+      as_of: "2026-06-16T00:00:00.000Z",
+    });
+
+    // subscription-service-client mocks (stripe-service passthrough).
+    createSpy = vi.fn().mockResolvedValue({
+      subscriptionId: "sub_mock",
+      status: "active",
+      dailyAmountCents: 2500,
+      brandId,
+    });
+    updateSpy = vi.fn().mockResolvedValue({
+      subscriptionId: "sub_mock",
+      status: "active",
+      dailyAmountCents: 9900,
+      brandId,
+    });
+    pauseSpy = vi.fn().mockResolvedValue({
+      subscriptionId: "sub_mock",
+      status: "paused",
+      brandId,
+    });
+    resumeSpy = vi.fn().mockResolvedValue({
+      subscriptionId: "sub_mock",
+      status: "active",
+      dailyAmountCents: 2500,
+      brandId,
+    });
+    vi.spyOn(subClient, "createBrandSubscription").mockImplementation(createSpy);
+    vi.spyOn(subClient, "updateBrandSubscriptionAmount").mockImplementation(updateSpy);
+    vi.spyOn(subClient, "pauseBrandSubscription").mockImplementation(pauseSpy);
+    vi.spyOn(subClient, "resumeBrandSubscription").mockImplementation(resumeSpy);
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  // --- Lifecycle: onboard / change / pause / resume ---
+
+  it("onboard at $25/day creates the subscription and sets budget = $25", async () => {
+    const res = await request(app)
+      .post(subPath(brandId))
+      .set(authHeaders)
+      .send({ dailyAmountCents: 2500 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      brandId,
+      orgId,
+      subscriptionId: "sub_mock",
+      status: "active",
+      dailyAmountCents: 2500,
+      dailyBudgetCents: "2500.0000000000",
+    });
+    expect(createSpy).toHaveBeenCalledWith(brandId, {
+      orgId,
+      userId,
+      dailyAmountCents: 2500,
+    });
+    expect(await readBudget(brandId)).toBe("2500.0000000000");
+  });
+
+  it("change amount updates BOTH the subscription and the budget", async () => {
+    await request(app).post(subPath(brandId)).set(authHeaders).send({ dailyAmountCents: 2500 });
+
+    const res = await request(app)
+      .patch(subPath(brandId))
+      .set(authHeaders)
+      .send({ dailyAmountCents: 9900 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.dailyAmountCents).toBe(9900);
+    expect(res.body.dailyBudgetCents).toBe("9900.0000000000");
+    expect(updateSpy).toHaveBeenCalledWith(brandId, 9900);
+    expect(await readBudget(brandId)).toBe("9900.0000000000");
+  });
+
+  it("pause stops collection and sets the budget to 0", async () => {
+    await request(app).post(subPath(brandId)).set(authHeaders).send({ dailyAmountCents: 2500 });
+
+    const res = await request(app)
+      .post(`${subPath(brandId)}/pause`)
+      .set(authHeaders)
+      .send();
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("paused");
+    expect(res.body.dailyBudgetCents).toBe("0.0000000000");
+    expect(pauseSpy).toHaveBeenCalledWith(brandId);
+    expect(await readBudget(brandId)).toBe("0.0000000000");
+  });
+
+  it("resume restores collection and the budget to the subscription amount", async () => {
+    await request(app).post(subPath(brandId)).set(authHeaders).send({ dailyAmountCents: 2500 });
+    await request(app).post(`${subPath(brandId)}/pause`).set(authHeaders).send();
+
+    const res = await request(app)
+      .post(`${subPath(brandId)}/resume`)
+      .set(authHeaders)
+      .send();
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("active");
+    expect(res.body.dailyAmountCents).toBe(2500);
+    expect(res.body.dailyBudgetCents).toBe("2500.0000000000");
+    expect(resumeSpy).toHaveBeenCalledWith(brandId);
+    expect(await readBudget(brandId)).toBe("2500.0000000000");
+  });
+
+  it("propagates a stripe-service failure as 502", async () => {
+    createSpy.mockRejectedValueOnce(new Error("stripe-service down"));
+    const res = await request(app)
+      .post(subPath(brandId))
+      .set(authHeaders)
+      .send({ dailyAmountCents: 2500 });
+    expect(res.status).toBe(502);
+  });
+
+  it("rejects a non-UUID brandId with 400", async () => {
+    const res = await request(app)
+      .post(subPath("not-a-uuid"))
+      .set(authHeaders)
+      .send({ dailyAmountCents: 2500 });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-positive amount with 400", async () => {
+    const res = await request(app)
+      .post(subPath(brandId))
+      .set(authHeaders)
+      .send({ dailyAmountCents: 0 });
+    expect(res.status).toBe(400);
+  });
+
+  it("requires org headers (400 without x-org-id)", async () => {
+    const res = await request(app)
+      .post(subPath(brandId))
+      .set(apiKeyHeaders)
+      .send({ dailyAmountCents: 2500 });
+    expect(res.status).toBe(400);
+  });
+
+  // --- Card-confirmed → one-time $25 grant, 4-key dedup ---
+
+  const card = "fp_card_AAA";
+  function confirm(body: {
+    brandId?: string;
+    orgId?: string;
+    userId?: string;
+    cardFingerprint?: string;
+  }) {
+    const path = cardConfirmedPath(body.brandId ?? brandId);
+    return request(app)
+      .post(path)
+      .set(apiKeyHeaders)
+      .send({
+        orgId: body.orgId ?? orgId,
+        userId: body.userId ?? userId,
+        cardFingerprint: body.cardFingerprint ?? card,
+      });
+  }
+
+  it("first card-confirmed grants $25 and records the claim + credit", async () => {
+    const res = await confirm({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.granted).toBe(true);
+    expect(res.body.amountCents).toBe("2500.0000000000");
+    expect(res.body.newBalanceCents).toBe("2500.0000000000");
+
+    const claims = await db
+      .select()
+      .from(welcomeCreditClaims)
+      .where(eq(welcomeCreditClaims.brandId, brandId));
+    expect(claims).toHaveLength(1);
+    expect(claims[0].cardFingerprint).toBe(card);
+    expect(claims[0].localPromoId).not.toBeNull();
+
+    const [code] = await db
+      .select()
+      .from(localPromoCodes)
+      .where(eq(localPromoCodes.code, BRAND_WELCOME_CODE))
+      .limit(1);
+    const promos = await db
+      .select()
+      .from(localPromos)
+      .where(eq(localPromos.promoCodeId, code.id));
+    expect(promos).toHaveLength(1);
+    expect(promos[0].amountCents).toBe("2500.0000000000");
+  });
+
+  it("a second claim by the same ORG (different brand/user/card) grants $0", async () => {
+    await confirm({});
+    const res = await confirm({
+      brandId: "33333333-0000-4000-8000-0000000000ff",
+      userId: "22222222-0000-4000-8000-0000000000ff",
+      cardFingerprint: "fp_card_OTHER",
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.granted).toBe(false);
+    expect(res.body.amountCents).toBe("0.0000000000");
+  });
+
+  it("a second claim by the same USER grants $0", async () => {
+    await confirm({});
+    const res = await confirm({
+      orgId: "11111111-0000-4000-8000-0000000000ff",
+      brandId: "33333333-0000-4000-8000-0000000000ee",
+      cardFingerprint: "fp_card_USER2",
+    });
+    expect(res.body.granted).toBe(false);
+  });
+
+  it("a second claim for the same BRAND grants $0", async () => {
+    await confirm({});
+    const res = await confirm({
+      orgId: "11111111-0000-4000-8000-0000000000aa",
+      userId: "22222222-0000-4000-8000-0000000000aa",
+      cardFingerprint: "fp_card_BRAND2",
+    });
+    expect(res.body.granted).toBe(false);
+  });
+
+  it("a second claim with the same CARD fingerprint grants $0", async () => {
+    await confirm({});
+    const res = await confirm({
+      orgId: "11111111-0000-4000-8000-0000000000bb",
+      userId: "22222222-0000-4000-8000-0000000000bb",
+      brandId: "33333333-0000-4000-8000-0000000000bb",
+    });
+    expect(res.body.granted).toBe(false);
+    // Only ONE credit row exists across all the suppressed attempts.
+    const [code] = await db
+      .select()
+      .from(localPromoCodes)
+      .where(eq(localPromoCodes.code, BRAND_WELCOME_CODE))
+      .limit(1);
+    const promos = await db
+      .select()
+      .from(localPromos)
+      .where(eq(localPromos.promoCodeId, code.id));
+    expect(promos).toHaveLength(1);
+  });
+
+  it("card-confirmed requires service auth (401 without x-api-key)", async () => {
+    const res = await request(app)
+      .post(cardConfirmedPath(brandId))
+      .send({ orgId, userId, cardFingerprint: card });
+    expect(res.status).toBe(401);
+  });
+
+  it("card-confirmed rejects a non-UUID orgId in the body with 400", async () => {
+    const res = await request(app)
+      .post(cardConfirmedPath(brandId))
+      .set(apiKeyHeaders)
+      .send({ orgId: "nope", userId, cardFingerprint: card });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -129,6 +129,33 @@ beforeAll(async () => {
     ON CONFLICT ("code") DO NOTHING
   `;
 
+  // welcome_credit_claims — 4-key suppression ledger for the per-brand $25 gift
+  // (migration 0023). Each key has its OWN unique index → the grant is a plain
+  // INSERT the DB rejects (23505) when any key was already claimed.
+  await sql`
+    CREATE TABLE IF NOT EXISTS "welcome_credit_claims" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+      "org_id" uuid NOT NULL,
+      "user_id" uuid NOT NULL,
+      "brand_id" uuid NOT NULL,
+      "card_fingerprint" text NOT NULL,
+      "amount_cents" numeric(16,10) NOT NULL,
+      "local_promo_id" uuid,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL
+    )
+  `;
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_welcome_claims_org" ON "welcome_credit_claims" ("org_id")`;
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_welcome_claims_user" ON "welcome_credit_claims" ("user_id")`;
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_welcome_claims_brand" ON "welcome_credit_claims" ("brand_id")`;
+  await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_welcome_claims_card" ON "welcome_credit_claims" ("card_fingerprint")`;
+
+  // Seed the per-brand welcome promo code @2500 (matches migration 0023).
+  await sql`
+    INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")
+    VALUES ('brand_welcome', 2500, NULL, NULL)
+    ON CONFLICT ("code") DO NOTHING
+  `;
+
   // Drop legacy tables that may linger.
   await sql`DROP TABLE IF EXISTS "customer_balance_transactions"`;
   await sql`DROP TABLE IF EXISTS "cbt_archive_pre104_usage"`;


### PR DESCRIPTION
## What
billing-service becomes the **conductor** for per-brand daily subscriptions. A founder onboards a brand at a chosen daily amount; Stripe bills it daily per brand; billing keeps three dials in lock-step and grants a one-time, un-farmable $25 welcome gift.

## Dials kept in sync per brand
1. Stripe subscription amount (owned by stripe-service; billing calls its by-brand passthrough)
2. brand daily-budget ceiling (`brand_daily_budgets`, `0`=pause)
3. pause/resume collection state

## Endpoints
- `POST /v1/brands/:brandId/subscription` — onboard at amount → create sub + set budget
- `PATCH /v1/brands/:brandId/subscription` — change amount → update sub + budget together
- `POST /v1/brands/:brandId/subscription/{pause,resume}` — pause→budget 0; resume→restore from stripe-service
- `POST /internal/brands/:brandId/subscription/card-confirmed` — stripe-service signal → $25 grant (4-key deduped)

## $25 welcome gift — 4-key un-farmable grant
New table `welcome_credit_claims` (migration 0023). Deduped across **org_id, user_id, brand_id, card_fingerprint** — a prior claim on ANY key → `granted:false, $0`. Each key has its OWN unique index → grant is a plain INSERT the DB rejects (23505) when any key was claimed (race-safe). Money is a `local_promos` row under the **new** `brand_welcome` code ($2500) — distinct from the org-level `welcome` $2 code.

## Design notes
- **No billing-stored subscription id/amount** (never duplicate Stripe state) — stripe-service resolves by brand metadata; resume reads amount back.
- **Paid daily invoice → credit is automatic** — settles as a `payment_intent` already summed into `credited`; no invoice receiver (avoids double-count).
- **Per-brand spend gate deferred** — belongs in runs-service (`/internal/brand-usage-total`), not synthesized client-side. Authorize stays org-level.
- Fail-loud 502 on stripe-service errors (explicit try/catch — no global async error middleware in this service).

## ⚠️ Deployment ordering
Cross-repo deps must ship before this is **live** (not a merge blocker — dormant/additive, no consumer calls these paths yet):
- **stripe-service**: by-brand subscription passthrough + Stripe webhooks → the card-confirmed callback + card-fingerprint exposure. (LOCKED contract in `src/lib/subscription-service-client.ts`.) — spawned workspace.
- **runs-service**: per-brand spend (deferred). — follow-up issue.
- **api-service** gateway proxy + **dashboard** onboarding UI — follow-ups.

No new env vars (reuses `STRIPE_SERVICE_*`, `RUNS_SERVICE_*`, `BILLING_SERVICE_API_KEY`).

## Tests
All 201 green (15 new in `tests/integration/brand-subscription.test.ts`: lifecycle onboard/change/pause/resume + 4-key dedup org/user/brand/card + 502 propagation + auth/validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)