### PR TITLE
feat(billing): threshold-based postpaid top-up (charge on credit-line crossing, not daily)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,18 @@ The same CSV convention applies to the `x-brand-id` header forwarded by workflow
 - `AUTO_RELOAD_BLOCKED_CARD_COUNTRIES` + `isAutoReloadBlockedCountry()` + `getOrgCardCountry` (real-user) / `getOrgCardCountryByOrg` (balance path) live in `src/lib/stripe-service-client.ts`. **Blocklist = `{ IN }` only.** EEA is deliberately NOT blocked (its mandate is satisfied by `setup_future_usage` + SCA on the initial Checkout save, which already works — EU orgs auto-reload fine). Mexico / Brazil are listed by Stripe as agreement-requiring but the mechanism is unconfirmed and there is zero prod evidence — left out to avoid blocking orgs that may work. Extend the set ONLY when a decline is confirmed in prod.
 - Enforced in BOTH reload paths so the UI "deactivated" state never contradicts backend behavior: `customer_balance/authorize` gates on `snapshot.autoReloadSupported` (from `computeBalance`), `usage_apply` checks `getOrgCardCountry` — both **skip the reload** for a blocked country and fall through to depletion dunning (which prompts manual recharge). `PATCH /v1/accounts/auto_topup` rejects a blocked-country card (400, fail-loud) rather than storing config that never fires. `GET /v1/accounts` exposes `auto_reload_supported` / `auto_reload_unsupported_reason` / `card_country`, and forces `has_auto_topup=false` when unsupported.
 
+## Threshold-based postpaid top-up (Google/Meta-Ads cadence)
+
+Auto-topup is **postpaid on a derived tier ladder**, not a fixed daily charge. The balance is allowed to run NEGATIVE down to a credit-line floor; a fixed reload fires only when spend crosses that floor — so a $32/day org is charged ~every 1.5 days, not daily.
+
+- **Derived tier** (`src/lib/topup-tier.ts`, `tierFor(cumulativePaidCents)`): pure function of the org's cumulative **succeeded topups** (the same `sumSucceededTopupsForOrg` / `sumSucceededTopupsForCustomer` sum already computed — NOT credited, promos excluded). Returns `{ thresholdCents (NEGATIVE floor), amountCents }`, magnitudes equal so one charge clears one crossed line. Ladder: `≥ $1000 paid → {-50000, 50000}` ($500 line); `≥ $200 → {-20000, 20000}`; else `{-5000, 5000}` ($50 start line). The line grows with trust. **No storage** — derived every read.
+- **Stored `billing_accounts.topup_amount_cents` / `topup_threshold_cents` are ONLY the "auto-topup enabled" flag** (non-null ⇒ enabled). The effective `(amount, threshold)` come from `tierFor()` EVERYWHERE — reload math in `authorize` + `usage_apply`, and the account-read response. The `PATCH/wallet_setup` request schema is unchanged (still `min(0)`); the negative threshold is derived + returned, never written through the route.
+- **`authorize` (true postpaid):** sufficient (no reload) when `balance − required >= threshold` (floor). Below it, reload multiples of the tier `amount` toward `threshold + required`, then recheck against the floor. Orgs that can't be reloaded (no config / no card / blocked country) have **no credit line → floor `"0"`** (strictly prepaid) — the sufficiency + dunning gates behave as pre-postpaid for them.
+- **`usage_apply`:** reload when `balance < threshold` (negative floor), charging tier `amount` multiples toward the floor.
+- **Dunning gate is threshold-aware** (`src/lib/cents.ts` `isDepleted(a, threshold="0")`, 2-arg): a depletion episode / T0 email opens ONLY when `balance <= threshold` (past the floor), NEVER on a normal negative balance within the line. `openDepletionEpisodeIfDepleted` takes `thresholdCents` (the derived floor for reload-capable orgs, `"0"` otherwise). This is also the structural root-fix for #170 (the balance-flutter duplicate-email bug): an enabled org running at ~0 never reaches the depletion path until it genuinely blows past the negative floor. The `credited`-rising recovery logic is unchanged; the dunning-tick follow-up gate stays at floor `"0"` (still-in-the-red check).
+- Credit exposure is bounded by `|threshold|` of the current tier plus one run's overshoot.
+- Onboarding / initial wallet-setup checkout is unchanged (seeds a positive buffer, lowers risk). The month-end forced-charge is a separate follow-up, not built here.
+
 ## Public surface field names
 
 ### `GET /v1/accounts` and `PATCH/DELETE /v1/accounts/auto_topup`
@@ -129,8 +141,8 @@ The same CSV convention applies to the `x-brand-id` header forwarded by workflow
   "usage_cents": "38289.2958000000",         // runs-service spent_cents (platform actual+provisioned)
   "balance_cents": "16910.7042000000",       // credited_cents − usage_cents; USE THIS for depletion/budget gates
   "actual_balance_cents": "16920.7042000000", // credited_cents − actualized usage only; display this as the user's credit balance
-  "topup_amount_cents": 2500,                // auto-topup amount
-  "topup_threshold_cents": 500,              // auto-topup triggers when balance_cents < threshold
+  "topup_amount_cents": 5000,                // DERIVED tier reload amount (tierFor(cumulative paid)); null when auto-topup disabled. NOT the stored daily amount.
+  "topup_threshold_cents": -5000,            // DERIVED tier NEGATIVE credit-line floor; auto-topup reloads when balance crosses it. null when disabled. See "Threshold-based postpaid top-up"
   "has_payment_method": true,                // ≥1 chargeable PM: card OR link (GET /v1/payment_methods?type=card, then type=link); NOT invoice_settings.default_payment_method
   "has_auto_topup": true,                     // false when auto_reload_supported is false, even if topup config exists (it would never fire)
   "auto_reload_supported": true,             // false when the saved card's issuing country can't be charged off_session (e.g. India). See "Off_session auto-reload" below

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -28,6 +28,12 @@ export interface BalanceSnapshot {
    * India / RBI). The reload trigger skips these cards — see customer_balance authorize.
    */
   autoReloadSupported: boolean;
+  /**
+   * Paid succeeded topups only (excludes promos) — the cumulative-paid signal
+   * that drives the derived postpaid tier (see lib/topup-tier). Distinct from
+   * creditedCents, which also includes local promo grants.
+   */
+  paidTopupsCents: string;
   creditedCents: string;
   usageCents: string;
   balanceCents: string;
@@ -59,6 +65,7 @@ export async function computeBalance(orgId: string): Promise<BalanceSnapshot> {
     hasCardPm,
     cardCountry,
     autoReloadSupported: !isAutoReloadBlockedCountry(cardCountry),
+    paidTopupsCents: paidTopups,
     creditedCents,
     usageCents: runsUsage.spent_cents,
     balanceCents,

--- a/src/lib/cents.ts
+++ b/src/lib/cents.ts
@@ -90,9 +90,16 @@ export function cmpCents(a: string, b: string): -1 | 0 | 1 {
   return new Decimal(a).comparedTo(b) as -1 | 0 | 1;
 }
 
-/** True if value <= 0 (depleted check). */
-export function isDepleted(a: string): boolean {
-  return new Decimal(a).lessThanOrEqualTo(0);
+/**
+ * True if `a` is at or below the depletion floor `threshold`.
+ *
+ * In the threshold-based postpaid model the floor is the tier's NEGATIVE credit
+ * line (balance may legitimately go negative down to it). Default threshold "0"
+ * preserves the legacy strictly-prepaid check (balance <= 0) for callers that
+ * have no credit line (the `/balance` shortcut, prepaid orgs).
+ */
+export function isDepleted(a: string, threshold: string = "0"): boolean {
+  return new Decimal(a).lessThanOrEqualTo(threshold);
 }
 
 /** True if a >= b. */

--- a/src/lib/dunning.ts
+++ b/src/lib/dunning.ts
@@ -74,6 +74,13 @@ export interface OpenEpisodeParams {
   runId: string;
   /** Balance snapshot at the failing authorize. */
   balanceCents: string;
+  /**
+   * Depletion floor (the derived postpaid tier's NEGATIVE credit line, or "0"
+   * for prepaid orgs with no auto-reload). An episode opens ONLY when the
+   * balance is at/below this floor — a normal negative balance WITHIN the line
+   * never triggers a T0 email. Defaults to "0" (legacy strictly-prepaid gate).
+   */
+  thresholdCents?: string;
   /** Credited snapshot at the failing authorize — the recovery baseline. */
   creditedCents: string;
   /** Parsed workflow headers — gates the open on campaign activity. */
@@ -98,7 +105,7 @@ export interface OpenEpisodeParams {
 export async function openDepletionEpisodeIfDepleted(
   params: OpenEpisodeParams
 ): Promise<{ opened: boolean }> {
-  if (!isDepleted(params.balanceCents)) return { opened: false };
+  if (!isDepleted(params.balanceCents, params.thresholdCents ?? "0")) return { opened: false };
   if (!hasCampaignActivity(params.workflow)) return { opened: false };
 
   // The partial unique index `(org_id) WHERE recovered_at IS NULL` is the

--- a/src/lib/topup-tier.ts
+++ b/src/lib/topup-tier.ts
@@ -1,0 +1,49 @@
+import { Decimal } from "decimal.js";
+
+/**
+ * Threshold-based postpaid top-up tiers (Google/Meta-Ads billing cadence).
+ *
+ * Instead of charging a fixed daily amount, the org's balance is allowed to go
+ * NEGATIVE down to a credit-line floor (`thresholdCents`, negative). A reload of
+ * the fixed `amountCents` fires only when spend crosses that floor — so a
+ * $32/day org is charged ~every 1.5 days, not daily. The magnitudes are equal
+ * (|threshold| === amount) so exactly one charge clears one crossed line.
+ *
+ * The tier is DERIVED (no storage) from the org's cumulative succeeded topups —
+ * the SAME "paid topups" sum the balance path already computes. The credit line
+ * grows with trust: the more an org has already paid, the larger its line.
+ *
+ * The stored billing_accounts.topup_amount_cents / topup_threshold_cents columns
+ * are used ONLY as the "auto-topup enabled" flag (non-null ⇒ enabled). The
+ * effective (amount, threshold) come from tierFor().
+ */
+export interface TopupTier {
+  /**
+   * NEGATIVE credit-line floor, integer cents. The balance may run this far
+   * below zero before a top-up charge fires (true postpaid).
+   */
+  thresholdCents: number;
+  /** Fixed reload amount, integer cents. Magnitude equals |thresholdCents|. */
+  amountCents: number;
+}
+
+// Cumulative-paid breakpoints (integer cents).
+const TIER_HIGH_MIN = 100000; // $1000 paid → $500 line
+const TIER_MID_MIN = 20000; //   $200 paid  → $200 line
+
+/**
+ * Resolve the postpaid tier for an org from its cumulative succeeded topups.
+ *
+ * @param cumulativePaidCents decimal-cents string (numeric(16,10)) — the paid
+ *   topups sum (`sumSucceededTopupsForOrg` / `sumSucceededTopupsForCustomer`).
+ */
+export function tierFor(cumulativePaidCents: string): TopupTier {
+  const paid = new Decimal(cumulativePaidCents);
+  if (paid.greaterThanOrEqualTo(TIER_HIGH_MIN)) {
+    return { thresholdCents: -50000, amountCents: 50000 };
+  }
+  if (paid.greaterThanOrEqualTo(TIER_MID_MIN)) {
+    return { thresholdCents: -20000, amountCents: 20000 };
+  }
+  return { thresholdCents: -5000, amountCents: 5000 };
+}

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -7,6 +7,7 @@ import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from ".
 import { UpdateAutoTopupRequestSchema, WalletSetupRequestSchema } from "../schemas.js";
 import { findOrCreateAccount, findOrCreateWalletAccount } from "../lib/account.js";
 import { addCents, isDepleted, subCents } from "../lib/cents.js";
+import { tierFor } from "../lib/topup-tier.js";
 import { fetchRunsOrgActualUsageTotal, fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
 import { grantFirstLoadMatch, sumLocalPromoCreditsForOrg } from "../lib/promos.js";
 import { reloadViaPaymentIntent } from "../lib/reload.js";
@@ -45,6 +46,7 @@ async function composeAccountFunds(
   usageCents: string;
   balanceCents: string;
   actualBalanceCents: string;
+  paidTopupsCents: string;
   hasPaymentMethod: boolean;
   cardCountry: string | null;
   autoReloadSupported: boolean;
@@ -66,6 +68,7 @@ async function composeAccountFunds(
     usageCents: runsUsage.spent_cents,
     balanceCents,
     actualBalanceCents,
+    paidTopupsCents: paidTopups,
     hasPaymentMethod: hasCardPm,
     cardCountry,
     autoReloadSupported: !isAutoReloadBlockedCountry(cardCountry),
@@ -79,11 +82,20 @@ function buildAccountResponse(
     usageCents: string;
     balanceCents: string;
     actualBalanceCents: string;
+    paidTopupsCents: string;
     hasPaymentMethod: boolean;
     cardCountry: string | null;
     autoReloadSupported: boolean;
   }
 ) {
+  // Auto-topup is enabled iff the stored columns are non-null (they are the
+  // enabled flag). When enabled, the effective (amount, threshold) are the
+  // DERIVED postpaid tier (a function of cumulative paid topups) — the negative
+  // threshold is the credit-line floor the dashboard renders. When disabled,
+  // both fields are null (no top-up). See lib/topup-tier.
+  const enabled =
+    account.topupAmountCents != null && account.topupThresholdCents != null;
+  const tier = enabled ? tierFor(funds.paidTopupsCents) : null;
   return {
     id: account.id,
     org_id: account.orgId,
@@ -91,8 +103,8 @@ function buildAccountResponse(
     usage_cents: funds.usageCents,
     balance_cents: funds.balanceCents,
     actual_balance_cents: funds.actualBalanceCents,
-    topup_amount_cents: account.topupAmountCents,
-    topup_threshold_cents: account.topupThresholdCents,
+    topup_amount_cents: tier ? tier.amountCents : null,
+    topup_threshold_cents: tier ? tier.thresholdCents : null,
     has_payment_method: funds.hasPaymentMethod,
     // Off_session auto-reload is impossible for cards issued in mandate-required countries
     // (e.g. India / RBI, issue #220). When unsupported, the dashboard shows a notice and

--- a/src/routes/customer_balance.ts
+++ b/src/routes/customer_balance.ts
@@ -17,6 +17,7 @@ import {
   isAutoReloadBlockedCountry,
 } from "../lib/stripe-service-client.js";
 import { computeBalance } from "../lib/balance.js";
+import { tierFor } from "../lib/topup-tier.js";
 import { upsertCampaignAuthorizeCost } from "../lib/campaign-costs.js";
 import { openDepletionEpisodeIfDepleted } from "../lib/dunning.js";
 import { reloadViaPaymentIntent } from "../lib/reload.js";
@@ -115,8 +116,22 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
       return;
     }
 
-    if (gteCents(snapshot.balanceCents, requiredCents)) {
-      traceEvent(runId, { service: "billing-service", event: "customer_balance.authorize.done", data: { sufficient: true, balance_cents: snapshot.balanceCents, required_cents: requiredCents } }, req.headers);
+    // Threshold-based postpaid: the account is allowed to run NEGATIVE down to a
+    // credit-line floor. The effective (amount, threshold) come from the derived
+    // tier (a function of cumulative paid topups) — the stored columns are only
+    // the "auto-topup enabled" flag. Orgs that can't be reloaded (no config, no
+    // card, or a blocked issuing country) have no credit line → floor "0"
+    // (strictly prepaid), so the sufficiency + dunning gates behave as before.
+    const canReload =
+      account.topupAmountCents != null && snapshot.hasCardPm && snapshot.autoReloadSupported;
+    const tier = canReload ? tierFor(snapshot.paidTopupsCents) : null;
+    const thresholdCents = tier ? String(tier.thresholdCents) : "0";
+
+    // Sufficient (no reload) when running this cost keeps the balance at/above
+    // the floor: balance − required >= threshold. A negative balance still
+    // within the credit line reads sufficient and runs on credit.
+    if (gteCents(subCents(snapshot.balanceCents, requiredCents), thresholdCents)) {
+      traceEvent(runId, { service: "billing-service", event: "customer_balance.authorize.done", data: { sufficient: true, balance_cents: snapshot.balanceCents, required_cents: requiredCents, threshold_cents: thresholdCents } }, req.headers);
       res.json({
         sufficient: true,
         balance_cents: snapshot.balanceCents,
@@ -129,6 +144,7 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
       await openDepletionEpisodeIfDepleted({
         orgId, userId, runId,
         balanceCents: snapshot.balanceCents,
+        thresholdCents,
         creditedCents: snapshot.creditedCents,
         workflow: wf,
         workflowHeaders: wfHeaders,
@@ -148,6 +164,7 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
       await openDepletionEpisodeIfDepleted({
         orgId, userId, runId,
         balanceCents: snapshot.balanceCents,
+        thresholdCents,
         creditedCents: snapshot.creditedCents,
         workflow: wf,
         workflowHeaders: wfHeaders,
@@ -169,6 +186,7 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
       await openDepletionEpisodeIfDepleted({
         orgId, userId, runId,
         balanceCents: snapshot.balanceCents,
+        thresholdCents,
         creditedCents: snapshot.creditedCents,
         workflow: wf,
         workflowHeaders: wfHeaders,
@@ -184,11 +202,17 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
       return;
     }
 
-    const chargeAmount = computeTopupCharge(snapshot.balanceCents, requiredCents, account.topupAmountCents);
+    // canReload is true here → tier is non-null. Reload enough tier-amount
+    // multiples to bring the balance up to (threshold + required) so the run
+    // clears WITH the floor headroom preserved. Charge uses the tier amount, not
+    // the stored daily amount.
+    const targetCents = addCents(thresholdCents, requiredCents);
+    const chargeAmount = computeTopupCharge(snapshot.balanceCents, targetCents, tier!.amountCents);
     if (chargeAmount <= 0) {
       await openDepletionEpisodeIfDepleted({
         orgId, userId, runId,
         balanceCents: snapshot.balanceCents,
+        thresholdCents,
         creditedCents: snapshot.creditedCents,
         workflow: wf,
         workflowHeaders: wfHeaders,
@@ -225,6 +249,7 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
       await openDepletionEpisodeIfDepleted({
         orgId, userId, runId,
         balanceCents: snapshot.balanceCents,
+        thresholdCents,
         creditedCents: snapshot.creditedCents,
         workflow: wf,
         workflowHeaders: wfHeaders,
@@ -248,11 +273,12 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
       return;
     }
 
-    const sufficient = gteCents(after.balanceCents, requiredCents);
+    const sufficient = gteCents(subCents(after.balanceCents, requiredCents), thresholdCents);
     if (!sufficient) {
       await openDepletionEpisodeIfDepleted({
         orgId, userId, runId,
         balanceCents: after.balanceCents,
+        thresholdCents,
         creditedCents: after.creditedCents,
         workflow: wf,
         workflowHeaders: wfHeaders,
@@ -329,7 +355,13 @@ router.post("/v1/customer_balance/usage_apply", requireOrgHeaders, async (req, r
 
     const creditedCents = addCents(paidTopups, localCredits);
     const balanceCents = subCents(creditedCents, spentTotalCents);
-    const thresholdCents = String(account.topupThresholdCents);
+
+    // Threshold-based postpaid: the effective (amount, threshold) come from the
+    // derived tier (a function of cumulative paid topups), NOT the stored daily
+    // columns. The floor is NEGATIVE, so a reload only fires once spend crosses
+    // the credit line — not every day.
+    const tier = tierFor(paidTopups);
+    const thresholdCents = String(tier.thresholdCents);
 
     if (gteCents(balanceCents, thresholdCents)) {
       traceEvent(runId, { service: "billing-service", event: "customer_balance.usage_apply.no-topup", data: { balance_cents: balanceCents, threshold_cents: thresholdCents } }, req.headers);
@@ -337,7 +369,7 @@ router.post("/v1/customer_balance/usage_apply", requireOrgHeaders, async (req, r
       return;
     }
 
-    const chargeAmount = computeTopupCharge(balanceCents, thresholdCents, account.topupAmountCents);
+    const chargeAmount = computeTopupCharge(balanceCents, thresholdCents, tier.amountCents);
     if (chargeAmount <= 0) {
       res.status(202).json({ acknowledged: true, topup_triggered: false });
       return;

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -174,6 +174,33 @@ describe("Accounts endpoints", () => {
       expect(res.body.has_auto_topup).toBe(false);
     });
 
+    it("enabled account surfaces the DERIVED tier scaled to cumulative paid ($1000 → $500 line)", async () => {
+      await insertTestAccount({ orgId, topupAmountCents: 1000, topupThresholdCents: 200 });
+      // Cumulative paid $1000 → high tier {amount 50000, threshold -50000}.
+      ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("100000.0000000000");
+
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set(getAuthHeaders(orgId));
+
+      expect(res.status).toBe(200);
+      expect(res.body.topup_amount_cents).toBe(50000);
+      expect(res.body.topup_threshold_cents).toBe(-50000);
+    });
+
+    it("disabled account (no topup config) → topup amount/threshold null", async () => {
+      await insertTestAccount({ orgId }); // topupAmountCents null
+      ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("100000.0000000000");
+
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set(getAuthHeaders(orgId));
+
+      expect(res.status).toBe(200);
+      expect(res.body.topup_amount_cents).toBeNull();
+      expect(res.body.topup_threshold_cents).toBeNull();
+    });
+
     it("credited reflects only succeeded payment intents (failed PIs excluded)", async () => {
       await insertTestAccount({ orgId });
       // Helper already filters succeeded — assert by configuring its return.
@@ -310,18 +337,21 @@ describe("Accounts endpoints", () => {
   });
 
   describe("PATCH /v1/accounts/auto_topup", () => {
-    it("enables auto-topup when SS reports payment method present", async () => {
+    it("enables auto-topup; response returns the DERIVED tier, not the posted daily amount", async () => {
       await insertTestAccount({ orgId });
       ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+      // Posted daily amount/threshold are now only the enabled flag. Cumulative
+      // paid = 0 → start tier {amount 5000, threshold -5000} (negative floor).
+      ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
 
       const res = await request(app)
         .patch("/v1/accounts/auto_topup")
         .set(getAuthHeaders(orgId))
-        .send({ topup_amount_cents: 5000, topup_threshold_cents: 1000 });
+        .send({ topup_amount_cents: 1234, topup_threshold_cents: 999 });
 
       expect(res.status).toBe(200);
       expect(res.body.topup_amount_cents).toBe(5000);
-      expect(res.body.topup_threshold_cents).toBe(1000);
+      expect(res.body.topup_threshold_cents).toBe(-5000);
       expect(res.body.has_auto_topup).toBe(true);
     });
 
@@ -395,8 +425,11 @@ describe("Accounts endpoints", () => {
           });
 
         expect(res.status).toBe(200);
-        expect(res.body.topup_amount_cents).toBe(3000);
-        expect(res.body.topup_threshold_cents).toBe(700);
+        // Posted daily amount/threshold (3000/700) are only the enabled flag;
+        // the response returns the derived tier. These loads (≤ $50) all resolve
+        // to the start tier → amount 5000, threshold -5000.
+        expect(res.body.topup_amount_cents).toBe(5000);
+        expect(res.body.topup_threshold_cents).toBe(-5000);
         expect(res.body.has_auto_topup).toBe(true);
         expect(res.body.first_load_match_applied).toBe(true);
         expect(res.body.first_load_match_cents).toBe(expectedBonus);

--- a/tests/integration/authorize-runs-total.test.ts
+++ b/tests/integration/authorize-runs-total.test.ts
@@ -86,12 +86,43 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
   });
 
-  it("insufficient + topup configured + SS has PM → calls reload and re-evaluates", async () => {
+  it("negative balance still within the credit line → sufficient:true, NO reload (postpaid)", async () => {
+    // Cumulative paid 0 → start tier {amount 5000, threshold -5000}. usage 4000,
+    // paid 0 → balance -4000. required 10 → -4010 still >= -5000 floor → runs on credit.
+    await insertTestAccount({ orgId, topupAmountCents: 1000 });
+    ssMocks.fetchOrgCustomer.mockResolvedValue(customerWithDefaultPM());
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "4000.0000000000",
+      as_of: "x",
+    });
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(getAuthHeaders(orgId, userId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sufficient).toBe(true);
+    expect(res.body.balance_cents).toBe("-4000.0000000000");
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("crossing the floor → reloads the TIER amount (not the stored daily amount) and re-evaluates", async () => {
+    // Stored daily amount is 1000, but the reload charge must be the derived tier
+    // amount (5000 at start tier). usage 5000, paid 0 → balance -5000; required 10
+    // → -5010 < -5000 floor → reload one tier unit (5000).
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
     ssMocks.fetchOrgCustomer.mockResolvedValue(customerWithDefaultPM());
     ssMocks.sumSucceededTopupsForOrg
       .mockResolvedValueOnce("0.0000000000")
-      .mockResolvedValueOnce("1000.0000000000");
+      .mockResolvedValueOnce("5000.0000000000");
+    fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "5000.0000000000",
+      as_of: "x",
+    });
 
     const res = await request(app)
       .post("/v1/customer_balance/authorize")
@@ -101,18 +132,48 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(true);
     expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
-    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(1000);
+    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(5000);
   });
 
-  it("insufficient + topup + card attached but no default PM → fires reload (regression)", async () => {
+  it("tier scales with cumulative paid: $200-tier org crossing floor reloads $200", async () => {
+    // Cumulative paid 20000 ($200) → mid tier {amount 20000, threshold -20000}.
+    // usage 40000, paid 20000 → balance -20000; required 10 → -20010 < -20000 → reload 20000.
+    await insertTestAccount({ orgId, topupAmountCents: 1000 });
+    ssMocks.fetchOrgCustomer.mockResolvedValue(customerWithDefaultPM());
+    ssMocks.sumSucceededTopupsForOrg
+      .mockResolvedValueOnce("20000.0000000000")
+      .mockResolvedValueOnce("40000.0000000000");
+    fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "40000.0000000000",
+      as_of: "x",
+    });
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(getAuthHeaders(orgId, userId))
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sufficient).toBe(true);
+    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(20000);
+  });
+
+  it("crossing the floor + card attached but no default PM → fires reload (regression)", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
     // Customer has NO default_payment_method, but a card is attached. The gate now
-    // keys on the attached card (hasAttachedCardPm), not invoice_settings.default.
+    // keys on the attached card (hasChargeablePmForOrg), not invoice_settings.default.
     ssMocks.fetchOrgCustomer.mockResolvedValue(customerWithDefaultPM({ invoice_settings: { default_payment_method: null } }));
     ssMocks.hasChargeablePmForOrg.mockResolvedValue(true);
     ssMocks.sumSucceededTopupsForOrg
       .mockResolvedValueOnce("0.0000000000")
-      .mockResolvedValueOnce("1000.0000000000");
+      .mockResolvedValueOnce("5000.0000000000");
+    fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "5000.0000000000",
+      as_of: "x",
+    });
 
     const res = await request(app)
       .post("/v1/customer_balance/authorize")
@@ -122,7 +183,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(true);
     expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
-    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(1000);
+    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(5000);
   });
 
   it("insufficient + topup + no card attached → graceful sufficient:false, no reload", async () => {
@@ -172,10 +233,15 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
   });
 
-  it("reload status=failed → sufficient:false", async () => {
+  it("reload status=failed (past the floor) → sufficient:false", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
     ssMocks.fetchOrgCustomer.mockResolvedValue(customerWithDefaultPM());
     ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "5000.0000000000",
+      as_of: "x",
+    });
     ssMocks.reloadViaPaymentIntent.mockResolvedValue({
       status: "failed",
       failure_reason: "card_declined",
@@ -190,10 +256,15 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     expect(res.body.sufficient).toBe(false);
   });
 
-  it("reload throws (SS down) → 502", async () => {
+  it("reload throws (SS down, past the floor) → 502", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
     ssMocks.fetchOrgCustomer.mockResolvedValue(customerWithDefaultPM());
     ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "5000.0000000000",
+      as_of: "x",
+    });
     ssMocks.reloadViaPaymentIntent.mockRejectedValue(new Error("SS down"));
 
     const res = await request(app)
@@ -208,6 +279,11 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     await insertTestAccount({ orgId, topupAmountCents: 1000 });
     ssMocks.fetchOrgCustomer.mockResolvedValue(customerWithDefaultPM());
     ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+      org_id: orgId,
+      spent_cents: "5000.0000000000",
+      as_of: "x",
+    });
 
     ssMocks.reloadViaPaymentIntent.mockImplementation(
       () =>

--- a/tests/integration/dunning.test.ts
+++ b/tests/integration/dunning.test.ts
@@ -374,6 +374,47 @@ describe("Out-of-credit dunning engine (issue #147)", () => {
     expect(eventTypes).toEqual(["credit-depleted-followup-10d", "credit-depleted-followup-3d"]);
   });
 
+  it("17: auto-topup org negative WITHIN the credit line → sufficient:true, NO episode, NO T0", async () => {
+    // Enabled org (card + config). paid 0 → floor -5000. usage 4000 → balance -4000,
+    // still above the floor → the run proceeds on credit, no depletion, no email.
+    await insertTestAccount({ orgId, topupAmountCents: 5000, topupThresholdCents: 1000 });
+    setBalance("0.0000000000");
+    setUsage("4000.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(campaignHeaders())
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sufficient).toBe(true);
+    expect(await listEpisodes(orgId)).toHaveLength(0);
+    expect(sendEmailSpy).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("18: auto-topup org crosses the floor + reload fails → opens episode, sends T0", async () => {
+    await insertTestAccount({ orgId, topupAmountCents: 5000, topupThresholdCents: 1000 });
+    setBalance("0.0000000000");
+    setUsage("5001.0000000000"); // balance -5001, past the -5000 floor
+    ssMocks.reloadViaPaymentIntent.mockResolvedValue({
+      status: "failed",
+      failure_reason: "card_declined",
+    });
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(campaignHeaders())
+      .send(authorizeBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sufficient).toBe(false);
+    expect(await listEpisodes(orgId)).toHaveLength(1);
+    const t0 = sendEmailSpy.mock.calls.filter((c) => c[0].eventType === "credit-depleted");
+    expect(t0).toHaveLength(1);
+    expect(t0[0][0]).toMatchObject({ recipientEmail: billingEmail });
+  });
+
   it("10: tick endpoint returns a summary over multiple open episodes", async () => {
     setBalance("0.0000000000");
     // window sanity: constants exported for any caller

--- a/tests/integration/usage-apply.test.ts
+++ b/tests/integration/usage-apply.test.ts
@@ -44,23 +44,46 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
     expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
   });
 
-  it("triggers reload when available < threshold and PM present", async () => {
+  it("no reload while the negative balance is within the credit line (postpaid)", async () => {
     await insertTestAccount({
       orgId,
       topupAmountCents: 1000,
       topupThresholdCents: 500,
     });
     ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
-    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("600.0000000000");
+    // paid 0 → start tier floor -5000. spent 4000 → balance -4000, still above floor.
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
 
     const res = await request(app)
       .post("/v1/customer_balance/usage_apply")
       .set(getAuthHeaders(orgId, userId))
-      .send({ spent_total_cents: "200.0000000000" });
+      .send({ spent_total_cents: "4000.0000000000" });
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ acknowledged: true, topup_triggered: false });
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("triggers reload when balance crosses the floor; charges the TIER amount not the stored daily", async () => {
+    await insertTestAccount({
+      orgId,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+    // paid 0 → floor -5000, tier amount 5000. spent 5001 → balance -5001 < -5000 → reload.
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/usage_apply")
+      .set(getAuthHeaders(orgId, userId))
+      .send({ spent_total_cents: "5001.0000000000" });
 
     expect(res.status).toBe(202);
     expect(res.body).toEqual({ acknowledged: true, topup_triggered: true });
     expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+    // Charge is the tier amount (5000), NOT the stored daily topup_amount (1000).
+    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(5000);
   });
 
   it("triggers reload when card attached but no default PM (regression)", async () => {
@@ -72,12 +95,12 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
     // Customer has no default_payment_method, but a card is attached.
     ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM({ invoice_settings: { default_payment_method: null } }));
     ssMocks.hasAttachedCardPm.mockResolvedValue(true);
-    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("600.0000000000");
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
 
     const res = await request(app)
       .post("/v1/customer_balance/usage_apply")
       .set(getAuthHeaders(orgId, userId))
-      .send({ spent_total_cents: "200.0000000000" });
+      .send({ spent_total_cents: "5001.0000000000" });
 
     expect(res.status).toBe(202);
     expect(res.body).toEqual({ acknowledged: true, topup_triggered: true });
@@ -143,7 +166,7 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
       topupThresholdCents: 500,
     });
     ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
-    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("600.0000000000");
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
     ssMocks.reloadViaPaymentIntent.mockResolvedValue({
       status: "failed",
       failure_reason: "decline",
@@ -152,7 +175,7 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
     const res = await request(app)
       .post("/v1/customer_balance/usage_apply")
       .set(getAuthHeaders(orgId, userId))
-      .send({ spent_total_cents: "200.0000000000" });
+      .send({ spent_total_cents: "5001.0000000000" });
 
     expect(res.status).toBe(202);
     expect(res.body).toEqual({ acknowledged: true, topup_triggered: false });

--- a/tests/unit/cents.test.ts
+++ b/tests/unit/cents.test.ts
@@ -97,10 +97,21 @@ describe("addCents / subCents / cmpCents", () => {
     expect(cmpCents("1.5", "1.6")).toBe(-1);
   });
 
-  it("isDepleted true for ≤ 0", () => {
+  it("isDepleted true for ≤ 0 (default threshold 0)", () => {
     expect(isDepleted("0")).toBe(true);
     expect(isDepleted("-0.0001")).toBe(true);
     expect(isDepleted("0.0000000001")).toBe(false);
+  });
+
+  it("isDepleted threshold-aware: depleted only at/below the negative floor", () => {
+    // Within the credit line (above the floor) → NOT depleted.
+    expect(isDepleted("-30", "-5000")).toBe(false);
+    expect(isDepleted("-4999.9999999999", "-5000")).toBe(false);
+    // At or past the floor → depleted.
+    expect(isDepleted("-5000", "-5000")).toBe(true);
+    expect(isDepleted("-5000.0000000001", "-5000")).toBe(true);
+    // A normal positive balance is never depleted against a negative floor.
+    expect(isDepleted("100", "-5000")).toBe(false);
   });
 
   it("gte handles fractions", () => {

--- a/tests/unit/topup-tier.test.ts
+++ b/tests/unit/topup-tier.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { tierFor } from "../../src/lib/topup-tier.js";
+
+describe("tierFor — derived postpaid credit-line tiers", () => {
+  it("start tier below $200 cumulative paid → $50 line", () => {
+    expect(tierFor("0.0000000000")).toEqual({ thresholdCents: -5000, amountCents: 5000 });
+    expect(tierFor("0")).toEqual({ thresholdCents: -5000, amountCents: 5000 });
+    expect(tierFor("19999.9999999999")).toEqual({ thresholdCents: -5000, amountCents: 5000 });
+  });
+
+  it("mid tier at/above $200 cumulative paid → $200 line", () => {
+    expect(tierFor("20000")).toEqual({ thresholdCents: -20000, amountCents: 20000 });
+    expect(tierFor("20000.0000000000")).toEqual({ thresholdCents: -20000, amountCents: 20000 });
+    expect(tierFor("99999.9999999999")).toEqual({ thresholdCents: -20000, amountCents: 20000 });
+  });
+
+  it("high tier at/above $1000 cumulative paid → $500 line", () => {
+    expect(tierFor("100000")).toEqual({ thresholdCents: -50000, amountCents: 50000 });
+    expect(tierFor("100000.0000000000")).toEqual({ thresholdCents: -50000, amountCents: 50000 });
+    expect(tierFor("500000")).toEqual({ thresholdCents: -50000, amountCents: 50000 });
+  });
+
+  it("every tier: threshold is negative and |threshold| equals amount", () => {
+    for (const paid of ["0", "20000", "100000", "1000000"]) {
+      const tier = tierFor(paid);
+      expect(tier.thresholdCents).toBeLessThan(0);
+      expect(Math.abs(tier.thresholdCents)).toBe(tier.amountCents);
+    }
+  });
+
+  it("breakpoints are inclusive at the lower edge, exclusive one cent below", () => {
+    expect(tierFor("19999").amountCents).toBe(5000);
+    expect(tierFor("20000").amountCents).toBe(20000);
+    expect(tierFor("99999").amountCents).toBe(20000);
+    expect(tierFor("100000").amountCents).toBe(50000);
+  });
+});


### PR DESCRIPTION
## What
Restructure credit top-up from a **daily charge** to **threshold-based postpaid** billing (Google/Meta-Ads cadence). The balance is allowed to run negative down to a **derived credit-line floor**; a fixed reload fires only when spend crosses that floor. A $32/day org is charged ~every 1.5 days, not daily. The credit line grows with cumulative amount paid.

Closes #233. Structural root-fix for #170 (duplicate out-of-credit dunning email).

## How
- **`src/lib/topup-tier.ts`** — `tierFor(cumulativePaidCents)` → `{ thresholdCents (NEGATIVE floor), amountCents }`, magnitudes equal. Ladder: `≥$1000 paid → {-50000, 50000}`; `≥$200 → {-20000, 20000}`; else `{-5000, 5000}`. Pure function of the existing "succeeded topups" sum — no storage.
- **`authorize`** — sufficient (no reload) when `balance − required >= threshold`. Below the floor, reload tier-amount multiples toward `threshold + required`, then recheck. No-config / no-card / blocked-country orgs have no credit line → floor `"0"` (unchanged prepaid behavior).
- **`usage_apply`** — reload when `balance < threshold`, charging the tier amount (not the stored daily amount).
- **`cents.isDepleted(a, threshold="0")`** threshold-aware; **`openDepletionEpisodeIfDepleted`** gated on the floor — a normal negative balance within the line no longer opens an episode / sends a T0.
- **Account-read** (`GET /v1/accounts`, `PATCH`/`wallet_setup`) returns the DERIVED tier for `topup_amount_cents` / `topup_threshold_cents` (null when disabled). Stored columns are now only the enabled flag.

## Guardrails held
No DB migration · no new response field · no new endpoint · no api-service change · request schemas (`UpdateAutoTopupRequest`, wallet PATCH) unchanged · response contract (field names/types) stable — `topup_threshold_cents` (`z.number().int().nullable()`) now carries the derived negative value.

## Tests
`pnpm test` → **264 passing** (25 files). New: `tierFor` breakpoints + magnitudes; `isDepleted` threshold-aware; authorize sufficiency/reload/fail at negative balances (sign correctness) + tier scaling; usage_apply negative-floor; dunning "no episode within line" / "episode on floor crossing". Build green.

## Manual (post-merge, staging, Stripe test-mode)
Spend past a tier → exactly ONE charge at the floor, not daily · no "out of credit" email while within the line · tier climbs after cumulative-paid crosses $200.
