### PR TITLE
feat(checkout): Stripe Embedded Checkout for in-app modal credit top-up

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -217,18 +217,26 @@
           "url": {
             "type": "string"
           },
+          "client_secret": {
+            "type": "string"
+          },
           "session_id": {
             "type": "string"
           }
         },
         "required": [
-          "url",
           "session_id"
         ]
       },
       "CreateCheckoutRequest": {
         "type": "object",
         "properties": {
+          "ui_mode": {
+            "type": "string",
+            "enum": [
+              "embedded"
+            ]
+          },
           "success_url": {
             "type": "string",
             "format": "uri"
@@ -249,11 +257,7 @@
             "minimum": 0,
             "exclusiveMinimum": true
           }
-        },
-        "required": [
-          "success_url",
-          "cancel_url"
-        ]
+        }
       },
       "WalletSetupResponse": {
         "allOf": [
@@ -1471,7 +1475,7 @@
     "/v1/checkout-sessions": {
       "post": {
         "summary": "Create Stripe Checkout session via stripe-service",
-        "description": "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written.",
+        "description": "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. HOSTED (default, no ui_mode): requires success_url + cancel_url and returns a redirect `url`. mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written. EMBEDDED (ui_mode='embedded'): Stripe Embedded Checkout for an in-app modal — no success_url/cancel_url, returns a `client_secret` the front-end mounts in an iframe; always charges topup_amount_cents (payment-only). Credit + first-load match land via the existing checkout.session.completed webhook in all modes.",
         "parameters": [
           {
             "schema": {

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -80,7 +80,10 @@ export interface CustomerEnsureResult {
 }
 
 export interface CheckoutSessionResult {
-  url: string;
+  /** Present for hosted (redirect) sessions; absent for embedded. */
+  url?: string;
+  /** Present for embedded (ui_mode:"embedded") sessions; absent for hosted. */
+  client_secret?: string;
   session_id: string;
 }
 
@@ -286,12 +289,24 @@ export interface CheckoutLineItem {
 
 export interface CheckoutSessionBody {
   mode: "payment" | "setup";
+  /**
+   * "embedded" → Stripe Embedded Checkout (in-app modal iframe). Omitted → hosted
+   * (redirect) checkout. stripe-service returns a `client_secret` for embedded sessions.
+   */
+  ui_mode?: "embedded";
+  /**
+   * Embedded-mode completion behavior. "never" → Stripe does NOT redirect after the
+   * payment completes (the modal stays in-app); required by Stripe when ui_mode is
+   * "embedded" and no success_url is supplied.
+   */
+  redirect_on_completion?: "never";
   /** Required by Stripe for setup mode when payment_method_types is omitted. */
   currency?: string;
   /** Required for payment mode; omitted for setup mode (no charge). */
   line_items?: CheckoutLineItem[];
-  success_url: string;
-  cancel_url: string;
+  /** Required for hosted checkout; omitted for embedded (redirect_on_completion:"never"). */
+  success_url?: string;
+  cancel_url?: string;
   customer: string;
   metadata: Record<string, string>;
   /** Payment-mode charge config; omitted for setup mode (no PaymentIntent created). */

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -25,16 +25,19 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
       return;
     }
     const { success_url, cancel_url, topup_amount_cents } = parsed.data;
-    const isSetup = parsed.data.mode === "setup";
+    const isEmbedded = parsed.data.ui_mode === "embedded";
+    // Embedded is payment-only (always charges topup_amount_cents); hosted "setup" is
+    // a no-charge card capture. Embedded therefore never takes the setup branch.
+    const isSetup = !isEmbedded && parsed.data.mode === "setup";
 
-    // Payment-mode (absent mode or "payment") requires an explicit amount. Fail loud
-    // rather than defaulting — a payment checkout with no amount is a malformed request.
+    // Payment-mode (absent mode or "payment") AND embedded mode require an explicit
+    // amount. Fail loud rather than defaulting — a charge with no amount is malformed.
     if (!isSetup && topup_amount_cents === undefined) {
       res.status(400).json({ error: "topup_amount_cents is required for payment-mode checkout" });
       return;
     }
 
-    traceEvent(runId, { service: "billing-service", event: "checkout.start", data: { mode: isSetup ? "setup" : "payment", topup_amount_cents } }, req.headers);
+    traceEvent(runId, { service: "billing-service", event: "checkout.start", data: { mode: isSetup ? "setup" : "payment", ui_mode: isEmbedded ? "embedded" : "hosted", topup_amount_cents } }, req.headers);
 
     await findOrCreateAccount(orgId, userId, wfHeaders);
 
@@ -62,9 +65,9 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
           metadata: { org_id: orgId },
         };
       } else {
-        // payment mode — topup_amount_cents is guaranteed present by the 400 guard
-        // above (non-setup + undefined already returned). The `!` reflects that proven
-        // invariant; it is not a fallback.
+        // payment mode (hosted or embedded) — topup_amount_cents is guaranteed present
+        // by the 400 guard above (non-setup + undefined already returned). The `!`
+        // reflects that proven invariant; it is not a fallback.
         body = {
           mode: "payment",
           line_items: [
@@ -77,8 +80,6 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
               quantity: 1,
             },
           ],
-          success_url,
-          cancel_url,
           customer: customer.id,
           metadata: { org_id: orgId },
           payment_intent_data: {
@@ -86,6 +87,17 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
             setup_future_usage: "off_session",
           },
         };
+        if (isEmbedded) {
+          // Embedded Checkout: mounted in an in-app modal iframe. No redirect URLs —
+          // Stripe keeps the flow in-app (redirect_on_completion:"never") and returns a
+          // client_secret instead of a hosted `url`. Same charge + card-save accounting;
+          // credit lands via the same checkout.session.completed webhook.
+          body.ui_mode = "embedded";
+          body.redirect_on_completion = "never";
+        } else {
+          body.success_url = success_url;
+          body.cancel_url = cancel_url;
+        }
       }
       session = await createCheckoutSession(identity, body);
     } catch (err) {
@@ -95,6 +107,14 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
     }
 
     traceEvent(runId, { service: "billing-service", event: "checkout.done", data: { session_id: session.session_id } }, req.headers);
+
+    if (isEmbedded) {
+      res.json({
+        client_secret: session.client_secret,
+        session_id: session.session_id,
+      });
+      return;
+    }
 
     res.json({
       url: session.url,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -127,25 +127,45 @@ export const WalletSetupResponseSchema = BillingAccountSchema.extend({
 
 export const CreateCheckoutRequestSchema = z
   .object({
-    success_url: z.string().url(),
-    cancel_url: z.string().url(),
     /**
-     * Checkout flavor. Absent or "payment" → one-shot top-up checkout.
+     * Checkout UI flavor.
+     * Absent → HOSTED redirect Checkout (default; requires success_url + cancel_url,
+     * returns a `url` the dashboard redirects to).
+     * "embedded" → Stripe Embedded Checkout mounted in an in-app modal (no redirect;
+     * success_url/cancel_url are not required, returns a `client_secret`). Embedded is
+     * payment-only: it always charges topup_amount_cents as a one-shot top-up.
+     */
+    ui_mode: z.literal("embedded").optional(),
+    /** Required for HOSTED checkout; not required (and ignored) in embedded mode. */
+    success_url: z.string().url().optional(),
+    cancel_url: z.string().url().optional(),
+    /**
+     * Checkout flavor (hosted only). Absent or "payment" → one-shot top-up checkout.
      * "setup" → no-charge Stripe Checkout that saves a reusable off-session card so
      * the org can enable auto-topup without buying credits.
      */
     mode: z.enum(["payment", "setup"]).optional(),
     /**
-     * Required for payment-mode (validated in the route — fail loud with 400 when
-     * absent). Omitted for setup-mode (no charge).
+     * Required for payment-mode and for embedded mode (validated in the route — fail
+     * loud with 400 when absent). Omitted for hosted setup-mode (no charge).
      */
     topup_amount_cents: z.number().int().positive().optional(),
   })
+  .refine(
+    (data) => data.ui_mode === "embedded" || (!!data.success_url && !!data.cancel_url),
+    {
+      message: "success_url and cancel_url are required for hosted checkout",
+      path: ["success_url"],
+    }
+  )
   .openapi("CreateCheckoutRequest");
 
 export const CheckoutResponseSchema = z
   .object({
-    url: z.string(),
+    /** Present for HOSTED checkout (the redirect URL); absent in embedded mode. */
+    url: z.string().optional(),
+    /** Present for EMBEDDED checkout (mounted in the in-app modal iframe); absent for hosted. */
+    client_secret: z.string().optional(),
     session_id: z.string(),
   })
   .openapi("CheckoutResponse");
@@ -581,8 +601,11 @@ registry.registerPath({
   summary: "Create Stripe Checkout session via stripe-service",
   description:
     "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. " +
+    "HOSTED (default, no ui_mode): requires success_url + cancel_url and returns a redirect `url`. " +
     "mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. " +
-    "mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written.",
+    "mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written. " +
+    "EMBEDDED (ui_mode='embedded'): Stripe Embedded Checkout for an in-app modal — no success_url/cancel_url, returns a `client_secret` the front-end mounts in an iframe; always charges topup_amount_cents (payment-only). " +
+    "Credit + first-load match land via the existing checkout.session.completed webhook in all modes.",
   request: {
     headers: protectedHeaders,
     body: {

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -233,4 +233,123 @@ describe("POST /v1/checkout-sessions", () => {
     // Never falls back to a charge.
     expect(ssMocks.createPaymentIntent).not.toHaveBeenCalled();
   });
+
+  // --- Embedded mode (in-app modal, no redirect) ---
+
+  it("embedded-mode: returns client_secret + session_id (no url), no success/cancel URLs needed", async () => {
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      client_secret: "cs_abc_secret_xyz",
+      session_id: "cs_abc",
+    });
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        ui_mode: "embedded",
+        topup_amount_cents: 2000,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      client_secret: "cs_abc_secret_xyz",
+      session_id: "cs_abc",
+    });
+    expect(res.body).not.toHaveProperty("url");
+  });
+
+  it("embedded-mode: proxies an embedded payment session that charges the topup and saves the card off-session", async () => {
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      client_secret: "cs_abc_secret_xyz",
+      session_id: "cs_abc",
+    });
+
+    await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        ui_mode: "embedded",
+        topup_amount_cents: 2000,
+      });
+
+    expect(ssMocks.createCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({ "x-org-id": orgId }),
+      {
+        mode: "payment",
+        ui_mode: "embedded",
+        redirect_on_completion: "never",
+        line_items: [
+          {
+            price_data: {
+              currency: "usd",
+              product_data: { name: "Distribute credit top-up" },
+              unit_amount: 2000,
+            },
+            quantity: 1,
+          },
+        ],
+        customer: "cus_mock_123",
+        metadata: { org_id: orgId },
+        payment_intent_data: {
+          metadata: { org_id: orgId },
+          setup_future_usage: "off_session",
+        },
+      }
+    );
+    // No redirect URLs on an embedded session.
+    const sentBody = ssMocks.createCheckoutSession.mock.calls[0][1];
+    expect(sentBody).not.toHaveProperty("success_url");
+    expect(sentBody).not.toHaveProperty("cancel_url");
+  });
+
+  it("embedded-mode: auto-creates the billing account on first checkout (same as hosted)", async () => {
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      client_secret: "cs_abc_secret_xyz",
+      session_id: "cs_abc",
+    });
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        ui_mode: "embedded",
+        topup_amount_cents: 2000,
+      });
+
+    expect(res.status).toBe(200);
+    expect(ssMocks.ensureCustomer).toHaveBeenCalled();
+  });
+
+  it("embedded-mode: requires topup_amount_cents (400 when absent)", async () => {
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ ui_mode: "embedded" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("embedded-mode: returns 502 when stripe-service fails", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.createCheckoutSession.mockRejectedValue(new Error("SS down"));
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        ui_mode: "embedded",
+        topup_amount_cents: 2000,
+      });
+
+    expect(res.status).toBe(502);
+  });
+
+  it("hosted-mode: still requires success_url + cancel_url (400 when absent)", async () => {
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ topup_amount_cents: 2000 });
+
+    expect(res.status).toBe(400);
+  });
 });


### PR DESCRIPTION
## What

`POST /v1/checkout-sessions` gains an **embedded** mode (Stripe Embedded Checkout, in-app modal iframe) alongside today's hosted (redirect) Checkout.

## Contract (LOCKED — dashboard ↔ billing-service, byte-equal)

- **Embedded request:** `{ ui_mode:"embedded", topup_amount_cents:<positive int> }` — no `success_url`/`cancel_url` required.
- **Embedded response:** `{ client_secret, session_id }` (no `url`).
- **Hosted path unchanged:** `{ success_url, cancel_url, mode?, topup_amount_cents? }` → `{ url, session_id }`, incl auto-create-account + welcome promo.

## How

- Embedded proxies a payment session to stripe-service with `ui_mode:"embedded"` + `redirect_on_completion:"never"`, charging `topup_amount_cents` and saving the card `setup_future_usage:"off_session"` for auto-topup — same accounting as the hosted `mode:"payment"` path.
- Credit + first-load match still land via the existing `checkout.session.completed` webhook (no synchronous write).
- Embedded is payment-only (always charges); hosted `mode:"setup"` no-charge capture untouched.

## AC

1. ✅ `{ ui_mode:"embedded", topup_amount_cents:N }` (no URLs) → 2xx `{ client_secret, session_id }`.
2. ✅ Existing hosted call → `{ url, session_id }` (unchanged).
3. ✅ Webhook accounting (topup + first-load match + card save) reused as-is.
4. ✅ OpenAPI regenerated, 230 tests green (new embedded-mode suite).

## Notes

- stripe-service embedded support is being built in parallel; this builds against that capability (`ui_mode:"embedded"`, `redirect_on_completion:"never"`, returns `client_secret`).
- Heads-up: `daily-budget-registry` workspace touches shared files (route registration, openapi.json) — expect a trivial merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)