### PR TITLE
feat(checkout): embedded Stripe Checkout mode (in-app, no redirect)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -217,18 +217,27 @@
           "url": {
             "type": "string"
           },
+          "client_secret": {
+            "type": "string"
+          },
           "session_id": {
             "type": "string"
           }
         },
         "required": [
-          "url",
           "session_id"
         ]
       },
       "CreateCheckoutRequest": {
         "type": "object",
         "properties": {
+          "ui_mode": {
+            "type": "string",
+            "enum": [
+              "hosted",
+              "embedded"
+            ]
+          },
           "success_url": {
             "type": "string",
             "format": "uri"
@@ -249,11 +258,7 @@
             "minimum": 0,
             "exclusiveMinimum": true
           }
-        },
-        "required": [
-          "success_url",
-          "cancel_url"
-        ]
+        }
       },
       "WalletSetupResponse": {
         "allOf": [
@@ -1471,7 +1476,7 @@
     "/v1/checkout-sessions": {
       "post": {
         "summary": "Create Stripe Checkout session via stripe-service",
-        "description": "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written.",
+        "description": "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. ui_mode='hosted' (default) returns a Stripe-hosted page `url` to redirect to and requires success_url + cancel_url. ui_mode='embedded' returns a `client_secret` for in-app Stripe Embedded Checkout (mounted in an iframe, no redirect); success_url/cancel_url are not required and it is always payment (charges topup_amount_cents). mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. mode='setup' (hosted only) creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written. In all cases credit accounting (wallet credit, first-load match, saved card) lands via the existing checkout.session.completed webhook, not synchronously.",
         "parameters": [
           {
             "schema": {
@@ -1566,7 +1571,7 @@
         },
         "responses": {
           "200": {
-            "description": "Checkout session URL",
+            "description": "Checkout session: { url, session_id } for hosted, { client_secret, session_id } for embedded",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -80,7 +80,10 @@ export interface CustomerEnsureResult {
 }
 
 export interface CheckoutSessionResult {
-  url: string;
+  /** Hosted checkout — the Stripe-hosted page URL. Absent for embedded sessions. */
+  url?: string;
+  /** Embedded checkout — the client secret the front-end mounts in the iframe. Absent for hosted sessions. */
+  client_secret?: string;
   session_id: string;
 }
 
@@ -286,12 +289,22 @@ export interface CheckoutLineItem {
 
 export interface CheckoutSessionBody {
   mode: "payment" | "setup";
+  /**
+   * Checkout UI surface. Omitted (hosted) → Stripe returns a redirect `url`.
+   * "embedded" → Stripe returns a `client_secret` for the in-app iframe and
+   * requires `redirect_on_completion: "never"` (no success_url).
+   */
+  ui_mode?: "embedded";
+  /** Embedded sessions never redirect; set to "never" so no success_url is required. */
+  redirect_on_completion?: "never";
   /** Required by Stripe for setup mode when payment_method_types is omitted. */
   currency?: string;
   /** Required for payment mode; omitted for setup mode (no charge). */
   line_items?: CheckoutLineItem[];
-  success_url: string;
-  cancel_url: string;
+  /** Required for hosted checkout; omitted for embedded (no redirect). */
+  success_url?: string;
+  /** Required for hosted checkout; omitted for embedded (no redirect). */
+  cancel_url?: string;
   customer: string;
   metadata: Record<string, string>;
   /** Payment-mode charge config; omitted for setup mode (no PaymentIntent created). */

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -25,16 +25,20 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
       return;
     }
     const { success_url, cancel_url, topup_amount_cents } = parsed.data;
-    const isSetup = parsed.data.mode === "setup";
+    const isEmbedded = parsed.data.ui_mode === "embedded";
+    // Embedded checkout is always payment (the iframe captures a card + charges the
+    // top-up); mode is ignored when ui_mode="embedded".
+    const isSetup = !isEmbedded && parsed.data.mode === "setup";
 
-    // Payment-mode (absent mode or "payment") requires an explicit amount. Fail loud
-    // rather than defaulting — a payment checkout with no amount is a malformed request.
+    // Payment checkout (hosted payment-mode or embedded) requires an explicit amount.
+    // Fail loud rather than defaulting — a payment checkout with no amount is malformed.
+    // (Embedded already enforces this in the schema; the guard keeps hosted-payment safe.)
     if (!isSetup && topup_amount_cents === undefined) {
       res.status(400).json({ error: "topup_amount_cents is required for payment-mode checkout" });
       return;
     }
 
-    traceEvent(runId, { service: "billing-service", event: "checkout.start", data: { mode: isSetup ? "setup" : "payment", topup_amount_cents } }, req.headers);
+    traceEvent(runId, { service: "billing-service", event: "checkout.start", data: { ui_mode: isEmbedded ? "embedded" : "hosted", mode: isSetup ? "setup" : "payment", topup_amount_cents } }, req.headers);
 
     await findOrCreateAccount(orgId, userId, wfHeaders);
 
@@ -62,9 +66,9 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
           metadata: { org_id: orgId },
         };
       } else {
-        // payment mode — topup_amount_cents is guaranteed present by the 400 guard
-        // above (non-setup + undefined already returned). The `!` reflects that proven
-        // invariant; it is not a fallback.
+        // payment mode (hosted or embedded) — topup_amount_cents is guaranteed present
+        // by the 400 guard above (non-setup + undefined already returned). The `!`
+        // reflects that proven invariant; it is not a fallback.
         body = {
           mode: "payment",
           line_items: [
@@ -77,8 +81,6 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
               quantity: 1,
             },
           ],
-          success_url,
-          cancel_url,
           customer: customer.id,
           metadata: { org_id: orgId },
           payment_intent_data: {
@@ -86,6 +88,19 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
             setup_future_usage: "off_session",
           },
         };
+        if (isEmbedded) {
+          // Embedded Checkout: mounted in an in-app iframe, returns a client_secret,
+          // never redirects (so no success_url). The card is still saved off-session
+          // via payment_intent_data.setup_future_usage above. The SAME
+          // checkout.session.completed webhook fires on completion, so all credit
+          // accounting (wallet credit, first-load match, saved card) is unchanged.
+          body.ui_mode = "embedded";
+          body.redirect_on_completion = "never";
+        } else {
+          // Hosted Checkout: redirect to the Stripe-hosted page.
+          body.success_url = success_url;
+          body.cancel_url = cancel_url;
+        }
       }
       session = await createCheckoutSession(identity, body);
     } catch (err) {
@@ -96,10 +111,12 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
 
     traceEvent(runId, { service: "billing-service", event: "checkout.done", data: { session_id: session.session_id } }, req.headers);
 
-    res.json({
-      url: session.url,
-      session_id: session.session_id,
-    });
+    // Embedded returns a client_secret (mounted in the iframe); hosted returns a url.
+    res.json(
+      isEmbedded
+        ? { client_secret: session.client_secret, session_id: session.session_id }
+        : { url: session.url, session_id: session.session_id }
+    );
   } catch (err) {
     console.error("[billing-service] Error creating checkout session:", err);
     res.status(500).json({ error: "Internal server error" });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -127,25 +127,69 @@ export const WalletSetupResponseSchema = BillingAccountSchema.extend({
 
 export const CreateCheckoutRequestSchema = z
   .object({
-    success_url: z.string().url(),
-    cancel_url: z.string().url(),
+    /**
+     * Checkout UI surface. Absent or "hosted" → redirect to a Stripe-hosted
+     * Checkout page (returns `url`); requires success_url + cancel_url.
+     * "embedded" → in-app Stripe Embedded Checkout mounted in an iframe
+     * (returns `client_secret`, no redirect); success_url/cancel_url are not
+     * used. Embedded is payment-only (charges topup_amount_cents).
+     */
+    ui_mode: z.enum(["hosted", "embedded"]).optional(),
+    /**
+     * Required for hosted checkout; not used in embedded mode (the iframe does
+     * not redirect). Cross-field validation in superRefine below.
+     */
+    success_url: z.string().url().optional(),
+    cancel_url: z.string().url().optional(),
     /**
      * Checkout flavor. Absent or "payment" → one-shot top-up checkout.
      * "setup" → no-charge Stripe Checkout that saves a reusable off-session card so
-     * the org can enable auto-topup without buying credits.
+     * the org can enable auto-topup without buying credits. Embedded mode is
+     * always payment (mode is ignored when ui_mode="embedded").
      */
     mode: z.enum(["payment", "setup"]).optional(),
     /**
-     * Required for payment-mode (validated in the route — fail loud with 400 when
-     * absent). Omitted for setup-mode (no charge).
+     * Required for payment-mode and embedded mode (validated below — fail loud
+     * with 400 when absent). Omitted for hosted setup-mode (no charge).
      */
     topup_amount_cents: z.number().int().positive().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.ui_mode === "embedded") {
+      // Embedded checkout is payment-only and never redirects.
+      if (data.topup_amount_cents === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "topup_amount_cents is required for embedded checkout",
+          path: ["topup_amount_cents"],
+        });
+      }
+    } else {
+      // Hosted checkout redirects, so success_url + cancel_url are required.
+      if (data.success_url === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "success_url is required for hosted checkout",
+          path: ["success_url"],
+        });
+      }
+      if (data.cancel_url === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "cancel_url is required for hosted checkout",
+          path: ["cancel_url"],
+        });
+      }
+    }
   })
   .openapi("CreateCheckoutRequest");
 
 export const CheckoutResponseSchema = z
   .object({
-    url: z.string(),
+    /** Present for hosted checkout — the Stripe-hosted page the dashboard redirects to. */
+    url: z.string().optional(),
+    /** Present for embedded checkout — mounted in the in-app Stripe Embedded Checkout iframe. */
+    client_secret: z.string().optional(),
     session_id: z.string(),
   })
   .openapi("CheckoutResponse");
@@ -581,8 +625,11 @@ registry.registerPath({
   summary: "Create Stripe Checkout session via stripe-service",
   description:
     "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. " +
+    "ui_mode='hosted' (default) returns a Stripe-hosted page `url` to redirect to and requires success_url + cancel_url. " +
+    "ui_mode='embedded' returns a `client_secret` for in-app Stripe Embedded Checkout (mounted in an iframe, no redirect); success_url/cancel_url are not required and it is always payment (charges topup_amount_cents). " +
     "mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. " +
-    "mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written.",
+    "mode='setup' (hosted only) creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written. " +
+    "In all cases credit accounting (wallet credit, first-load match, saved card) lands via the existing checkout.session.completed webhook, not synchronously.",
   request: {
     headers: protectedHeaders,
     body: {
@@ -593,7 +640,7 @@ registry.registerPath({
   },
   responses: {
     200: {
-      description: "Checkout session URL",
+      description: "Checkout session: { url, session_id } for hosted, { client_secret, session_id } for embedded",
       content: { "application/json": { schema: CheckoutResponseSchema } },
     },
     502: {

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -233,4 +233,119 @@ describe("POST /v1/checkout-sessions", () => {
     // Never falls back to a charge.
     expect(ssMocks.createPaymentIntent).not.toHaveBeenCalled();
   });
+
+  // --- Embedded mode (in-app iframe, no redirect) ---
+
+  it("embedded: returns client_secret + session_id (no url), no success/cancel URL required", async () => {
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      client_secret: "cs_test_secret_abc",
+      session_id: "cs_emb",
+    });
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        ui_mode: "embedded",
+        topup_amount_cents: 2000,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      client_secret: "cs_test_secret_abc",
+      session_id: "cs_emb",
+    });
+    expect(res.body).not.toHaveProperty("url");
+  });
+
+  it("embedded: proxies a payment session with ui_mode=embedded, redirect_on_completion=never, off-session card, no success/cancel", async () => {
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      client_secret: "cs_test_secret_abc",
+      session_id: "cs_emb",
+    });
+
+    await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        ui_mode: "embedded",
+        topup_amount_cents: 2000,
+      });
+
+    expect(ssMocks.createCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({ "x-org-id": orgId }),
+      {
+        mode: "payment",
+        ui_mode: "embedded",
+        redirect_on_completion: "never",
+        line_items: [
+          {
+            price_data: {
+              currency: "usd",
+              product_data: { name: "Distribute credit top-up" },
+              unit_amount: 2000,
+            },
+            quantity: 1,
+          },
+        ],
+        customer: "cus_mock_123",
+        metadata: { org_id: orgId },
+        payment_intent_data: {
+          metadata: { org_id: orgId },
+          setup_future_usage: "off_session",
+        },
+      }
+    );
+    // Embedded never sends redirect URLs to stripe-service.
+    const sentBody = ssMocks.createCheckoutSession.mock.calls[0][1];
+    expect(sentBody).not.toHaveProperty("success_url");
+    expect(sentBody).not.toHaveProperty("cancel_url");
+  });
+
+  it("embedded: auto-creates the billing account with welcome promo on first checkout", async () => {
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      client_secret: "cs_test_secret_abc",
+      session_id: "cs_emb",
+    });
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        ui_mode: "embedded",
+        topup_amount_cents: 2000,
+      });
+
+    expect(res.status).toBe(200);
+    expect(ssMocks.ensureCustomer).toHaveBeenCalled();
+    const [account] = await db
+      .select()
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId));
+    expect(account).toBeDefined();
+  });
+
+  it("embedded: 400 when topup_amount_cents is missing", async () => {
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ ui_mode: "embedded" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("embedded: returns 502 when stripe-service fails", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.createCheckoutSession.mockRejectedValue(new Error("SS down"));
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        ui_mode: "embedded",
+        topup_amount_cents: 2000,
+      });
+
+    expect(res.status).toBe(502);
+  });
 });


### PR DESCRIPTION
## Job
Let the dashboard capture a card + add credit inside an in-app modal (Stripe Embedded Checkout, no redirect), in addition to today's hosted (redirect) Checkout.

## Change
`POST /v1/checkout-sessions` gains an **embedded** UI mode:

| | Request | Response |
|---|---|---|
| **Hosted** (unchanged) | `{ success_url, cancel_url, mode?, topup_amount_cents? }` | `{ url, session_id }` |
| **Embedded** (new) | `{ ui_mode: "embedded", topup_amount_cents }` | `{ client_secret, session_id }` |

Embedded:
- `success_url`/`cancel_url` **not required** (the iframe never redirects).
- Still auto-creates the billing account with welcome promo if missing, resolves the org's Stripe customer, then creates the underlying session via stripe-service with `ui_mode="embedded"`, `redirect_on_completion="never"`, `payment_intent_data.setup_future_usage="off_session"`, no `success_url`.
- Card saved off-session for auto-topup; `topup_amount_cents` charged as a one-shot top-up (same accounting as hosted `mode:"payment"`).
- Credit + first-load match land via the existing `checkout.session.completed` webhook — **no synchronous write**.

## No regressions
- Hosted flow + response shape unchanged (existing tests still assert byte-equal `{ url, session_id }` + welcome-promo auto-create).
- Credit accounting stays on the webhook.
- Embedded never sends success/cancel URLs to stripe-service.

## AC
1. ✅ `{ ui_mode:"embedded", topup_amount_cents:N }` (no URLs) → 2xx `{ client_secret, session_id }`.
2. ✅ Existing hosted call → `{ url, session_id }`.
3. ✅ Card saved + topup/first-load credit via existing webhook (accounting unchanged).
4. ✅ OpenAPI regenerated, 229 tests green.

## Notes
- Built against stripe-service's in-flight embedded capability (`ui_mode`, `redirect_on_completion:"never"`, returns `client_secret`).
- Trivial overlap possible with the `daily-budget-registry` workspace on route registration / `openapi.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)