### PR TITLE
feat(auto-reload): disable off_session auto-reload for India-issued cards (#220)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -116,6 +116,17 @@
           "has_auto_topup": {
             "type": "boolean"
           },
+          "auto_reload_supported": {
+            "type": "boolean"
+          },
+          "auto_reload_unsupported_reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "card_country": {
+            "type": "string",
+            "nullable": true
+          },
           "created_at": {
             "type": "string"
           },
@@ -134,6 +145,9 @@
           "topup_threshold_cents",
           "has_payment_method",
           "has_auto_topup",
+          "auto_reload_supported",
+          "auto_reload_unsupported_reason",
+          "card_country",
           "created_at",
           "updated_at"
         ]

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -13,12 +13,21 @@ import {
   fetchOrgCustomer,
   sumSucceededTopupsForOrg,
   hasChargeablePmForOrg,
+  getOrgCardCountryByOrg,
+  isAutoReloadBlockedCountry,
   type StripeCustomer,
 } from "./stripe-service-client.js";
 
 export interface BalanceSnapshot {
   customer: StripeCustomer;
   hasCardPm: boolean;
+  /** Issuing country of the card the reload would charge (null when no card PM). */
+  cardCountry: string | null;
+  /**
+   * False when the saved card's issuing country can't be charged off_session (e.g.
+   * India / RBI). The reload trigger skips these cards — see customer_balance authorize.
+   */
+  autoReloadSupported: boolean;
   creditedCents: string;
   usageCents: string;
   balanceCents: string;
@@ -36,17 +45,20 @@ export interface BalanceSnapshot {
  */
 export async function computeBalance(orgId: string): Promise<BalanceSnapshot> {
   const customer = await fetchOrgCustomer(orgId);
-  const [paidTopups, localCredits, runsUsage, hasCardPm] = await Promise.all([
+  const [paidTopups, localCredits, runsUsage, hasCardPm, cardCountry] = await Promise.all([
     sumSucceededTopupsForOrg(orgId),
     sumLocalPromoCreditsForOrg(orgId),
     fetchRunsOrgUsageTotal(orgId, {}),
     hasChargeablePmForOrg(orgId),
+    getOrgCardCountryByOrg(orgId),
   ]);
   const creditedCents = addCents(paidTopups, localCredits);
   const balanceCents = subCents(creditedCents, runsUsage.spent_cents);
   return {
     customer,
     hasCardPm,
+    cardCountry,
+    autoReloadSupported: !isAutoReloadBlockedCountry(cardCountry),
     creditedCents,
     usageCents: runsUsage.spent_cents,
     balanceCents,

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -66,6 +66,17 @@ export interface StripePaymentMethod {
   id: string;
   object: "payment_method";
   type: string;
+  /**
+   * Card detail (present when type === "card"). stripe-service passes the Stripe
+   * PaymentMethod object through verbatim, so `card.country` (the ISO-3166-1 alpha-2
+   * issuing country, e.g. "IN") is already on the wire — used to gate off_session
+   * auto-reload (see AUTO_RELOAD_BLOCKED_CARD_COUNTRIES). Null/absent for non-card PMs.
+   */
+  card?: {
+    country?: string | null;
+    brand?: string | null;
+    last4?: string | null;
+  } | null;
 }
 
 export interface StripePaymentMethodList {
@@ -400,6 +411,54 @@ export async function hasAttachedCardPm(
   return links.data.length > 0;
 }
 
+// --- Off_session auto-reload country eligibility ---
+//
+// Some countries' card networks REQUIRE a pre-registered mandate / agreement for
+// off-session (merchant-initiated) charges. Stripe CANNOT register that mandate through
+// the PaymentIntent / SetupIntent path billing-service uses for card capture + reload —
+// it is only creatable via Stripe Subscriptions (see issue #220). India (RBI e-mandate)
+// is the confirmed, prod-observed case: an off_session reload on an India-issued card is
+// declined with "You must provide a mandate for off-session card payments made with cards
+// issued in India."
+//
+// Forward-only: a card already saved without a mandate cannot be retrofitted. So instead
+// of attempting a charge Stripe will decline every cycle, we detect the issuing country
+// and (a) report auto_reload_supported=false on the account so the dashboard shows a
+// notice, and (b) skip the reload trigger for these cards.
+//
+// NOT included:
+//   - EEA/SCA — that mandate is satisfied by setup_future_usage + SCA on the initial
+//     save, which billing's Checkout flow already performs; off_session MITs work.
+//   - Mexico / Brazil — listed by Stripe as agreement-requiring, but the mechanism is
+//     unconfirmed and we have no prod evidence. Left out to avoid blocking orgs that may
+//     work today. Add the ISO-2 code here if a decline is confirmed.
+export const AUTO_RELOAD_BLOCKED_CARD_COUNTRIES: ReadonlySet<string> = new Set(["IN"]);
+
+/**
+ * True when a card's issuing country cannot be charged off_session (e.g. "IN").
+ * Null/absent country (no card, or a link PM) is NOT blocked.
+ */
+export function isAutoReloadBlockedCountry(country: string | null | undefined): boolean {
+  return country != null && AUTO_RELOAD_BLOCKED_CARD_COUNTRIES.has(country.toUpperCase());
+}
+
+/**
+ * Issuing country (ISO-3166-1 alpha-2, e.g. "IN") of the CARD the off_session reload
+ * would charge — the first attached `card` PM, mirroring reload.ts's pick order. Returns
+ * null when the org has no card PM (link-only or none): a link PM has no blocked issuing
+ * country, so it is always reload-eligible.
+ *
+ * Real-user path (org-implicit GET /v1/payment_methods, requires x-user-id). Fail-loud:
+ * a stripe-service error propagates.
+ */
+export async function getOrgCardCountry(
+  identity: IdentityHeaders,
+  customerId: string
+): Promise<string | null> {
+  const cards = await listPaymentMethods(identity, { customer: customerId, type: "card" });
+  return cards.data[0]?.card?.country ?? null;
+}
+
 // --- User-less org-scoped reads (balance path only) ---
 //
 // stripe-service exposes a service-authenticated, org-scoped read surface under
@@ -466,4 +525,19 @@ export async function hasChargeablePmForOrg(orgId: string): Promise<boolean> {
   if (cards.data.length > 0) return true;
   const links = await call<StripePaymentMethodList>("GET", `${path}?type=link`, {});
   return links.data.length > 0;
+}
+
+/**
+ * User-less (balance-path) twin of getOrgCardCountry — issuing country of the org's first
+ * card PM via the service-authenticated GET /internal/payment_methods/by-org/{orgId}?type=card
+ * route (X-API-Key + org only, NO x-user-id). Returns null when the org has no card PM.
+ * Fail-loud: a stripe-service error propagates.
+ */
+export async function getOrgCardCountryByOrg(orgId: string): Promise<string | null> {
+  const cards = await call<StripePaymentMethodList>(
+    "GET",
+    `/internal/payment_methods/by-org/${encodeURIComponent(orgId)}?type=card`,
+    {}
+  );
+  return cards.data[0]?.card?.country ?? null;
 }

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -14,6 +14,8 @@ import {
   getCustomerByOrg,
   sumSucceededTopupsForCustomer,
   hasAttachedCardPm,
+  getOrgCardCountry,
+  isAutoReloadBlockedCountry,
 } from "../lib/stripe-service-client.js";
 
 const router = Router();
@@ -44,14 +46,17 @@ async function composeAccountFunds(
   balanceCents: string;
   actualBalanceCents: string;
   hasPaymentMethod: boolean;
+  cardCountry: string | null;
+  autoReloadSupported: boolean;
 }> {
   const customer = await getCustomerByOrg(identity);
-  const [paidTopups, localCredits, runsUsage, actualRunsUsage, hasCardPm] = await Promise.all([
+  const [paidTopups, localCredits, runsUsage, actualRunsUsage, hasCardPm, cardCountry] = await Promise.all([
     sumSucceededTopupsForCustomer(identity, customer.id),
     sumLocalPromoCreditsForOrg(orgId),
     fetchRunsOrgUsageTotal(orgId, identity),
     fetchRunsOrgActualUsageTotal(orgId, identity),
     hasAttachedCardPm(identity, customer.id),
+    getOrgCardCountry(identity, customer.id),
   ]);
   const creditedCents = addCents(paidTopups, localCredits);
   const balanceCents = subCents(creditedCents, runsUsage.spent_cents);
@@ -62,6 +67,8 @@ async function composeAccountFunds(
     balanceCents,
     actualBalanceCents,
     hasPaymentMethod: hasCardPm,
+    cardCountry,
+    autoReloadSupported: !isAutoReloadBlockedCountry(cardCountry),
   };
 }
 
@@ -73,6 +80,8 @@ function buildAccountResponse(
     balanceCents: string;
     actualBalanceCents: string;
     hasPaymentMethod: boolean;
+    cardCountry: string | null;
+    autoReloadSupported: boolean;
   }
 ) {
   return {
@@ -85,7 +94,17 @@ function buildAccountResponse(
     topup_amount_cents: account.topupAmountCents,
     topup_threshold_cents: account.topupThresholdCents,
     has_payment_method: funds.hasPaymentMethod,
-    has_auto_topup: account.topupAmountCents != null && account.topupThresholdCents != null && funds.hasPaymentMethod,
+    // Off_session auto-reload is impossible for cards issued in mandate-required countries
+    // (e.g. India / RBI, issue #220). When unsupported, the dashboard shows a notice and
+    // has_auto_topup is false even if topup config exists — the reload would never fire.
+    auto_reload_supported: funds.autoReloadSupported,
+    auto_reload_unsupported_reason: funds.autoReloadSupported ? null : "card_issuing_country_unsupported",
+    card_country: funds.cardCountry,
+    has_auto_topup:
+      account.topupAmountCents != null &&
+      account.topupThresholdCents != null &&
+      funds.hasPaymentMethod &&
+      funds.autoReloadSupported,
     created_at: account.createdAt.toISOString(),
     updated_at: account.updatedAt.toISOString(),
   };
@@ -202,9 +221,13 @@ router.patch("/v1/accounts/auto_topup", requireOrgHeaders, async (req, res) => {
     }
 
     let hasCardPm: boolean;
+    let cardCountry: string | null;
     try {
       const customer = await getCustomerByOrg(identity);
-      hasCardPm = await hasAttachedCardPm(identity, customer.id);
+      [hasCardPm, cardCountry] = await Promise.all([
+        hasAttachedCardPm(identity, customer.id),
+        getOrgCardCountry(identity, customer.id),
+      ]);
     } catch (err) {
       console.error("[billing-service] Failed to fetch customer for PM check:", err);
       res.status(502).json({ error: "Failed to query payment method status" });
@@ -214,6 +237,16 @@ router.patch("/v1/accounts/auto_topup", requireOrgHeaders, async (req, res) => {
     if (!hasCardPm) {
       res.status(400).json({
         error: "Payment method required. Create a checkout session first.",
+      });
+      return;
+    }
+
+    // Off_session auto-reload can't be charged for cards issued in mandate-required
+    // countries (e.g. India / RBI, issue #220). Reject the config rather than store one
+    // that silently never fires — fail loud so the dashboard surfaces the real reason.
+    if (isAutoReloadBlockedCountry(cardCountry)) {
+      res.status(400).json({
+        error: `Auto-reload is unavailable for cards issued in ${cardCountry} — off-session charges require a mandate Stripe can't register on this card. Add a card from another country to enable auto-reload.`,
       });
       return;
     }

--- a/src/routes/customer_balance.ts
+++ b/src/routes/customer_balance.ts
@@ -13,6 +13,8 @@ import {
   getCustomerByOrg,
   sumSucceededTopupsForCustomer,
   hasAttachedCardPm,
+  getOrgCardCountry,
+  isAutoReloadBlockedCountry,
 } from "../lib/stripe-service-client.js";
 import { computeBalance } from "../lib/balance.js";
 import { upsertCampaignAuthorizeCost } from "../lib/campaign-costs.js";
@@ -158,6 +160,27 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
       return;
     }
 
+    if (!snapshot.autoReloadSupported) {
+      // Card issued in a country that can't be charged off_session (e.g. India / RBI
+      // e-mandate, issue #220). A reload here would be declined every cycle, so we skip
+      // it and fall through to depletion dunning, which prompts a manual recharge.
+      await openDepletionEpisodeIfDepleted({
+        orgId, userId, runId,
+        balanceCents: snapshot.balanceCents,
+        creditedCents: snapshot.creditedCents,
+        workflow: wf,
+        workflowHeaders: wfHeaders,
+        recipientEmail: snapshot.customer.email,
+      });
+      traceEvent(runId, { service: "billing-service", event: "customer_balance.authorize.done", data: { sufficient: false, reason: "auto_reload_unsupported_country", card_country: snapshot.cardCountry } }, req.headers);
+      res.json({
+        sufficient: false,
+        balance_cents: snapshot.balanceCents,
+        required_cents: requiredCents,
+      });
+      return;
+    }
+
     const chargeAmount = computeTopupCharge(snapshot.balanceCents, requiredCents, account.topupAmountCents);
     if (chargeAmount <= 0) {
       await openDepletionEpisodeIfDepleted({
@@ -280,6 +303,15 @@ router.post("/v1/customer_balance/usage_apply", requireOrgHeaders, async (req, r
     const customer = await getCustomerByOrg(identity);
 
     if (!(await hasAttachedCardPm(identity, customer.id))) {
+      res.status(202).json({ acknowledged: true, topup_triggered: false });
+      return;
+    }
+
+    // India (and other off_session-mandate) cards can't be auto-reloaded — Stripe declines
+    // the off_session charge with no registered mandate (issue #220). Skip rather than spam
+    // a doomed reload; the depletion dunning path prompts the org to recharge manually.
+    if (isAutoReloadBlockedCountry(await getOrgCardCountry(identity, customer.id))) {
+      traceEvent(runId, { service: "billing-service", event: "customer_balance.usage_apply.topup-skipped", data: { reason: "auto_reload_unsupported_country" } }, req.headers);
       res.status(202).json({ acknowledged: true, topup_triggered: false });
       return;
     }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -49,6 +49,17 @@ export const BillingAccountSchema = z
     topup_threshold_cents: z.number().int().nullable(),
     has_payment_method: z.boolean(),
     has_auto_topup: z.boolean(),
+    /**
+     * False when the saved card's issuing country can't be charged off_session (e.g.
+     * India / RBI e-mandate). The dashboard hides/disables the auto-reload section and
+     * shows a notice when false. has_auto_topup is also false in that case (a stored
+     * config would never fire). See issue #220.
+     */
+    auto_reload_supported: z.boolean(),
+    /** Machine reason when auto_reload_supported is false; null otherwise. */
+    auto_reload_unsupported_reason: z.string().nullable(),
+    /** ISO-3166-1 alpha-2 issuing country of the card the reload would charge; null when no card PM. */
+    card_country: z.string().nullable(),
     created_at: z.string(),
     updated_at: z.string(),
   })

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -11,11 +11,13 @@ export interface StripeServiceMocks {
   listPaymentIntents: ReturnType<typeof vi.fn>;
   listPaymentMethods: ReturnType<typeof vi.fn>;
   hasAttachedCardPm: ReturnType<typeof vi.fn>;
+  getOrgCardCountry: ReturnType<typeof vi.fn>;
   sumSucceededTopupsForCustomer: ReturnType<typeof vi.fn>;
   // User-less org-keyed reads (balance path — computeBalance).
   fetchOrgCustomer: ReturnType<typeof vi.fn>;
   sumSucceededTopupsForOrg: ReturnType<typeof vi.fn>;
   hasChargeablePmForOrg: ReturnType<typeof vi.fn>;
+  getOrgCardCountryByOrg: ReturnType<typeof vi.fn>;
   listCustomersByMetadata: ReturnType<typeof vi.fn>;
   updateCustomer: ReturnType<typeof vi.fn>;
   createCheckoutSession: ReturnType<typeof vi.fn>;
@@ -94,10 +96,14 @@ export function setupStripeMocks(): StripeServiceMocks {
       has_more: false,
     }),
     hasAttachedCardPm: vi.fn().mockResolvedValue(true),
+    // Default null = no blocked issuing country → auto-reload supported. Override to "IN"
+    // to exercise the India / off_session-mandate path.
+    getOrgCardCountry: vi.fn().mockResolvedValue(null),
     sumSucceededTopupsForCustomer: vi.fn().mockResolvedValue("0.0000000000"),
     fetchOrgCustomer: vi.fn().mockResolvedValue(buildMockCustomer()),
     sumSucceededTopupsForOrg: vi.fn().mockResolvedValue("0.0000000000"),
     hasChargeablePmForOrg: vi.fn().mockResolvedValue(true),
+    getOrgCardCountryByOrg: vi.fn().mockResolvedValue(null),
     createCheckoutSession: vi.fn().mockResolvedValue({
       url: "https://checkout.stripe.com/pay/cs_mock",
       session_id: "cs_mock",
@@ -133,6 +139,7 @@ export function setupStripeMocks(): StripeServiceMocks {
   vi.spyOn(ssClient, "listPaymentIntents").mockImplementation(mocks.listPaymentIntents);
   vi.spyOn(ssClient, "listPaymentMethods").mockImplementation(mocks.listPaymentMethods);
   vi.spyOn(ssClient, "hasAttachedCardPm").mockImplementation(mocks.hasAttachedCardPm);
+  vi.spyOn(ssClient, "getOrgCardCountry").mockImplementation(mocks.getOrgCardCountry);
   vi.spyOn(ssClient, "sumSucceededTopupsForCustomer").mockImplementation(
     mocks.sumSucceededTopupsForCustomer
   );
@@ -141,6 +148,7 @@ export function setupStripeMocks(): StripeServiceMocks {
     mocks.sumSucceededTopupsForOrg
   );
   vi.spyOn(ssClient, "hasChargeablePmForOrg").mockImplementation(mocks.hasChargeablePmForOrg);
+  vi.spyOn(ssClient, "getOrgCardCountryByOrg").mockImplementation(mocks.getOrgCardCountryByOrg);
   vi.spyOn(ssClient, "createCheckoutSession").mockImplementation(mocks.createCheckoutSession);
   vi.spyOn(ssClient, "createPortalSession").mockImplementation(mocks.createPortalSession);
   vi.spyOn(ssClient, "listCustomersByMetadata").mockImplementation(mocks.listCustomersByMetadata);

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -142,6 +142,38 @@ describe("Accounts endpoints", () => {
       expect(res.body.has_payment_method).toBe(true);
     });
 
+    it("reports auto_reload_supported=true for a non-blocked card country", async () => {
+      await insertTestAccount({ orgId });
+      ssMocks.getOrgCardCountry.mockResolvedValue("US");
+
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set(getAuthHeaders(orgId));
+
+      expect(res.status).toBe(200);
+      expect(res.body.auto_reload_supported).toBe(true);
+      expect(res.body.auto_reload_unsupported_reason).toBeNull();
+      expect(res.body.card_country).toBe("US");
+    });
+
+    it("reports auto_reload_supported=false + reason for an India-issued card", async () => {
+      // Account has full topup config, but the India card can't be charged off_session
+      // → auto_reload_supported false, reason set, has_auto_topup forced false.
+      await insertTestAccount({ orgId, topupAmountCents: 5000, topupThresholdCents: 1000 });
+      ssMocks.getOrgCardCountry.mockResolvedValue("IN");
+
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set(getAuthHeaders(orgId));
+
+      expect(res.status).toBe(200);
+      expect(res.body.auto_reload_supported).toBe(false);
+      expect(res.body.auto_reload_unsupported_reason).toBe("card_issuing_country_unsupported");
+      expect(res.body.card_country).toBe("IN");
+      expect(res.body.has_payment_method).toBe(true);
+      expect(res.body.has_auto_topup).toBe(false);
+    });
+
     it("credited reflects only succeeded payment intents (failed PIs excluded)", async () => {
       await insertTestAccount({ orgId });
       // Helper already filters succeeded — assert by configuring its return.
@@ -304,6 +336,21 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("Payment method required");
+    });
+
+    it("rejects enabling auto-topup for an India-issued card (off_session mandate unsupported)", async () => {
+      await insertTestAccount({ orgId });
+      ssMocks.hasAttachedCardPm.mockResolvedValue(true);
+      ssMocks.getOrgCardCountry.mockResolvedValue("IN");
+
+      const res = await request(app)
+        .patch("/v1/accounts/auto_topup")
+        .set(getAuthHeaders(orgId))
+        .send({ topup_amount_cents: 5000, topup_threshold_cents: 1000 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("IN");
+      expect(res.body.error).toContain("Auto-reload is unavailable");
     });
 
     it("requires an explicit auto-topup threshold", async () => {

--- a/tests/integration/authorize-runs-total.test.ts
+++ b/tests/integration/authorize-runs-total.test.ts
@@ -140,6 +140,24 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
   });
 
+  it("insufficient + topup + India card → sufficient:false, no reload attempted", async () => {
+    await insertTestAccount({ orgId, topupAmountCents: 1000 });
+    // Card attached, but issued in India → off_session reload would be declined. The
+    // authorize path must NOT attempt it; it falls through to graceful sufficient:false.
+    ssMocks.hasChargeablePmForOrg.mockResolvedValue(true);
+    ssMocks.getOrgCardCountryByOrg.mockResolvedValue("IN");
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(getAuthHeaders(orgId, userId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sufficient).toBe(false);
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
   it("PM lookup errors (stripe-service down) → 502, never silent no-PM", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
     ssMocks.hasChargeablePmForOrg.mockRejectedValue(new Error("stripe-service down"));

--- a/tests/integration/usage-apply.test.ts
+++ b/tests/integration/usage-apply.test.ts
@@ -103,6 +103,26 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
     expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
   });
 
+  it("does not topup for an India-issued card (off_session mandate unsupported)", async () => {
+    await insertTestAccount({
+      orgId,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    ssMocks.hasAttachedCardPm.mockResolvedValue(true);
+    ssMocks.getOrgCardCountry.mockResolvedValue("IN");
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("100.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/usage_apply")
+      .set(getAuthHeaders(orgId, userId))
+      .send({ spent_total_cents: "50.0000000000" });
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ acknowledged: true, topup_triggered: false });
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
   it("does not topup when no topup config", async () => {
     await insertTestAccount({ orgId });
 

--- a/tests/unit/stripe-service-client.test.ts
+++ b/tests/unit/stripe-service-client.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   sumSucceededTopupsForCustomer,
   hasAttachedCardPm,
+  getOrgCardCountry,
+  getOrgCardCountryByOrg,
+  isAutoReloadBlockedCountry,
   type StripePaymentIntent,
   type StripePaymentIntentList,
   type StripePaymentMethod,
@@ -220,5 +223,81 @@ describe("hasAttachedCardPm", () => {
     await expect(hasAttachedCardPm({}, "cus_test")).rejects.toThrow(
       /stripe-service GET \/v1\/payment_methods.*failed: 404/
     );
+  });
+});
+
+describe("isAutoReloadBlockedCountry", () => {
+  it("blocks India (case-insensitive)", () => {
+    expect(isAutoReloadBlockedCountry("IN")).toBe(true);
+    expect(isAutoReloadBlockedCountry("in")).toBe(true);
+  });
+
+  it("does not block US / EEA / null / undefined", () => {
+    expect(isAutoReloadBlockedCountry("US")).toBe(false);
+    expect(isAutoReloadBlockedCountry("FR")).toBe(false);
+    expect(isAutoReloadBlockedCountry(null)).toBe(false);
+    expect(isAutoReloadBlockedCountry(undefined)).toBe(false);
+  });
+});
+
+describe("getOrgCardCountry / getOrgCardCountryByOrg", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function pmListBody(data: StripePaymentMethod[]) {
+    return { object: "list", url: "/v1/payment_methods", data, has_more: false };
+  }
+
+  it("returns the first card PM's issuing country (real-user path)", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pmListBody([{ id: "pm_1", object: "payment_method", type: "card", card: { country: "IN" } }])
+      )
+    );
+
+    expect(await getOrgCardCountry({}, "cus_test")).toBe("IN");
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain("type=card");
+    expect(url).toContain("customer=cus_test");
+  });
+
+  it("returns null when no card PM is attached", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(pmListBody([])));
+    expect(await getOrgCardCountry({}, "cus_test")).toBeNull();
+  });
+
+  it("returns null when the card object carries no country", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(pmListBody([{ id: "pm_1", object: "payment_method", type: "card" }]))
+    );
+    expect(await getOrgCardCountry({}, "cus_test")).toBeNull();
+  });
+
+  it("by-org variant hits the user-less /internal route with type=card", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pmListBody([{ id: "pm_1", object: "payment_method", type: "card", card: { country: "US" } }])
+      )
+    );
+
+    expect(await getOrgCardCountryByOrg("org-123")).toBe("US");
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain("/internal/payment_methods/by-org/org-123");
+    expect(url).toContain("type=card");
+  });
+
+  it("propagates stripe-service errors (fail-loud)", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("boom", { status: 500, headers: { "content-type": "text/plain" } })
+    );
+    await expect(getOrgCardCountry({}, "cus_test")).rejects.toThrow(/failed: 500/);
   });
 });


### PR DESCRIPTION
## What

Disable off_session **auto-reload for India-issued cards** and surface it coherently on the billing account, instead of attempting a charge Stripe declines every cycle.

Prod symptom: India orgs' auto-reload fails with *"You must provide a mandate for off-session card payments made with cards issued in India."*

## Why the original mandate-fix approach was abandoned

Verified against current Stripe docs (2026-06-27) — see **#220** for full evidence. Stripe **does not support India RBI e-mandates via PaymentIntents or SetupIntents** (only via Subscriptions). billing-service's wallet = SetupIntent capture + raw off_session PaymentIntent reload → **no Stripe-supported path** to register the mandate. Adding `payment_method_options.card.mandate_options` would either be rejected by Checkout (global card-capture regression) or accepted-but-inert (no real fix). So the fix is to stop promising a feature that physically can't work for these cards.

## Approach (forward-only, no stripe-service change)

`card.country` is **already on the wire** — stripe-service passes the Stripe PaymentMethod object through verbatim. billing just reads it now.

- **stripe-service-client**: type `card.country`; add `AUTO_RELOAD_BLOCKED_CARD_COUNTRIES = {IN}`, `isAutoReloadBlockedCountry()`, `getOrgCardCountry` (real-user) + `getOrgCardCountryByOrg` (balance path).
- **GET /v1/accounts**: new fields `auto_reload_supported`, `auto_reload_unsupported_reason`, `card_country`. `has_auto_topup` is forced false when unsupported (a stored config would never fire) → dashboard stays coherent.
- **PATCH /v1/accounts/auto_topup**: reject (400, fail-loud) enabling auto-topup on a blocked-country card.
- **authorize + usage_apply**: skip the reload trigger for blocked-country cards → fall through to depletion dunning (prompts manual recharge). Keeps UI "deactivated" and backend behaviour in sync (no self-contradictory surface).

## Country scope

**India only.** EEA is excluded — its mandate is satisfied by `setup_future_usage` + SCA on save, which the existing Checkout flow already does (EU orgs auto-reload fine today). Mexico / Brazil are listed by Stripe as agreement-requiring but the mechanism is unconfirmed and there's zero prod evidence — blocking them prematurely would break orgs that may work. The set is one const, trivially extendable if a decline is confirmed.

## Out of scope / follow-ups

- **Dashboard (distribute.you)**: render the disabled auto-reload section + (i) notice from `auto_reload_supported` / `card_country`. Drives the actual user-visible message. Copy will pass through the humanizer.
- **"Re-add your card" prompt** for currently-affected India orgs (forward-only fix can't retrofit already-saved cards).
- **Subscription billing** for India (the only path to true auto-debit) — separate product decision; even then it's 26h-delayed + ≤~$180/charge, so manual top-up remains the recommended India path.

## Verify

- `tsc --noEmit` clean; `pnpm test` → **242 passing** (new: India cases for GET accounts, PATCH gate, authorize, usage_apply; unit tests for `isAutoReloadBlockedCountry` + `getOrgCardCountry`).
- No stripe-service change. Additive response fields only.

Closes #220 (documents + ships the real fix).
