### PR TITLE
feat: add org wallet setup with first-load match

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ When reconciling or computing real cost: `WHERE rc.status='actual' AND rc.cost_s
 
 ## Local promos (`local_promos` table)
 
-The only persistent ledger billing-service owns. One row per (org, promo_code) — `UNIQUE (org_id, promo_code_id)`. Welcome trial = `code='welcome'` ($2 grant; seeded @$2 by migration 0016, bumped to $25 by 0018, reverted to $2 by 0019). Other codes are admin-managed.
+The only persistent ledger billing-service owns. One row per (org, promo_code) — `UNIQUE (org_id, promo_code_id)`. Welcome trial = `code='welcome'` ($2 grant; seeded @$2 by migration 0016, bumped to $25 by 0018, reverted to $2 by 0019). First paid wallet load match = `code='first_load_match'` (technical code seeded at 0; actual dynamic match amount is stored on the `local_promos` row, dollar-for-dollar capped at $25, once per org). Other codes are admin-managed.
 
 **Re-pricing a promo code at runtime (NO migration):** `PATCH /internal/promo-codes/:code` body `{ amountCents }` updates `local_promo_codes.amount_cents` in place (`GET /internal/promo-codes/:code` reads it). This is the live source read at redeem time, so it changes what NEW signups receive immediately — use this to re-price the welcome gift, not a migration. Service-auth only; the gateway must gate it to staff. Migrations are now only for the SEED DEFAULT (a fresh prod DB) — a `WELCOME_PROMO_AMOUNT_CENTS` change still wants a migration so the default is right on the next deploy, but day-to-day amount tweaks go through the endpoint.
 
@@ -159,9 +159,10 @@ Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed liv
 |---|---|---|
 | `GET` | `/v1/accounts` | account snapshot (credited, usage, balance, topup config) |
 | `GET` | `/v1/accounts/balance` | shortcut: `{ balance_cents, depleted }` |
-| `PATCH` | `/v1/accounts/auto_topup` | configure auto-topup |
+| `PATCH` | `/v1/accounts/auto_topup` | configure auto-topup; body must include both `topup_amount_cents` and `topup_threshold_cents` |
+| `POST` | `/v1/accounts/wallet_setup` | first-campaign wallet setup: requires `initial_load_amount_cents`, `topup_amount_cents`, `topup_threshold_cents`; charges the initial load, stores org auto-topup config, grants `first_load_match` up to $25 once |
 | `DELETE` | `/v1/accounts/auto_topup` | disable auto-topup |
-| `POST` | `/v1/checkout-sessions` | one-shot top-up via Stripe Checkout |
+| `POST` | `/v1/checkout-sessions` | one-shot top-up or setup-mode PM capture via Stripe Checkout; does NOT configure auto-topup |
 | `POST` | `/v1/portal-sessions` | Stripe Customer Portal session |
 | `POST` | `/v1/customer_balance/authorize` | check if `balance_cents >= amount` ; auto-reload via PI if configured |
 | `POST` | `/v1/customer_balance/usage_apply` | proactive topup hint after a run; no-op for the ledger |

--- a/drizzle/0023_first_load_match.sql
+++ b/drizzle/0023_first_load_match.sql
@@ -1,0 +1,6 @@
+-- First-load wallet match.
+-- The promo-code row is a technical ledger key: local_promos stores the actual
+-- dynamic match amount for the org's first paid load, capped in application code.
+INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")
+VALUES ('first_load_match', 0, NULL, NULL)
+ON CONFLICT ("code") DO UPDATE SET "amount_cents" = EXCLUDED."amount_cents";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1790157600000,
       "tag": "0022_brand_daily_budgets",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1790244000000,
+      "tag": "0023_first_load_match",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -171,7 +171,8 @@
           }
         },
         "required": [
-          "topup_amount_cents"
+          "topup_amount_cents",
+          "topup_threshold_cents"
         ]
       },
       "PortalSessionResponse": {
@@ -239,6 +240,68 @@
         "required": [
           "success_url",
           "cancel_url"
+        ]
+      },
+      "WalletSetupResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BillingAccount"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "initial_load_amount_cents": {
+                "type": "integer",
+                "minimum": 0,
+                "exclusiveMinimum": true
+              },
+              "initial_load_payment_intent_id": {
+                "type": "string"
+              },
+              "first_load_match_applied": {
+                "type": "boolean"
+              },
+              "first_load_match_cents": {
+                "type": "string"
+              },
+              "first_load_match_local_promo_id": {
+                "type": "string",
+                "nullable": true,
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "initial_load_amount_cents",
+              "initial_load_payment_intent_id",
+              "first_load_match_applied",
+              "first_load_match_cents",
+              "first_load_match_local_promo_id"
+            ]
+          }
+        ]
+      },
+      "WalletSetupRequest": {
+        "type": "object",
+        "properties": {
+          "initial_load_amount_cents": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "topup_amount_cents": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "topup_threshold_cents": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "initial_load_amount_cents",
+          "topup_amount_cents",
+          "topup_threshold_cents"
         ]
       },
       "AuthorizeResponse": {
@@ -1206,7 +1269,7 @@
     "/v1/checkout-sessions": {
       "post": {
         "summary": "Create Stripe Checkout session via stripe-service",
-        "description": "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. mode='payment' (default) charges topup_amount_cents and persists it as the auto-topup amount. mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written.",
+        "description": "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written.",
         "parameters": [
           {
             "schema": {
@@ -1303,6 +1366,137 @@
           },
           "502": {
             "description": "stripe-service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/accounts/wallet_setup": {
+      "post": {
+        "summary": "Configure mandatory org wallet funding and process the initial load",
+        "description": "First-campaign funding setup. Requires explicit initial_load_amount_cents, topup_amount_cents, and topup_threshold_cents. Charges the initial load via stripe-service, stores org-level auto-topup settings, and grants a first-load local promo match dollar-for-dollar up to $25 exactly once per org.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-user-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-run-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign ID injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)",
+              "example": "uuid1,uuid2,uuid3"
+            },
+            "required": false,
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug injected by workflow-service"
+            },
+            "required": false,
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking"
+            },
+            "required": false,
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WalletSetupRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Wallet setup result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletSetupResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or missing payment method",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Initial load payment failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "stripe-service or runs-service unavailable",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -102,6 +102,8 @@ export const WELCOME_PROMO_AMOUNT_CENTS = 200;
 export const INVITE_REWARD_CODE = "invite_reward";
 export const INVITE_WELCOME_CODE = "invite_welcome";
 export const INVITE_GRANT_AMOUNT_CENTS = 2500;
+export const FIRST_LOAD_MATCH_CODE = "first_load_match";
+export const FIRST_LOAD_MATCH_CAP_CENTS = 2500;
 
 export const PLATFORM_GRANT_REASONS = [
   INVITE_REWARD_CODE,

--- a/src/lib/account.ts
+++ b/src/lib/account.ts
@@ -56,3 +56,51 @@ export async function findOrCreateAccount(
 
   return inserted;
 }
+
+/**
+ * Find or create the org-level billing account for a paid wallet setup.
+ *
+ * This deliberately does NOT redeem the legacy welcome promo. The first-campaign
+ * wallet path has its own first-load match ledger row; stacking the old welcome
+ * row would make a $10 load impact $22 instead of the product contract's $20.
+ */
+export async function findOrCreateWalletAccount(
+  orgId: string,
+  userId: string,
+  wfHeaders: Record<string, string>
+) {
+  const [existing] = await db
+    .select()
+    .from(billingAccounts)
+    .where(eq(billingAccounts.orgId, orgId))
+    .limit(1);
+
+  const account =
+    existing ??
+    (
+      await db
+        .insert(billingAccounts)
+        .values({ orgId })
+        .onConflictDoNothing()
+        .returning()
+    )[0] ??
+    (
+      await db
+        .select()
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId))
+        .limit(1)
+    )[0];
+
+  if (!account) {
+    throw new Error(`failed to create billing account for org ${orgId}`);
+  }
+
+  await ensureCustomer({
+    "x-org-id": orgId,
+    "x-user-id": userId,
+    ...wfHeaders,
+  });
+
+  return account;
+}

--- a/src/lib/promos.ts
+++ b/src/lib/promos.ts
@@ -6,9 +6,12 @@ import {
   localPromos,
   WELCOME_PROMO_CODE,
   INVITE_WELCOME_CODE,
+  FIRST_LOAD_MATCH_CAP_CENTS,
+  FIRST_LOAD_MATCH_CODE,
   PLATFORM_GRANT_REASONS,
   type PlatformGrantReason,
 } from "../db/schema.js";
+import { Decimal } from "decimal.js";
 
 export class PromoNotFoundError extends Error {
   constructor(code: string) {
@@ -186,6 +189,12 @@ export class GrantPromoCodeMissingError extends Error {
   }
 }
 
+export class FirstLoadMatchPromoCodeMissingError extends Error {
+  constructor() {
+    super(`first-load match promo code seed missing: ${FIRST_LOAD_MATCH_CODE}`);
+  }
+}
+
 export interface GrantResult {
   localPromoId: string;
   promoCodeId: string;
@@ -302,3 +311,69 @@ export async function grantCredit(
 
 /** Re-export billing_accounts table for callers that need it alongside promo helpers. */
 export { billingAccounts };
+
+export interface FirstLoadMatchResult {
+  applied: boolean;
+  amountCents: string;
+  localPromoId: string | null;
+}
+
+function formatIntegerCents(amountCents: number): string {
+  return new Decimal(amountCents).toFixed(10);
+}
+
+/**
+ * Grant the org's first-load match: dollar-for-dollar up to $25, exactly once.
+ *
+ * The unique `(org_id, promo_code_id)` index is the hard once-per-org guard. A
+ * repeated paid load returns `applied:false` and a zero newly-granted amount.
+ */
+export async function grantFirstLoadMatch(
+  orgId: string,
+  userId: string,
+  paidLoadAmountCents: number
+): Promise<FirstLoadMatchResult> {
+  const matchAmountCents = Math.min(paidLoadAmountCents, FIRST_LOAD_MATCH_CAP_CENTS);
+
+  const [promo] = await db
+    .select()
+    .from(localPromoCodes)
+    .where(eq(localPromoCodes.code, FIRST_LOAD_MATCH_CODE))
+    .limit(1);
+
+  if (!promo) throw new FirstLoadMatchPromoCodeMissingError();
+
+  const inserted = await db
+    .insert(localPromos)
+    .values({
+      orgId,
+      userId,
+      amountCents: formatIntegerCents(matchAmountCents),
+      promoCodeId: promo.id,
+      description: `First-load match: $${(matchAmountCents / 100).toFixed(2)}`,
+    })
+    .onConflictDoNothing({
+      target: [localPromos.orgId, localPromos.promoCodeId],
+    })
+    .returning();
+
+  if (inserted.length > 0) {
+    return {
+      applied: true,
+      amountCents: formatIntegerCents(matchAmountCents),
+      localPromoId: inserted[0].id,
+    };
+  }
+
+  const [existing] = await db
+    .select({ id: localPromos.id })
+    .from(localPromos)
+    .where(and(eq(localPromos.orgId, orgId), eq(localPromos.promoCodeId, promo.id)))
+    .limit(1);
+
+  return {
+    applied: false,
+    amountCents: formatIntegerCents(0),
+    localPromoId: existing?.id ?? null,
+  };
+}

--- a/src/lib/reload.ts
+++ b/src/lib/reload.ts
@@ -46,7 +46,8 @@ function flattenStatus(pi: StripePaymentIntent): ReloadOutcome {
 export async function reloadViaPaymentIntent(
   identity: IdentityHeaders,
   amountCents: number,
-  idempotencyKey: string
+  idempotencyKey: string,
+  metadata?: Record<string, string>
 ): Promise<ReloadOutcome> {
   const customer = await getCustomerByOrg(identity);
   const cards = await listPaymentMethods(identity, {
@@ -75,6 +76,7 @@ export async function reloadViaPaymentIntent(
       payment_method: pm.id,
       confirm: true,
       off_session: true,
+      metadata,
     },
     idempotencyKey
   );

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -285,7 +285,7 @@ export interface CheckoutLineItem {
 }
 
 export interface CheckoutSessionBody {
-  mode: "payment" | "subscription" | "setup";
+  mode: "payment" | "setup";
   /** Required by Stripe for setup mode when payment_method_types is omitted. */
   currency?: string;
   /** Required for payment mode; omitted for setup mode (no charge). */

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -1,13 +1,15 @@
 import { Router } from "express";
 import { eq } from "drizzle-orm";
+import crypto from "crypto";
 import { db } from "../db/index.js";
 import { billingAccounts } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
-import { UpdateAutoTopupRequestSchema } from "../schemas.js";
-import { findOrCreateAccount } from "../lib/account.js";
+import { UpdateAutoTopupRequestSchema, WalletSetupRequestSchema } from "../schemas.js";
+import { findOrCreateAccount, findOrCreateWalletAccount } from "../lib/account.js";
 import { addCents, isDepleted, subCents } from "../lib/cents.js";
 import { fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
-import { sumLocalPromoCreditsForOrg } from "../lib/promos.js";
+import { grantFirstLoadMatch, sumLocalPromoCreditsForOrg } from "../lib/promos.js";
+import { reloadViaPaymentIntent } from "../lib/reload.js";
 import {
   getCustomerByOrg,
   sumSucceededTopupsForCustomer,
@@ -15,6 +17,8 @@ import {
 } from "../lib/stripe-service-client.js";
 
 const router = Router();
+const INITIAL_LOAD_TIMEOUT_MS = 30_000;
+const INITIAL_LOAD_IDEMPOTENCY_BUCKET_MS = 60_000;
 
 function buildIdentity(
   orgId: string,
@@ -70,10 +74,29 @@ function buildAccountResponse(
     topup_amount_cents: account.topupAmountCents,
     topup_threshold_cents: account.topupThresholdCents,
     has_payment_method: funds.hasPaymentMethod,
-    has_auto_topup: !!(account.topupAmountCents && funds.hasPaymentMethod),
+    has_auto_topup: account.topupAmountCents != null && account.topupThresholdCents != null && funds.hasPaymentMethod,
     created_at: account.createdAt.toISOString(),
     updated_at: account.updatedAt.toISOString(),
   };
+}
+
+function initialLoadIdempotencyKey(orgId: string, amountCents: number): string {
+  const bucket = Math.floor(Date.now() / INITIAL_LOAD_IDEMPOTENCY_BUCKET_MS);
+  return crypto
+    .createHash("sha256")
+    .update(`wallet_setup:${orgId}:${amountCents}:${bucket}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+function withTimeout<T>(ms: number, p: Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`initial load timeout after ${ms}ms`)), ms);
+    p.then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); }
+    );
+  });
 }
 
 router.get("/v1/accounts", requireOrgHeaders, async (req, res) => {
@@ -187,7 +210,7 @@ router.patch("/v1/accounts/auto_topup", requireOrgHeaders, async (req, res) => {
       .update(billingAccounts)
       .set({
         topupAmountCents: topup_amount_cents,
-        topupThresholdCents: topup_threshold_cents ?? 200,
+        topupThresholdCents: topup_threshold_cents,
         updatedAt: new Date(),
       })
       .where(eq(billingAccounts.orgId, orgId))
@@ -205,6 +228,105 @@ router.patch("/v1/accounts/auto_topup", requireOrgHeaders, async (req, res) => {
     res.json(buildAccountResponse(updated, funds));
   } catch (err) {
     console.error("[billing-service] Error updating auto-topup:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.post("/v1/accounts/wallet_setup", requireOrgHeaders, async (req, res) => {
+  try {
+    const orgId = req.headers["x-org-id"] as string;
+    const userId = req.headers["x-user-id"] as string;
+    const runId = req.headers["x-run-id"] as string;
+    const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
+    const identity = buildIdentity(orgId, userId, runId, wfHeaders);
+
+    const parsed = WalletSetupRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.message });
+      return;
+    }
+    const {
+      initial_load_amount_cents,
+      topup_amount_cents,
+      topup_threshold_cents,
+    } = parsed.data;
+
+    await findOrCreateWalletAccount(orgId, userId, wfHeaders);
+
+    let customer;
+    let hasCardPm: boolean;
+    try {
+      customer = await getCustomerByOrg(identity);
+      hasCardPm = await hasAttachedCardPm(identity, customer.id);
+    } catch (err) {
+      console.error("[billing-service] wallet_setup PM check failed:", err);
+      res.status(502).json({ error: "Failed to query payment method status" });
+      return;
+    }
+
+    if (!hasCardPm) {
+      res.status(400).json({
+        error: "Payment method required. Create a setup checkout session first.",
+      });
+      return;
+    }
+
+    let initialLoad;
+    try {
+      initialLoad = await withTimeout(
+        INITIAL_LOAD_TIMEOUT_MS,
+        reloadViaPaymentIntent(
+          identity,
+          initial_load_amount_cents,
+          initialLoadIdempotencyKey(orgId, initial_load_amount_cents),
+          { org_id: orgId, billing_reason: "initial_load" }
+        )
+      );
+    } catch (err) {
+      console.error("[billing-service] wallet_setup initial load failed:", err);
+      res.status(502).json({ error: "Initial load via stripe-service failed" });
+      return;
+    }
+
+    if (initialLoad.status !== "succeeded") {
+      res.status(402).json({
+        error: "Initial load payment failed",
+        failure_reason: initialLoad.failure_reason ?? "payment_intent_not_succeeded",
+      });
+      return;
+    }
+
+    const [updated] = await db
+      .update(billingAccounts)
+      .set({
+        topupAmountCents: topup_amount_cents,
+        topupThresholdCents: topup_threshold_cents,
+        updatedAt: new Date(),
+      })
+      .where(eq(billingAccounts.orgId, orgId))
+      .returning();
+
+    const match = await grantFirstLoadMatch(orgId, userId, initial_load_amount_cents);
+
+    let funds;
+    try {
+      funds = await composeAccountFunds(orgId, identity);
+    } catch (err) {
+      console.error("[billing-service] Failed to compose account funds:", err);
+      res.status(502).json({ error: "Failed to compose account funds" });
+      return;
+    }
+
+    res.json({
+      ...buildAccountResponse(updated, funds),
+      initial_load_amount_cents,
+      initial_load_payment_intent_id: initialLoad.payment_intent_id,
+      first_load_match_applied: match.applied,
+      first_load_match_cents: match.amountCents,
+      first_load_match_local_promo_id: match.localPromoId,
+    });
+  } catch (err) {
+    console.error("[billing-service] Error setting up wallet:", err);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -1,7 +1,4 @@
 import { Router } from "express";
-import { eq } from "drizzle-orm";
-import { db } from "../db/index.js";
-import { billingAccounts } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { CreateCheckoutRequestSchema } from "../schemas.js";
 import { createCheckoutSession, getCustomerByOrg } from "../lib/stripe-service-client.js";
@@ -95,18 +92,6 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
       console.error("[billing-service] stripe-service createCheckoutSession failed:", err);
       res.status(502).json({ error: "Failed to create checkout session via stripe-service" });
       return;
-    }
-
-    // Payment-mode persists the chosen top-up amount as the org's auto-topup amount.
-    // Setup-mode is a pure card capture — it must NOT write any topup amount.
-    if (!isSetup) {
-      await db
-        .update(billingAccounts)
-        .set({
-          topupAmountCents: topup_amount_cents,
-          updatedAt: new Date(),
-        })
-        .where(eq(billingAccounts.orgId, orgId));
     }
 
     traceEvent(runId, { service: "billing-service", event: "checkout.done", data: { session_id: session.session_id } }, req.headers);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -84,9 +84,30 @@ export const UsageApplyResponseSchema = z
 export const UpdateAutoTopupRequestSchema = z
   .object({
     topup_amount_cents: z.number().int().positive(),
-    topup_threshold_cents: z.number().int().min(0).optional(),
+    topup_threshold_cents: z.number().int().min(0),
   })
   .openapi("UpdateAutoTopupRequest");
+
+// --- Wallet setup ---
+
+export const WalletSetupRequestSchema = z
+  .object({
+    /** Paid first load charged immediately via stripe-service PaymentIntent. */
+    initial_load_amount_cents: z.number().int().positive(),
+    /** Ongoing auto-topup reload amount. Required; no silent default. */
+    topup_amount_cents: z.number().int().positive(),
+    /** Ongoing auto-topup trigger threshold. Required; no silent default. */
+    topup_threshold_cents: z.number().int().min(0),
+  })
+  .openapi("WalletSetupRequest");
+
+export const WalletSetupResponseSchema = BillingAccountSchema.extend({
+  initial_load_amount_cents: z.number().int().positive(),
+  initial_load_payment_intent_id: z.string(),
+  first_load_match_applied: z.boolean(),
+  first_load_match_cents: CentsStringSchema,
+  first_load_match_local_promo_id: z.string().uuid().nullable(),
+}).openapi("WalletSetupResponse");
 
 // --- Checkout ---
 
@@ -95,9 +116,9 @@ export const CreateCheckoutRequestSchema = z
     success_url: z.string().url(),
     cancel_url: z.string().url(),
     /**
-     * Checkout flavor. Absent or "payment" → charge `topup_amount_cents` (unchanged
-     * behavior). "setup" → no-charge Stripe Checkout that saves a reusable off-session
-     * card so the org can enable auto-topup without buying credits.
+     * Checkout flavor. Absent or "payment" → one-shot top-up checkout.
+     * "setup" → no-charge Stripe Checkout that saves a reusable off-session card so
+     * the org can enable auto-topup without buying credits.
      */
     mode: z.enum(["payment", "setup"]).optional(),
     /**
@@ -477,7 +498,7 @@ registry.registerPath({
   summary: "Create Stripe Checkout session via stripe-service",
   description:
     "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. " +
-    "mode='payment' (default) charges topup_amount_cents and persists it as the auto-topup amount. " +
+    "mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. " +
     "mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written.",
   request: {
     headers: protectedHeaders,
@@ -494,6 +515,39 @@ registry.registerPath({
     },
     502: {
       description: "stripe-service unavailable",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/v1/accounts/wallet_setup",
+  summary: "Configure mandatory org wallet funding and process the initial load",
+  description:
+    "First-campaign funding setup. Requires explicit initial_load_amount_cents, topup_amount_cents, and topup_threshold_cents. " +
+    "Charges the initial load via stripe-service, stores org-level auto-topup settings, and grants a first-load local promo match dollar-for-dollar up to $25 exactly once per org.",
+  request: {
+    headers: protectedHeaders,
+    body: {
+      content: { "application/json": { schema: WalletSetupRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Wallet setup result",
+      content: { "application/json": { schema: WalletSetupResponseSchema } },
+    },
+    400: {
+      description: "Invalid request or missing payment method",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    402: {
+      description: "Initial load payment failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "stripe-service or runs-service unavailable",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -10,6 +10,7 @@ import {
   WELCOME_PROMO_CODE,
   INVITE_REWARD_CODE,
   INVITE_WELCOME_CODE,
+  FIRST_LOAD_MATCH_CODE,
   type CreditDepletionEpisode,
   type CampaignAuthorizeCost,
 } from "../../src/db/schema.js";
@@ -18,6 +19,7 @@ const SEEDED_PROMO_CODES = [
   WELCOME_PROMO_CODE,
   INVITE_REWARD_CODE,
   INVITE_WELCOME_CODE,
+  FIRST_LOAD_MATCH_CODE,
 ];
 
 export async function cleanTestData() {
@@ -26,11 +28,23 @@ export async function cleanTestData() {
   await db.delete(brandDailyBudgets);
   await db.delete(localPromos);
   await db.delete(billingAccounts);
-  // Keep seeded codes (welcome + invite_reward + invite_welcome); remove any
-  // test-created codes.
+  // Keep seeded codes (welcome + invite_reward + invite_welcome +
+  // first_load_match); remove any test-created codes.
   await db
     .delete(localPromoCodes)
     .where(notInArray(localPromoCodes.code, SEEDED_PROMO_CODES));
+  await db
+    .insert(localPromoCodes)
+    .values({
+      code: FIRST_LOAD_MATCH_CODE,
+      amountCents: 0,
+      maxRedemptions: null,
+      expiresAt: null,
+    })
+    .onConflictDoUpdate({
+      target: localPromoCodes.code,
+      set: { amountCents: 0 },
+    });
 }
 
 /** Insert a depletion episode directly (lets tests back-date started_at). */

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -7,6 +7,9 @@ import {
   customerWithDefaultPM,
   customerWithoutPM,
 } from "../helpers/mock-stripe.js";
+import { db } from "../../src/db/index.js";
+import { localPromoCodes, localPromos, FIRST_LOAD_MATCH_CODE } from "../../src/db/schema.js";
+import { eq } from "drizzle-orm";
 
 describe("Accounts endpoints", () => {
   const app = createTestApp();
@@ -251,18 +254,137 @@ describe("Accounts endpoints", () => {
       const res = await request(app)
         .patch("/v1/accounts/auto_topup")
         .set(getAuthHeaders(orgId))
-        .send({ topup_amount_cents: 5000 });
+        .send({ topup_amount_cents: 5000, topup_threshold_cents: 1000 });
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("Payment method required");
+    });
+
+    it("requires an explicit auto-topup threshold", async () => {
+      await insertTestAccount({ orgId });
+
+      const res = await request(app)
+        .patch("/v1/accounts/auto_topup")
+        .set(getAuthHeaders(orgId))
+        .send({ topup_amount_cents: 5000 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("topup_threshold_cents");
+      expect(ssMocks.getCustomerByOrg).not.toHaveBeenCalled();
     });
 
     it("returns 404 for unknown org", async () => {
       const res = await request(app)
         .patch("/v1/accounts/auto_topup")
         .set(getAuthHeaders("00000000-0000-0000-0000-999999999999"))
-        .send({ topup_amount_cents: 2000 });
+        .send({ topup_amount_cents: 2000, topup_threshold_cents: 100 });
       expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /v1/accounts/wallet_setup", () => {
+    it.each([
+      { orgId: "00000000-0000-0000-0000-000000000101", load: 1000, expectedBonus: "1000.0000000000", expectedBalance: "2000.0000000000" },
+      { orgId: "00000000-0000-0000-0000-000000000102", load: 2500, expectedBonus: "2500.0000000000", expectedBalance: "5000.0000000000" },
+      { orgId: "00000000-0000-0000-0000-000000000103", load: 5000, expectedBonus: "2500.0000000000", expectedBalance: "7500.0000000000" },
+    ])(
+      "charges initial load $load and applies capped first-load match",
+      async ({ orgId, load, expectedBonus, expectedBalance }) => {
+        ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue(`${load}.0000000000`);
+
+        const res = await request(app)
+          .post("/v1/accounts/wallet_setup")
+          .set(getAuthHeaders(orgId, userId))
+          .send({
+            initial_load_amount_cents: load,
+            topup_amount_cents: 3000,
+            topup_threshold_cents: 700,
+          });
+
+        expect(res.status).toBe(200);
+        expect(res.body.topup_amount_cents).toBe(3000);
+        expect(res.body.topup_threshold_cents).toBe(700);
+        expect(res.body.has_auto_topup).toBe(true);
+        expect(res.body.first_load_match_applied).toBe(true);
+        expect(res.body.first_load_match_cents).toBe(expectedBonus);
+        expect(res.body.balance_cents).toBe(expectedBalance);
+        expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledWith(
+          expect.objectContaining({ "x-org-id": orgId }),
+          load,
+          expect.any(String),
+          { org_id: orgId, billing_reason: "initial_load" }
+        );
+      }
+    );
+
+    it("does not apply the first-load match more than once per org", async () => {
+      const paidByCall = ["1000.0000000000", "2000.0000000000"];
+      ssMocks.sumSucceededTopupsForCustomer.mockImplementation(async () => {
+        return paidByCall.shift() ?? "2000.0000000000";
+      });
+
+      const body = {
+        initial_load_amount_cents: 1000,
+        topup_amount_cents: 3000,
+        topup_threshold_cents: 700,
+      };
+
+      const first = await request(app)
+        .post("/v1/accounts/wallet_setup")
+        .set(getAuthHeaders(orgId, userId))
+        .send(body);
+      const second = await request(app)
+        .post("/v1/accounts/wallet_setup")
+        .set(getAuthHeaders(orgId, userId))
+        .send(body);
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(first.body.first_load_match_applied).toBe(true);
+      expect(first.body.first_load_match_cents).toBe("1000.0000000000");
+      expect(second.body.first_load_match_applied).toBe(false);
+      expect(second.body.first_load_match_cents).toBe("0.0000000000");
+      expect(second.body.balance_cents).toBe("3000.0000000000");
+
+      const [matchCode] = await db
+        .select()
+        .from(localPromoCodes)
+        .where(eq(localPromoCodes.code, FIRST_LOAD_MATCH_CODE))
+        .limit(1);
+      const grants = await db
+        .select()
+        .from(localPromos)
+        .where(eq(localPromos.promoCodeId, matchCode.id));
+      expect(grants).toHaveLength(1);
+      expect(grants[0].amountCents).toBe("1000.0000000000");
+    });
+
+    it("requires all wallet setup amounts explicitly", async () => {
+      const res = await request(app)
+        .post("/v1/accounts/wallet_setup")
+        .set(getAuthHeaders(orgId, userId))
+        .send({ initial_load_amount_cents: 1000, topup_amount_cents: 3000 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("topup_threshold_cents");
+      expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    });
+
+    it("rejects wallet setup when no payment method is attached", async () => {
+      ssMocks.hasAttachedCardPm.mockResolvedValue(false);
+
+      const res = await request(app)
+        .post("/v1/accounts/wallet_setup")
+        .set(getAuthHeaders(orgId, userId))
+        .send({
+          initial_load_amount_cents: 1000,
+          topup_amount_cents: 3000,
+          topup_threshold_cents: 700,
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("Payment method required");
+      expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -111,6 +111,27 @@ describe("POST /v1/checkout-sessions", () => {
     expect(ssMocks.ensureCustomer).toHaveBeenCalled();
   });
 
+  it("payment-mode: does NOT write auto-topup config without an explicit threshold", async () => {
+    await insertTestAccount({ orgId });
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        success_url: "https://example.com/success",
+        cancel_url: "https://example.com/cancel",
+        topup_amount_cents: 2000,
+      });
+
+    expect(res.status).toBe(200);
+    const [account] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId));
+    expect(account.topupAmountCents).toBeNull();
+    expect(account.topupThresholdCents).toBe(200);
+  });
+
   it("returns 502 when stripe-service fails", async () => {
     await insertTestAccount({ orgId });
     ssMocks.createCheckoutSession.mockRejectedValue(new Error("SS down"));

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -125,8 +125,9 @@ beforeAll(async () => {
   await sql`
     INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")
     VALUES ('invite_reward', 2500, NULL, NULL),
-           ('invite_welcome', 2500, NULL, NULL)
-    ON CONFLICT ("code") DO NOTHING
+           ('invite_welcome', 2500, NULL, NULL),
+           ('first_load_match', 0, NULL, NULL)
+    ON CONFLICT ("code") DO UPDATE SET "amount_cents" = EXCLUDED."amount_cents"
   `;
 
   // Drop legacy tables that may linger.


### PR DESCRIPTION
## Summary
- Add `POST /v1/accounts/wallet_setup` for first-campaign org wallet setup with explicit initial load, auto-topup amount, and auto-topup threshold.
- Process the initial paid load via the existing org-level topup/payment-intent path and grant `first_load_match` local promo credit dollar-for-dollar up to $25 exactly once per org.
- Keep balance composition as paid Stripe topups + local promos - runs usage; no subscription fields, lifecycle, or Stripe subscription assumptions.
- Make auto-topup threshold explicit in `PATCH /v1/accounts/auto_topup` and stop payment checkout from silently configuring topup state.

## Verification
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm run build`
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm test` (20 files, 194 tests)
- `git diff --check HEAD`
- `rg subscription...` only leaves false-positive “subsequent” text in daily-budget docs/OpenAPI.

## Notes
- This PR targets `staging`. `main` currently has hotfix sync PR #194 open; this branch was recut from `origin/staging` to avoid bundling that prod hotfix drift.