### PR TITLE
Expose actual credit balance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ The same CSV convention applies to the `x-brand-id` header forwarded by workflow
   "credited_cents": "55200.0000000000",      // SUM(succeeded PI.amount_received) + SUM(local_promos.amount_cents)
   "usage_cents": "38289.2958000000",         // runs-service spent_cents (platform actual+provisioned)
   "balance_cents": "16910.7042000000",       // credited_cents − usage_cents; USE THIS for depletion/budget gates
+  "actual_balance_cents": "16920.7042000000", // credited_cents − actualized usage only; display this as the user's credit balance
   "topup_amount_cents": 2500,                // auto-topup amount
   "topup_threshold_cents": 500,              // auto-topup triggers when balance_cents < threshold
   "has_payment_method": true,                // ≥1 chargeable PM: card OR link (GET /v1/payment_methods?type=card, then type=link); NOT invoice_settings.default_payment_method
@@ -124,13 +125,16 @@ The same CSV convention applies to the `x-brand-id` header forwarded by workflow
 
 All three credited/usage/balance endpoints fail loud (502) when runs-service or stripe-service is unreachable.
 
+`balance_cents` and `actual_balance_cents` deliberately differ when the org has open provisioned holds. `balance_cents` is spendable availability and subtracts actualized costs plus provisioned holds so authorization cannot overspend. `actual_balance_cents` subtracts only actualized costs, so the dashboard does not show a hold as money already spent.
+
 Composition (`src/routes/accounts.ts:composeAccountFunds`):
 1. `getCustomerByOrg(identity)` → Stripe customer (for `id`)
 2. `sumSucceededTopupsForCustomer(identity, customer.id)` → paginates `GET /v1/payment_intents?customer=cus_X` and sums `amount_received` where `status='succeeded'`
 3. `sumLocalPromoCreditsForOrg(orgId)` → SUM `local_promos.amount_cents`
 4. `fetchRunsOrgUsageTotal(orgId, identity)` → runs-service `spent_cents`
-5. `hasAttachedCardPm(identity, customer.id)` → `has_payment_method` (≥1 chargeable PM: card or link)
-6. `credited_cents = paid_topups + local_credits` ; `balance_cents = credited_cents − usage`
+5. `fetchRunsOrgActualUsageTotal(orgId, identity)` → runs-service `total_expected_cents` from actualized platform costs only
+6. `hasAttachedCardPm(identity, customer.id)` → `has_payment_method` (≥1 chargeable PM: card or link)
+7. `credited_cents = paid_topups + local_credits`; `balance_cents = credited_cents − usage`; `actual_balance_cents = credited_cents − actualized_usage`
 
 ### `GET /public/stats/billing`
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # billing-service
 Open Source Billing Service
+
+## Credit balance fields
+
+`balance_cents` is spendable availability: credited funds minus actualized usage and provisioned holds. Keep using it for authorization, depletion, runway, and top-up safety checks.
+
+`actual_balance_cents` is the user-facing credit balance: credited funds minus actualized usage only. Provisioned holds are excluded because they may later actualize or cancel.

--- a/openapi.json
+++ b/openapi.json
@@ -91,10 +91,16 @@
             "type": "string"
           },
           "usage_cents": {
-            "type": "string"
+            "type": "string",
+            "description": "Platform usage from runs-service, including actualized costs and provisioned holds. Use with balance_cents for spend authorization."
           },
           "balance_cents": {
-            "type": "string"
+            "type": "string",
+            "description": "Spendable funds: credited_cents minus usage_cents. Includes provisioned holds, so this is the safety value for authorization, depletion, runway, and top-up checks."
+          },
+          "actual_balance_cents": {
+            "type": "string",
+            "description": "User-facing credit balance: credited funds minus actualized platform usage only. Provisioned holds are not subtracted here because they may later actualize or cancel."
           },
           "topup_amount_cents": {
             "type": "integer",
@@ -123,6 +129,7 @@
           "credited_cents",
           "usage_cents",
           "balance_cents",
+          "actual_balance_cents",
           "topup_amount_cents",
           "topup_threshold_cents",
           "has_payment_method",
@@ -146,7 +153,12 @@
         "type": "object",
         "properties": {
           "balance_cents": {
-            "type": "string"
+            "type": "string",
+            "description": "Spendable funds: credited_cents minus usage_cents. Includes provisioned holds, so this is the safety value for authorization, depletion, runway, and top-up checks."
+          },
+          "actual_balance_cents": {
+            "type": "string",
+            "description": "User-facing credit balance: credited funds minus actualized platform usage only. Provisioned holds are not subtracted here because they may later actualize or cancel."
           },
           "depleted": {
             "type": "boolean"
@@ -154,6 +166,7 @@
         },
         "required": [
           "balance_cents",
+          "actual_balance_cents",
           "depleted"
         ]
       },

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -8,6 +8,18 @@ export interface RunsOrgUsageTotalResult {
   as_of: string;
 }
 
+interface RunsExpectedTotalsResponse {
+  total_expected_cents: string;
+  runs: Array<{
+    run_id: string;
+    expected_cents: string;
+  }>;
+}
+
+export interface RunsOrgActualUsageTotalResult {
+  spent_cents: string;
+}
+
 function getRunsServiceConfig() {
   const url = process.env.RUNS_SERVICE_URL;
   const apiKey = process.env.RUNS_SERVICE_API_KEY;
@@ -49,4 +61,41 @@ export async function fetchRunsOrgUsageTotal(
   }
 
   return (await res.json()) as RunsOrgUsageTotalResult;
+}
+
+/**
+ * Fetch canonical actual-only org usage from runs-service.
+ *
+ * This excludes provisioned holds, so consumers can display money that has
+ * actually been spent without changing `fetchRunsOrgUsageTotal`, which remains
+ * the source for authorization/depletion availability.
+ */
+export async function fetchRunsOrgActualUsageTotal(
+  orgId: string,
+  wfHeaders: Record<string, string>
+): Promise<RunsOrgActualUsageTotalResult> {
+  const config = getRunsServiceConfig();
+  if (!config) {
+    throw new Error("RUNS_SERVICE_URL and RUNS_SERVICE_API_KEY must be configured");
+  }
+
+  const res = await fetchWithRetry(
+    `${config.url}/internal/runs-expected-totals?org_id=${encodeURIComponent(orgId)}`,
+    {
+      headers: {
+        "x-api-key": config.apiKey,
+        ...wfHeaders,
+      },
+    }
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `runs-service runs-expected-totals failed for org ${orgId}: ${res.status} ${body}`
+    );
+  }
+
+  const body = (await res.json()) as RunsExpectedTotalsResponse;
+  return { spent_cents: body.total_expected_cents };
 }

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -7,7 +7,7 @@ import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from ".
 import { UpdateAutoTopupRequestSchema, WalletSetupRequestSchema } from "../schemas.js";
 import { findOrCreateAccount, findOrCreateWalletAccount } from "../lib/account.js";
 import { addCents, isDepleted, subCents } from "../lib/cents.js";
-import { fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
+import { fetchRunsOrgActualUsageTotal, fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
 import { grantFirstLoadMatch, sumLocalPromoCreditsForOrg } from "../lib/promos.js";
 import { reloadViaPaymentIntent } from "../lib/reload.js";
 import {
@@ -42,28 +42,38 @@ async function composeAccountFunds(
   creditedCents: string;
   usageCents: string;
   balanceCents: string;
+  actualBalanceCents: string;
   hasPaymentMethod: boolean;
 }> {
   const customer = await getCustomerByOrg(identity);
-  const [paidTopups, localCredits, runsUsage, hasCardPm] = await Promise.all([
+  const [paidTopups, localCredits, runsUsage, actualRunsUsage, hasCardPm] = await Promise.all([
     sumSucceededTopupsForCustomer(identity, customer.id),
     sumLocalPromoCreditsForOrg(orgId),
     fetchRunsOrgUsageTotal(orgId, identity),
+    fetchRunsOrgActualUsageTotal(orgId, identity),
     hasAttachedCardPm(identity, customer.id),
   ]);
   const creditedCents = addCents(paidTopups, localCredits);
   const balanceCents = subCents(creditedCents, runsUsage.spent_cents);
+  const actualBalanceCents = subCents(creditedCents, actualRunsUsage.spent_cents);
   return {
     creditedCents,
     usageCents: runsUsage.spent_cents,
     balanceCents,
+    actualBalanceCents,
     hasPaymentMethod: hasCardPm,
   };
 }
 
 function buildAccountResponse(
   account: typeof billingAccounts.$inferSelect,
-  funds: { creditedCents: string; usageCents: string; balanceCents: string; hasPaymentMethod: boolean }
+  funds: {
+    creditedCents: string;
+    usageCents: string;
+    balanceCents: string;
+    actualBalanceCents: string;
+    hasPaymentMethod: boolean;
+  }
 ) {
   return {
     id: account.id,
@@ -71,6 +81,7 @@ function buildAccountResponse(
     credited_cents: funds.creditedCents,
     usage_cents: funds.usageCents,
     balance_cents: funds.balanceCents,
+    actual_balance_cents: funds.actualBalanceCents,
     topup_amount_cents: account.topupAmountCents,
     topup_threshold_cents: account.topupThresholdCents,
     has_payment_method: funds.hasPaymentMethod,
@@ -155,6 +166,7 @@ router.get("/v1/accounts/balance", requireOrgHeaders, async (req, res) => {
 
     res.json({
       balance_cents: funds.balanceCents,
+      actual_balance_cents: funds.actualBalanceCents,
       depleted: isDepleted(funds.balanceCents),
     });
   } catch (err) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -18,6 +18,18 @@ export const ErrorResponseSchema = z
  * Drizzle returns numeric columns as strings — we pass them through unchanged.
  */
 const CentsStringSchema = z.string();
+const UsageCentsSchema = CentsStringSchema.openapi({
+  description:
+    "Platform usage from runs-service, including actualized costs and provisioned holds. Use with balance_cents for spend authorization.",
+});
+const SpendableBalanceCentsSchema = CentsStringSchema.openapi({
+  description:
+    "Spendable funds: credited_cents minus usage_cents. Includes provisioned holds, so this is the safety value for authorization, depletion, runway, and top-up checks.",
+});
+const ActualBalanceCentsSchema = CentsStringSchema.openapi({
+  description:
+    "User-facing credit balance: credited funds minus actualized platform usage only. Provisioned holds are not subtracted here because they may later actualize or cancel.",
+});
 
 // --- Account ---
 
@@ -28,9 +40,11 @@ export const BillingAccountSchema = z
     /** Lifetime credits added: stripe-service paid topups + sum(local_promos). */
     credited_cents: CentsStringSchema,
     /** Lifetime platform usage from runs-service /internal/org-usage-total. */
-    usage_cents: CentsStringSchema,
+    usage_cents: UsageCentsSchema,
     /** Spendable funds = credited_cents − usage_cents. Use this for depletion/budget gates. */
-    balance_cents: CentsStringSchema,
+    balance_cents: SpendableBalanceCentsSchema,
+    /** User-facing balance = credited_cents − actualized usage only. */
+    actual_balance_cents: ActualBalanceCentsSchema,
     topup_amount_cents: z.number().int().nullable(),
     topup_threshold_cents: z.number().int().nullable(),
     has_payment_method: z.boolean(),
@@ -154,7 +168,8 @@ export const PortalSessionResponseSchema = z
 
 export const BalanceResponseSchema = z
   .object({
-    balance_cents: CentsStringSchema,
+    balance_cents: SpendableBalanceCentsSchema,
+    actual_balance_cents: ActualBalanceCentsSchema,
     depleted: z.boolean(),
   })
   .openapi("BalanceResponse");

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -17,6 +17,7 @@ describe("Accounts endpoints", () => {
   const userId = "00000000-0000-0000-0000-000000000099";
   let ssMocks: ReturnType<typeof setupStripeMocks>;
   let fetchRunsOrgUsageTotalSpy: ReturnType<typeof vi.fn>;
+  let fetchRunsOrgActualUsageTotalSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -31,6 +32,12 @@ describe("Accounts endpoints", () => {
     });
     vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(
       fetchRunsOrgUsageTotalSpy
+    );
+    fetchRunsOrgActualUsageTotalSpy = vi.fn().mockResolvedValue({
+      spent_cents: "0.0000000000",
+    });
+    vi.spyOn(runsClient, "fetchRunsOrgActualUsageTotal").mockImplementation(
+      fetchRunsOrgActualUsageTotalSpy
     );
   });
 
@@ -53,6 +60,7 @@ describe("Accounts endpoints", () => {
       expect(res.body.credited_cents).toBe("200.0000000000");
       expect(res.body.usage_cents).toBe("0.0000000000");
       expect(res.body.balance_cents).toBe("200.0000000000");
+      expect(res.body.actual_balance_cents).toBe("200.0000000000");
       expect(res.body.has_payment_method).toBe(false);
       expect(res.body.has_auto_topup).toBe(false);
       expect(ssMocks.ensureCustomer).toHaveBeenCalled();
@@ -76,6 +84,30 @@ describe("Accounts endpoints", () => {
       expect(res.body.credited_cents).toBe("1000.0000000000");
       expect(res.body.usage_cents).toBe("75.0000000000");
       expect(res.body.balance_cents).toBe("925.0000000000");
+      expect(res.body.actual_balance_cents).toBe("1000.0000000000");
+    });
+
+    it("keeps spendable balance reduced by holds but actual balance actual-only", async () => {
+      await insertTestAccount({ orgId });
+      ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("3000.0000000000");
+      fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+        org_id: orgId,
+        spent_cents: "105.0000000000",
+        as_of: "2026-05-13T00:00:00.000Z",
+      });
+      fetchRunsOrgActualUsageTotalSpy.mockResolvedValue({
+        spent_cents: "95.0000000000",
+      });
+
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set(getAuthHeaders(orgId));
+
+      expect(res.status).toBe(200);
+      expect(res.body.credited_cents).toBe("3000.0000000000");
+      expect(res.body.usage_cents).toBe("105.0000000000");
+      expect(res.body.balance_cents).toBe("2895.0000000000");
+      expect(res.body.actual_balance_cents).toBe("2905.0000000000");
     });
 
     it("returns negative balance_cents when usage > credited", async () => {
@@ -93,6 +125,7 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.balance_cents).toBe("-308.0000000000");
+      expect(res.body.actual_balance_cents).toBe("75.0000000000");
     });
 
     it("derives has_payment_method from attached card PMs (ignores default_payment_method)", async () => {
@@ -127,11 +160,23 @@ describe("Accounts endpoints", () => {
       // 55000 paid + 0 local − 38289.2958 usage = 16710.7042 spendable
       expect(res.body.credited_cents).toBe("55000.0000000000");
       expect(res.body.balance_cents).toBe("16710.7042000000");
+      expect(res.body.actual_balance_cents).toBe("55000.0000000000");
     });
 
     it("returns 502 when runs-service unavailable", async () => {
       await insertTestAccount({ orgId });
       fetchRunsOrgUsageTotalSpy.mockRejectedValue(new Error("runs-service down"));
+
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set(getAuthHeaders(orgId));
+
+      expect(res.status).toBe(502);
+    });
+
+    it("returns 502 when actual-only runs usage is unavailable", async () => {
+      await insertTestAccount({ orgId });
+      fetchRunsOrgActualUsageTotalSpy.mockRejectedValue(new Error("runs-service actual down"));
 
       const res = await request(app)
         .get("/v1/accounts")
@@ -207,6 +252,7 @@ describe("Accounts endpoints", () => {
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
         balance_cents: "125.0000000000",
+        actual_balance_cents: "150.0000000000",
         depleted: false,
       });
     });

--- a/tests/integration/credits-grant.test.ts
+++ b/tests/integration/credits-grant.test.ts
@@ -25,6 +25,7 @@ describe("POST /internal/credits/grant", () => {
   const systemUserId = "00000000-0000-0000-0000-000000000000";
   let ssMocks: ReturnType<typeof setupStripeMocks>;
   let fetchRunsOrgUsageTotalSpy: ReturnType<typeof vi.fn>;
+  let fetchRunsOrgActualUsageTotalSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -39,6 +40,12 @@ describe("POST /internal/credits/grant", () => {
     });
     vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(
       fetchRunsOrgUsageTotalSpy
+    );
+    fetchRunsOrgActualUsageTotalSpy = vi.fn().mockResolvedValue({
+      spent_cents: "0.0000000000",
+    });
+    vi.spyOn(runsClient, "fetchRunsOrgActualUsageTotal").mockImplementation(
+      fetchRunsOrgActualUsageTotalSpy
     );
   });
 

--- a/tests/integration/promo-codes.test.ts
+++ b/tests/integration/promo-codes.test.ts
@@ -44,6 +44,9 @@ describe("GET/PATCH /internal/promo-codes/:code", () => {
       spent_cents: "0.0000000000",
       as_of: "2026-06-12T00:00:00.000Z",
     });
+    vi.spyOn(runsClient, "fetchRunsOrgActualUsageTotal").mockResolvedValue({
+      spent_cents: "0.0000000000",
+    });
     await cleanTestData();
     // cleanTestData keeps promo-code rows as-is; these tests mutate the welcome
     // amount, so restore the seed value for deterministic, order-independent runs.


### PR DESCRIPTION
## Summary
- add actual_balance_cents to account and balance responses for display-only credit balance
- keep balance_cents as the conservative actual+provisioned value for authorization/depletion/top-up safety
- source actual-only usage from runs-service /internal/runs-expected-totals, which registry confirms sums platform costs with status=actual only
- update OpenAPI/docs and account-related tests

## Verification
- COREPACK_ENABLE_AUTO_PIN=0 pnpm build
- COREPACK_ENABLE_AUTO_PIN=0 pnpm vitest run tests/integration/accounts.test.ts tests/integration/authorize-runs-total.test.ts tests/integration/authorize-campaign-cost.test.ts tests/integration/dunning.test.ts
- COREPACK_ENABLE_AUTO_PIN=0 pnpm vitest run tests/integration/credits-grant.test.ts tests/integration/promo-codes.test.ts tests/integration/brand-daily-budget.test.ts
- COREPACK_ENABLE_AUTO_PIN=0 pnpm test

Dashboard consumer: shamanic-technologies/distribute.you#1832.