### PR TITLE
feat: propagate x-audience-id on internal tracking headers

### DIFF
--- a/src/lib/trace-event.ts
+++ b/src/lib/trace-event.ts
@@ -27,6 +27,7 @@ export async function traceEvent(
         ...(headers["x-campaign-id"] ? { "x-campaign-id": headers["x-campaign-id"] as string } : {}),
         ...(headers["x-workflow-slug"] ? { "x-workflow-slug": headers["x-workflow-slug"] as string } : {}),
         ...(headers["x-feature-slug"] ? { "x-feature-slug": headers["x-feature-slug"] as string } : {}),
+        ...(headers["x-audience-id"] ? { "x-audience-id": headers["x-audience-id"] as string } : {}),
       },
       body: JSON.stringify(payload),
     });

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -5,6 +5,7 @@ export interface WorkflowHeaders {
   brandIds?: string[];
   workflowSlug?: string;
   featureSlug?: string;
+  audienceId?: string;
 }
 
 /** Parse the x-brand-id header as a comma-separated list of UUIDs. */
@@ -21,6 +22,7 @@ export function getWorkflowHeaders(req: Request): WorkflowHeaders {
     brandIds: parseBrandIds(req.headers["x-brand-id"] as string | undefined),
     workflowSlug: req.headers["x-workflow-slug"] as string | undefined,
     featureSlug: req.headers["x-feature-slug"] as string | undefined,
+    audienceId: req.headers["x-audience-id"] as string | undefined,
   };
 }
 
@@ -31,6 +33,7 @@ export function forwardWorkflowHeaders(wf: WorkflowHeaders): Record<string, stri
   if (wf.brandIds && wf.brandIds.length > 0) headers["x-brand-id"] = wf.brandIds.join(",");
   if (wf.workflowSlug) headers["x-workflow-slug"] = wf.workflowSlug;
   if (wf.featureSlug) headers["x-feature-slug"] = wf.featureSlug;
+  if (wf.audienceId) headers["x-audience-id"] = wf.audienceId;
   return headers;
 }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -372,6 +372,7 @@ const protectedHeaders = z.object({
   "x-brand-id": z.string().optional().openapi({ description: "Brand ID(s) injected by workflow-service (comma-separated UUIDs for multi-brand campaigns)", example: "uuid1,uuid2,uuid3" }),
   "x-workflow-slug": z.string().optional().openapi({ description: "Workflow slug injected by workflow-service" }),
   "x-feature-slug": z.string().optional().openapi({ description: "Feature slug for tracking" }),
+  "x-audience-id": z.string().optional().openapi({ description: "Audience ID injected by campaign-service for per-audience cost attribution" }),
 });
 
 registry.registerPath({

--- a/tests/unit/trace-event.test.ts
+++ b/tests/unit/trace-event.test.ts
@@ -52,6 +52,7 @@ describe("traceEvent", () => {
         "x-campaign-id": "camp-1",
         "x-workflow-slug": "wf-slug",
         "x-feature-slug": "feat-slug",
+        "x-audience-id": "aud-1",
       }
     );
 
@@ -63,6 +64,7 @@ describe("traceEvent", () => {
     expect(headers["x-campaign-id"]).toBe("camp-1");
     expect(headers["x-workflow-slug"]).toBe("wf-slug");
     expect(headers["x-feature-slug"]).toBe("feat-slug");
+    expect(headers["x-audience-id"]).toBe("aud-1");
   });
 
   it("omits undefined identity headers", async () => {
@@ -78,6 +80,7 @@ describe("traceEvent", () => {
     expect(headers["x-org-id"]).toBe("org-1");
     expect(headers).not.toHaveProperty("x-user-id");
     expect(headers).not.toHaveProperty("x-brand-id");
+    expect(headers).not.toHaveProperty("x-audience-id");
   });
 
   it("skips silently when RUNS_SERVICE_URL is not set", async () => {

--- a/tests/unit/workflow-headers.test.ts
+++ b/tests/unit/workflow-headers.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import type { Request } from "express";
+import { getWorkflowHeaders, forwardWorkflowHeaders } from "../../src/middleware/auth.js";
+
+function reqWith(headers: Record<string, string>): Request {
+  return { headers } as unknown as Request;
+}
+
+describe("workflow tracking headers (audience attribution)", () => {
+  it("reads x-audience-id inbound alongside the other tracking headers", () => {
+    const wf = getWorkflowHeaders(
+      reqWith({
+        "x-campaign-id": "camp-1",
+        "x-brand-id": "brand-1,brand-2",
+        "x-workflow-slug": "wf-slug",
+        "x-feature-slug": "feat-slug",
+        "x-audience-id": "aud-1",
+      })
+    );
+
+    expect(wf.campaignId).toBe("camp-1");
+    expect(wf.brandIds).toEqual(["brand-1", "brand-2"]);
+    expect(wf.workflowSlug).toBe("wf-slug");
+    expect(wf.featureSlug).toBe("feat-slug");
+    expect(wf.audienceId).toBe("aud-1");
+  });
+
+  it("forwards x-audience-id on the downstream tracking block", () => {
+    const forwarded = forwardWorkflowHeaders({
+      campaignId: "camp-1",
+      brandIds: ["brand-1"],
+      workflowSlug: "wf-slug",
+      featureSlug: "feat-slug",
+      audienceId: "aud-1",
+    });
+
+    expect(forwarded["x-audience-id"]).toBe("aud-1");
+    // full block forwarded, not cherry-picked
+    expect(forwarded["x-campaign-id"]).toBe("camp-1");
+    expect(forwarded["x-brand-id"]).toBe("brand-1");
+    expect(forwarded["x-workflow-slug"]).toBe("wf-slug");
+    expect(forwarded["x-feature-slug"]).toBe("feat-slug");
+  });
+
+  it("inbound x-audience-id round-trips to the egress tracking block", () => {
+    const forwarded = forwardWorkflowHeaders(
+      getWorkflowHeaders(reqWith({ "x-audience-id": "aud-9" }))
+    );
+    expect(forwarded["x-audience-id"]).toBe("aud-9");
+  });
+
+  it("omits x-audience-id when absent (non-campaign flows), never throws", () => {
+    const forwarded = forwardWorkflowHeaders(getWorkflowHeaders(reqWith({})));
+    expect(forwarded).not.toHaveProperty("x-audience-id");
+  });
+});


### PR DESCRIPTION
## What
Add `x-audience-id` to billing-service's internal tracking-header allowlist so it propagates on every internal-service call.

## Why
Fleet-wide per-audience cost attribution. billing-service **declares no runs-service costs and creates no run/cost rows** → brief points 3 (tag cost declaration) & 4 (tag own run/cost rows) are **N/A** here. billing's only gap: its centralized forward builder (`forwardWorkflowHeaders`) already propagated `x-campaign-id / x-brand-id / x-workflow-slug / x-feature-slug` to every internal call (runs read, stripe, email, trace) but **dropped `x-audience-id`**. This makes billing the link that loses the header.

## Changes
- `src/middleware/auth.ts` — read `x-audience-id` in `getWorkflowHeaders`; forward in `forwardWorkflowHeaders` allowlist (auto-propagates to all internal clients via the `wfHeaders` spread).
- `src/lib/trace-event.ts` — include `x-audience-id` in trace egress headers (only non-builder forward spot).
- `src/schemas.ts` — declare `x-audience-id` optional in `protectedHeaders`.
- `tests/unit/workflow-headers.test.ts` (new) + `trace-event.test.ts` — regression: inbound `x-audience-id` round-trips to internal egress + omitted when absent.

## Guardrail
Optional header — absent outside campaign flows → omitted, never throws. billing makes **zero direct vendor calls** (only internal services), so the egress-strip requirement is satisfied structurally; the allowlist is scoped to internal services only.

## Tests
`pnpm test` → 209 passed (22 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)