### PR TITLE
Add internal org billing teardown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,7 @@ Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed liv
 | `POST` | `/v1/customer_balance/authorize` | check if `balance_cents >= amount` ; auto-reload via PI if configured |
 | `POST` | `/v1/customer_balance/usage_apply` | proactive topup hint after a run; no-op for the ledger |
 | `POST` | `/v1/promotion_codes/redeem` | redeem promo code → insert `local_promos` row |
+| `DELETE` | `/internal/accounts/by-org/:orgId` | client-service org teardown leg. Service-auth only; `:orgId` is the internal org UUID. Deletes billing-owned org rows (`billing_accounts`, `local_promos`, `credit_depletion_episodes`, `campaign_authorize_costs`, `brand_daily_budgets`, `welcome_credit_claims`) in one transaction. Idempotent: no rows → success. No cross-service fan-out. |
 | `POST` | `/internal/credits/grant` | platform-issued grant — body `{orgId, amountCents, reason: invite_reward\|invite_welcome}` → `{ok, newBalanceCents}`. Idempotent on `(orgId, reason)`. `invite_welcome` replaces the existing `$25` welcome row. Used by api-service invite claim handler (DIS-64). |
 | `POST` | `/internal/dunning/tick` | run one out-of-credit dunning pass (ops/manual). Same pass runs on the in-process hourly scheduler. → `{processed, recovered, followup3dSent, followup10dSent}`. |
 | `GET` | `/internal/campaigns/:campaignId/affordability` | READ-ONLY pre-flight gate (campaign-service). → `{affordable, balanceCents, lastRequiredCents, hasHistory}`. ZERO side effects. See "Campaign affordability gate" below. |

--- a/openapi.json
+++ b/openapi.json
@@ -353,6 +353,60 @@
           "code"
         ]
       },
+      "InternalAccountTeardownDeletedRows": {
+        "type": "object",
+        "properties": {
+          "billingAccounts": {
+            "type": "integer"
+          },
+          "localPromos": {
+            "type": "integer"
+          },
+          "creditDepletionEpisodes": {
+            "type": "integer"
+          },
+          "campaignAuthorizeCosts": {
+            "type": "integer"
+          },
+          "brandDailyBudgets": {
+            "type": "integer"
+          },
+          "welcomeCreditClaims": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "billingAccounts",
+          "localPromos",
+          "creditDepletionEpisodes",
+          "campaignAuthorizeCosts",
+          "brandDailyBudgets",
+          "welcomeCreditClaims"
+        ]
+      },
+      "InternalAccountTeardownResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deletedRows": {
+            "$ref": "#/components/schemas/InternalAccountTeardownDeletedRows"
+          }
+        },
+        "required": [
+          "ok",
+          "orgId",
+          "deletedRows"
+        ]
+      },
       "CreditGrantResponse": {
         "type": "object",
         "properties": {
@@ -1794,6 +1848,73 @@
           },
           "409": {
             "description": "Promo code already redeemed by this org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/accounts/by-org/{orgId}": {
+      "delete": {
+        "summary": "Remove billing-owned state for a deleted org",
+        "description": "Client-service cascade teardown leg for an internal org UUID. Removes only billing-service-owned org-scoped rows that can keep active billing effects alive: account topup config, local promo credits, dunning episodes, campaign affordability estimates, brand daily budgets, and welcome-credit claims. No cross-service fan-out. Idempotent: no rows for the org is still success.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "orgId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Billing-owned org state removed; all counts may be zero on retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalAccountTeardownResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "orgId is not a valid UUID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Database operation failed",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -1,7 +1,18 @@
 import { Router } from "express";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { TransferBrandRequestSchema } from "../schemas.js";
+import {
+  InternalAccountTeardownResponseSchema,
+  TransferBrandRequestSchema,
+} from "../schemas.js";
+import {
+  billingAccounts,
+  brandDailyBudgets,
+  campaignAuthorizeCosts,
+  creditDepletionEpisodes,
+  localPromos,
+  welcomeCreditClaims,
+} from "../db/schema.js";
 import {
   listCustomersByMetadata,
   updateCustomer,
@@ -21,6 +32,53 @@ const INTERNAL_IDENTITY: Record<string, string> = {
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type InternalAccountTeardownResponse = typeof InternalAccountTeardownResponseSchema._type;
+
+async function deleteBillingStateByOrg(
+  orgId: string
+): Promise<InternalAccountTeardownResponse["deletedRows"]> {
+  return db.transaction(async (tx) => {
+    const deletedWelcomeClaims = await tx
+      .delete(welcomeCreditClaims)
+      .where(eq(welcomeCreditClaims.orgId, orgId))
+      .returning({ id: welcomeCreditClaims.id });
+
+    const deletedLocalPromos = await tx
+      .delete(localPromos)
+      .where(eq(localPromos.orgId, orgId))
+      .returning({ id: localPromos.id });
+
+    const deletedDunningEpisodes = await tx
+      .delete(creditDepletionEpisodes)
+      .where(eq(creditDepletionEpisodes.orgId, orgId))
+      .returning({ id: creditDepletionEpisodes.id });
+
+    const deletedCampaignCosts = await tx
+      .delete(campaignAuthorizeCosts)
+      .where(eq(campaignAuthorizeCosts.orgId, orgId))
+      .returning({ campaignId: campaignAuthorizeCosts.campaignId });
+
+    const deletedBrandBudgets = await tx
+      .delete(brandDailyBudgets)
+      .where(eq(brandDailyBudgets.orgId, orgId))
+      .returning({ brandId: brandDailyBudgets.brandId });
+
+    const deletedBillingAccounts = await tx
+      .delete(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId))
+      .returning({ id: billingAccounts.id });
+
+    return {
+      billingAccounts: deletedBillingAccounts.length,
+      localPromos: deletedLocalPromos.length,
+      creditDepletionEpisodes: deletedDunningEpisodes.length,
+      campaignAuthorizeCosts: deletedCampaignCosts.length,
+      brandDailyBudgets: deletedBrandBudgets.length,
+      welcomeCreditClaims: deletedWelcomeClaims.length,
+    };
+  });
+}
 
 /**
  * Parse a Stripe customer's `metadata.brand_id` value. We store it as a
@@ -67,6 +125,28 @@ async function listAllOrgCustomers(sourceOrgId: string): Promise<StripeCustomer[
   }
   return out;
 }
+
+// DELETE /internal/accounts/by-org/:orgId — billing-service leg of org teardown.
+//
+// Local-only cleanup: removes billing-owned org rows that can keep active money,
+// pacing, dunning, or affordability effects alive after client-service deletes
+// the org. Stripe customers/subscriptions and runs usage are owned by their
+// services; this endpoint deliberately does not fan out.
+router.delete("/internal/accounts/by-org/:orgId", async (req, res) => {
+  const { orgId } = req.params;
+  if (!UUID_RE.test(orgId)) {
+    res.status(400).json({ error: "orgId must be a valid UUID" });
+    return;
+  }
+
+  try {
+    const deletedRows = await deleteBillingStateByOrg(orgId);
+    res.json({ ok: true, orgId, deletedRows });
+  } catch (err) {
+    console.error(`[billing-service] account teardown failed for org ${orgId}:`, err);
+    res.status(502).json({ error: "Failed to delete billing account state" });
+  }
+});
 
 // POST /internal/transfer-brand — re-assigns solo-brand rows between orgs.
 //

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -174,6 +174,27 @@ export const CreditGrantResponseSchema = z
   })
   .openapi("CreditGrantResponse");
 
+// --- Internal account teardown (client-service org cascade delete) ---
+
+export const InternalAccountTeardownDeletedRowsSchema = z
+  .object({
+    billingAccounts: z.number().int(),
+    localPromos: z.number().int(),
+    creditDepletionEpisodes: z.number().int(),
+    campaignAuthorizeCosts: z.number().int(),
+    brandDailyBudgets: z.number().int(),
+    welcomeCreditClaims: z.number().int(),
+  })
+  .openapi("InternalAccountTeardownDeletedRows");
+
+export const InternalAccountTeardownResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    orgId: z.string().uuid(),
+    deletedRows: InternalAccountTeardownDeletedRowsSchema,
+  })
+  .openapi("InternalAccountTeardownResponse");
+
 // --- Internal Promo-code config (re-price welcome / admin codes, no migration) ---
 
 export const PromoCodeSchema = z
@@ -643,6 +664,42 @@ registry.registerPath({
 
 const internalHeaders = z.object({
   "x-api-key": z.string(),
+});
+
+registry.registerPath({
+  method: "delete",
+  path: "/internal/accounts/by-org/{orgId}",
+  summary: "Remove billing-owned state for a deleted org",
+  description:
+    "Client-service cascade teardown leg for an internal org UUID. Removes only " +
+    "billing-service-owned org-scoped rows that can keep active billing effects " +
+    "alive: account topup config, local promo credits, dunning episodes, campaign " +
+    "affordability estimates, brand daily budgets, and welcome-credit claims. " +
+    "No cross-service fan-out. Idempotent: no rows for the org is still success.",
+  request: {
+    headers: internalHeaders,
+    params: z.object({ orgId: z.string().uuid() }),
+  },
+  responses: {
+    200: {
+      description: "Billing-owned org state removed; all counts may be zero on retry",
+      content: {
+        "application/json": { schema: InternalAccountTeardownResponseSchema },
+      },
+    },
+    400: {
+      description: "orgId is not a valid UUID",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "Database operation failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
 });
 
 registry.registerPath({

--- a/tests/integration/internal-account-teardown.test.ts
+++ b/tests/integration/internal-account-teardown.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { createTestApp } from "../helpers/test-app.js";
+import {
+  cleanTestData,
+  closeDb,
+  insertTestAccount,
+  insertTestCampaignCost,
+  insertTestEpisode,
+  insertTestPromoGrant,
+} from "../helpers/test-db.js";
+import { db } from "../../src/db/index.js";
+import {
+  billingAccounts,
+  brandDailyBudgets,
+  campaignAuthorizeCosts,
+  creditDepletionEpisodes,
+  localPromos,
+  welcomeCreditClaims,
+  WELCOME_PROMO_CODE,
+} from "../../src/db/schema.js";
+
+const targetOrgId = "aaaaaaaa-0000-4000-8000-000000000001";
+const otherOrgId = "bbbbbbbb-0000-4000-8000-000000000001";
+const userId = "cccccccc-0000-4000-8000-000000000001";
+const otherUserId = "dddddddd-0000-4000-8000-000000000001";
+const apiKeyHeaders = { "X-API-Key": "test-api-key" };
+
+function teardownPath(orgId: string) {
+  return `/internal/accounts/by-org/${orgId}`;
+}
+
+async function orgRowCounts(orgId: string) {
+  const [
+    accountRows,
+    promoRows,
+    episodeRows,
+    campaignCostRows,
+    brandBudgetRows,
+    welcomeClaimRows,
+  ] = await Promise.all([
+    db.select().from(billingAccounts).where(eq(billingAccounts.orgId, orgId)),
+    db.select().from(localPromos).where(eq(localPromos.orgId, orgId)),
+    db
+      .select()
+      .from(creditDepletionEpisodes)
+      .where(eq(creditDepletionEpisodes.orgId, orgId)),
+    db
+      .select()
+      .from(campaignAuthorizeCosts)
+      .where(eq(campaignAuthorizeCosts.orgId, orgId)),
+    db.select().from(brandDailyBudgets).where(eq(brandDailyBudgets.orgId, orgId)),
+    db
+      .select()
+      .from(welcomeCreditClaims)
+      .where(eq(welcomeCreditClaims.orgId, orgId)),
+  ]);
+
+  return {
+    billingAccounts: accountRows.length,
+    localPromos: promoRows.length,
+    creditDepletionEpisodes: episodeRows.length,
+    campaignAuthorizeCosts: campaignCostRows.length,
+    brandDailyBudgets: brandBudgetRows.length,
+    welcomeCreditClaims: welcomeClaimRows.length,
+  };
+}
+
+async function seedOrgBillingState(orgId: string, seed: "target" | "other") {
+  const campaignId =
+    seed === "target"
+      ? "aaaaaaaa-0000-4000-8000-00000000c001"
+      : "bbbbbbbb-0000-4000-8000-00000000c001";
+  const brandId =
+    seed === "target"
+      ? "aaaaaaaa-0000-4000-8000-00000000b001"
+      : "bbbbbbbb-0000-4000-8000-00000000b001";
+  const cardFingerprint = seed === "target" ? "fp_teardown_target" : "fp_teardown_other";
+
+  await insertTestAccount({ orgId, topupAmountCents: 5000, topupThresholdCents: 1000 });
+  await insertTestPromoGrant({
+    orgId,
+    userId: seed === "target" ? userId : otherUserId,
+    amountCents: 200,
+    promoCode: WELCOME_PROMO_CODE,
+  });
+  await insertTestEpisode({
+    orgId,
+    userId: seed === "target" ? userId : otherUserId,
+    campaignId,
+  });
+  await insertTestCampaignCost({
+    campaignId,
+    orgId,
+    lastAuthorizeRequiredCents: "42.0000000000",
+  });
+  await db.insert(brandDailyBudgets).values({
+    brandId,
+    orgId,
+    dailyBudgetCents: "2500.0000000000",
+  });
+  await db.insert(welcomeCreditClaims).values({
+    orgId,
+    userId: seed === "target" ? userId : otherUserId,
+    brandId,
+    cardFingerprint,
+    amountCents: "2500.0000000000",
+  });
+}
+
+describe("DELETE /internal/accounts/by-org/:orgId", () => {
+  const app = createTestApp();
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("deletes billing-owned org state and leaves other orgs untouched", async () => {
+    await seedOrgBillingState(targetOrgId, "target");
+    await seedOrgBillingState(otherOrgId, "other");
+
+    const res = await request(app).delete(teardownPath(targetOrgId)).set(apiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      orgId: targetOrgId,
+      deletedRows: {
+        billingAccounts: 1,
+        localPromos: 1,
+        creditDepletionEpisodes: 1,
+        campaignAuthorizeCosts: 1,
+        brandDailyBudgets: 1,
+        welcomeCreditClaims: 1,
+      },
+    });
+    expect(await orgRowCounts(targetOrgId)).toEqual({
+      billingAccounts: 0,
+      localPromos: 0,
+      creditDepletionEpisodes: 0,
+      campaignAuthorizeCosts: 0,
+      brandDailyBudgets: 0,
+      welcomeCreditClaims: 0,
+    });
+    expect(await orgRowCounts(otherOrgId)).toEqual({
+      billingAccounts: 1,
+      localPromos: 1,
+      creditDepletionEpisodes: 1,
+      campaignAuthorizeCosts: 1,
+      brandDailyBudgets: 1,
+      welcomeCreditClaims: 1,
+    });
+  });
+
+  it("is idempotent when no billing rows exist for the org", async () => {
+    const first = await request(app).delete(teardownPath(targetOrgId)).set(apiKeyHeaders);
+    const second = await request(app).delete(teardownPath(targetOrgId)).set(apiKeyHeaders);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.deletedRows).toEqual({
+      billingAccounts: 0,
+      localPromos: 0,
+      creditDepletionEpisodes: 0,
+      campaignAuthorizeCosts: 0,
+      brandDailyBudgets: 0,
+      welcomeCreditClaims: 0,
+    });
+  });
+
+  it("requires service auth", async () => {
+    const res = await request(app).delete(teardownPath(targetOrgId));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a non-UUID orgId", async () => {
+    const res = await request(app).delete(teardownPath("not-a-uuid")).set(apiKeyHeaders);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("fails loud when the DB transaction fails", async () => {
+    vi.spyOn(db, "transaction").mockRejectedValueOnce(new Error("db down") as never);
+
+    const res = await request(app).delete(teardownPath(targetOrgId)).set(apiKeyHeaders);
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe("Failed to delete billing account state");
+  });
+});


### PR DESCRIPTION
## Summary
- Exposes `DELETE /internal/accounts/by-org/:orgId` behind the existing service API-key middleware.
- Deletes billing-service-owned org-scoped state in one DB transaction: account topup config, local promo credits, dunning episodes, campaign affordability estimates, brand daily budgets, and welcome-credit claims.
- Keeps this as one producer leg for org cascade-teardown V1: no cross-service fan-out from billing-service; Stripe/runs-owned state remains owned by those services.
- Regenerates `openapi.json` and updates the local endpoint reference.

## Verification
- `pnpm build`
- `pnpm test tests/integration/internal-account-teardown.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run` (22 files, 206 tests)

## Triage
Hotfix to `main` / prod-direct. Additive internal endpoint; low blast radius.