### PR TITLE
hotfix: Add user-less internal GET /internal/accounts/by-org/:orgId/balance for platform fleet reads

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2604,6 +2604,73 @@
         }
       }
     },
+    "/internal/accounts/by-org/{orgId}/balance": {
+      "get": {
+        "summary": "User-less spendable balance for an org (platform/fleet reads)",
+        "description": "Same spendable-balance snapshot as GET /v1/accounts/balance (balance_cents = credited − committed usage; actual_balance_cents = credited − actualized usage; depleted = balance_cents <= 0), but keyed by the orgId PATH param and callable with the service x-api-key ONLY — no x-org-id / x-user-id / x-run-id, no sentinel identity. For platform/staff fleet aggregators (accounts audit, send-forecast) that have no end-user in context. Pure read: no auto-reload, no depletion mutation. 404 when the org has no billing account; 502 when stripe-service/runs-service is unreachable.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "orgId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balance info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BalanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "orgId is not a valid UUID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Billing account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "stripe-service or runs-service unavailable (balance compose failed)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/internal/brands/{brandId}/daily-budget": {
       "get": {
         "summary": "Read this org's current daily budget for a brand",

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -20,7 +20,8 @@ import {
 import { runDunningTick } from "../lib/dunning.js";
 import { getCampaignAuthorizeCost } from "../lib/campaign-costs.js";
 import { computeBalance } from "../lib/balance.js";
-import { gte as gteCents } from "../lib/cents.js";
+import { fetchRunsOrgActualUsageTotal } from "../lib/runs-client.js";
+import { gte as gteCents, isDepleted, subCents } from "../lib/cents.js";
 
 const router = Router();
 
@@ -314,6 +315,60 @@ router.get("/internal/campaigns/:campaignId/affordability", async (req, res) => 
     balanceCents: snapshot.balanceCents,
     lastRequiredCents,
     hasHistory: true,
+  });
+});
+
+// GET /internal/accounts/by-org/:orgId/balance
+//
+// User-less spendable-balance read for platform/staff fleet aggregators
+// (features-service accounts audit + fleet send-forecast) that need an org's
+// balance without a real end-user in context. Mirrors GET /v1/accounts/balance
+// (same response shape + field names + semantics) but keyed by the orgId PATH
+// param and guarded by requireApiKey only — no x-org-id / x-user-id / x-run-id
+// headers, no sentinel identity.
+//
+// Pure read: computeBalance (user-less /internal/*/by-org/{orgId} stripe reads +
+// runs-service org-usage) — NO auto-reload, NO depletion-episode mutation, no
+// side effects. 404 when the org has no billing account (same as /v1). Fail-loud
+// 502 when stripe-service / runs-service is unreachable.
+router.get("/internal/accounts/by-org/:orgId/balance", async (req, res) => {
+  const { orgId } = req.params;
+  if (!UUID_RE.test(orgId)) {
+    res.status(400).json({ error: "orgId must be a valid UUID" });
+    return;
+  }
+
+  const [account] = await db
+    .select({ id: billingAccounts.id })
+    .from(billingAccounts)
+    .where(eq(billingAccounts.orgId, orgId))
+    .limit(1);
+
+  if (!account) {
+    res.status(404).json({ error: "Billing account not found" });
+    return;
+  }
+
+  let snapshot;
+  let actualUsage;
+  try {
+    [snapshot, actualUsage] = await Promise.all([
+      computeBalance(orgId),
+      fetchRunsOrgActualUsageTotal(orgId, {}),
+    ]);
+  } catch (err) {
+    console.error(
+      `[billing-service] internal balance-by-org: compose failed for org ${orgId}:`,
+      err
+    );
+    res.status(502).json({ error: "Failed to compute balance" });
+    return;
+  }
+
+  res.json({
+    balance_cents: snapshot.balanceCents,
+    actual_balance_cents: subCents(snapshot.creditedCents, actualUsage.spent_cents),
+    depleted: isDepleted(snapshot.balanceCents),
   });
 });
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1031,6 +1031,42 @@ registry.registerPath({
 
 registry.registerPath({
   method: "get",
+  path: "/internal/accounts/by-org/{orgId}/balance",
+  summary: "User-less spendable balance for an org (platform/fleet reads)",
+  description:
+    "Same spendable-balance snapshot as GET /v1/accounts/balance (balance_cents = " +
+    "credited − committed usage; actual_balance_cents = credited − actualized usage; " +
+    "depleted = balance_cents <= 0), but keyed by the orgId PATH param and callable " +
+    "with the service x-api-key ONLY — no x-org-id / x-user-id / x-run-id, no sentinel " +
+    "identity. For platform/staff fleet aggregators (accounts audit, send-forecast) that " +
+    "have no end-user in context. Pure read: no auto-reload, no depletion mutation. " +
+    "404 when the org has no billing account; 502 when stripe-service/runs-service is unreachable.",
+  request: {
+    headers: internalHeaders,
+    params: z.object({ orgId: z.string().uuid() }),
+  },
+  responses: {
+    200: {
+      description: "Balance info",
+      content: { "application/json": { schema: BalanceResponseSchema } },
+    },
+    400: {
+      description: "orgId is not a valid UUID",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    404: {
+      description: "Billing account not found",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "stripe-service or runs-service unavailable (balance compose failed)",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
   path: "/internal/brands/{brandId}/daily-budget",
   summary: "Read this org's current daily budget for a brand",
   description:

--- a/tests/integration/internal-balance-by-org.test.ts
+++ b/tests/integration/internal-balance-by-org.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { createTestApp } from "../helpers/test-app.js";
+import {
+  cleanTestData,
+  insertTestAccount,
+  closeDb,
+} from "../helpers/test-db.js";
+import { setupStripeMocks, customerWithEmail } from "../helpers/mock-stripe.js";
+
+const orgId = "00000000-0000-0000-0000-00000000b101";
+const unknownOrgId = "00000000-0000-0000-0000-00000000b999";
+
+const apiKeyHeaders = { "X-API-Key": "test-api-key" };
+
+function balancePath(id: string) {
+  return `/internal/accounts/by-org/${id}/balance`;
+}
+
+describe("GET /internal/accounts/by-org/:orgId/balance (user-less balance read)", () => {
+  const app = createTestApp();
+  let ssMocks: ReturnType<typeof setupStripeMocks>;
+  let setUsage: (cents: string) => void;
+  let setActualUsage: (cents: string) => void;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    ssMocks = setupStripeMocks();
+    ssMocks.fetchOrgCustomer.mockResolvedValue(customerWithEmail("founder@acme.test"));
+    await cleanTestData();
+
+    const runsClient = await import("../../src/lib/runs-client.js");
+    let usage = "0.0000000000";
+    let actualUsage = "0.0000000000";
+    setUsage = (cents: string) => {
+      usage = cents;
+    };
+    setActualUsage = (cents: string) => {
+      actualUsage = cents;
+    };
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(async () => ({
+      org_id: orgId,
+      spent_cents: usage,
+      as_of: "2026-07-01T00:00:00.000Z",
+    }));
+    vi.spyOn(runsClient, "fetchRunsOrgActualUsageTotal").mockImplementation(async () => ({
+      spent_cents: actualUsage,
+    }));
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("404 when the org has no billing account (no side effects)", async () => {
+    const res = await request(app).get(balancePath(unknownOrgId)).set(apiKeyHeaders);
+
+    expect(res.status).toBe(404);
+    // Pure read: no balance compose for a non-existent account.
+    expect(ssMocks.fetchOrgCustomer).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("200 with same shape as /v1/accounts/balance (credited − usage)", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("100.0000000000");
+    setUsage("40.0000000000"); // balance = 100 − 40 = 60
+    setActualUsage("30.0000000000"); // actual balance = 100 − 30 = 70
+
+    const res = await request(app).get(balancePath(orgId)).set(apiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      balance_cents: "60.0000000000",
+      actual_balance_cents: "70.0000000000",
+      depleted: false,
+    });
+    // User-less balance path: keyed off orgId ONLY (no x-user-id / sentinel).
+    expect(ssMocks.fetchOrgCustomer).toHaveBeenCalledWith(orgId);
+    // Pure read: never reloads.
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("depleted=true when spendable balance <= 0", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("10.0000000000");
+    setUsage("50.0000000000"); // balance = 10 − 50 = −40
+    setActualUsage("50.0000000000");
+
+    const res = await request(app).get(balancePath(orgId)).set(apiKeyHeaders);
+
+    expect(res.status).toBe(200);
+    expect(res.body.balance_cents).toBe("-40.0000000000");
+    expect(res.body.depleted).toBe(true);
+  });
+
+  it("fails loud (502) when runs-service is unreachable", async () => {
+    await insertTestAccount({ orgId });
+    const runsClient = await import("../../src/lib/runs-client.js");
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockRejectedValue(
+      new Error("runs-service down")
+    );
+
+    const res = await request(app).get(balancePath(orgId)).set(apiKeyHeaders);
+
+    expect(res.status).toBe(502);
+  });
+
+  it("rejects a non-UUID orgId with 400", async () => {
+    const res = await request(app).get(balancePath("not-a-uuid")).set(apiKeyHeaders);
+    expect(res.status).toBe(400);
+  });
+
+  it("requires service auth (401 without x-api-key)", async () => {
+    const res = await request(app).get(balancePath(orgId));
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
Automated by release.sh