### PR TITLE
feat(billing): month-end forced top-up sweep (guarantee >=1 charge/month for postpaid tier)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,19 @@ Auto-topup is **postpaid on a derived tier ladder**, not a fixed daily charge. T
 - **`usage_apply`:** reload when `balance < threshold` (negative floor), charging tier `amount` multiples toward the floor.
 - **Dunning gate is threshold-aware** (`src/lib/cents.ts` `isDepleted(a, threshold="0")`, 2-arg): a depletion episode / T0 email opens ONLY when `balance <= threshold` (past the floor), NEVER on a normal negative balance within the line. `openDepletionEpisodeIfDepleted` takes `thresholdCents` (the derived floor for reload-capable orgs, `"0"` otherwise). This is also the structural root-fix for #170 (the balance-flutter duplicate-email bug): an enabled org running at ~0 never reaches the depletion path until it genuinely blows past the negative floor. The `credited`-rising recovery logic is unchanged; the dunning-tick follow-up gate stays at floor `"0"` (still-in-the-red check).
 - Credit exposure is bounded by `|threshold|` of the current tier plus one run's overshoot.
-- Onboarding / initial wallet-setup checkout is unchanged (seeds a positive buffer, lowers risk). The month-end forced-charge is a separate follow-up, not built here.
+- Onboarding / initial wallet-setup checkout is unchanged (seeds a positive buffer, lowers risk).
+- `computeTopupCharge(currentBalance, target, unit)` (the shared reload-math: cents to charge in whole tier-`unit` multiples to lift the balance to `target`, rounding the multiple up) lives in `src/lib/topup-tier.ts` and is reused by `authorize` (target = `threshold + required`), `usage_apply` (target = `threshold`), and the month-end sweep (target = `"0"`). It was moved out of `customer_balance.ts` so all three paths share one source.
+
+### Month-end forced top-up sweep (guarantee ≥1 charge/month)
+
+A slow spender whose balance never crosses the floor within a calendar month would go the whole month un-charged (Google/Meta Ads sweep any outstanding spend on the monthly bill date regardless of amount). `src/lib/month-end-sweep.ts` fixes this: `runMonthEndSweep(now = new Date())` settles every reload-capable org back to `>= 0` once a month.
+
+- **Trigger:** runs from the SAME hourly dunning scheduler (`dunning-scheduler.ts` tick, post-`listen()` — never the boot path), isolated in its own try/catch so a sweep failure never blocks dunning and vice-versa. Self-gates on `isLastDayOfMonth(now)` (UTC) — a single date check on every non-last-day tick.
+- **Selection:** auto-topup-ENABLED accounts (`topup_amount_cents` AND `topup_threshold_cents` non-null), then per-org reload-capability re-checked against the live snapshot (chargeable card + non-blocked issuing country — mirrors the `usage_apply` guards). Only a `balance < 0` org is charged; a non-negative org owes nothing, and anything already past the floor is owned by the normal floor-crossing path.
+- **Charge:** ONE `reloadViaPaymentIntent` (via `coalesceReload` + a 30s timeout) of `computeTopupCharge(balance, "0", tierFor(paidTopups).amountCents)` — settles the negative balance to `>= 0`. No end user on this path → the reload identity uses the `INTERNAL_IDENTITY` sentinel `x-user-id` (like transfer-brand), since the `/v1` reload primitives still require `x-user-id`.
+- **Idempotency (NO new storage):** the PRIMARY guard is the balance re-check — once the settle lands, `credited` rises past `usage` and the org reads non-negative, so later same-month ticks skip it. A month-bucketed (`YYYY-MM`), amount-independent Stripe idempotency key (`sweepIdempotencyKey`) collapses any same-month double-charge across the mirror-sync-lag window / multiple replicas (all last-day ticks fall inside Stripe's ~24h key retention).
+- **Fail-loud per org, isolated:** a per-org error is logged (`console.error("[billing-service] month-end sweep failed for org …")`) and skipped; one unreachable org never blocks the rest (same shape as `runDunningTick`).
+- **No cost declaration:** a reload collects the org's OWN money via Stripe — not a metered platform cost, exactly like the `authorize` / `usage_apply` reloads. No runs-service cost row.
 
 ## Public surface field names
 

--- a/src/lib/dunning-scheduler.ts
+++ b/src/lib/dunning-scheduler.ts
@@ -10,6 +10,7 @@
  */
 
 import { runDunningTick } from "./dunning.js";
+import { runMonthEndSweep } from "./month-end-sweep.js";
 
 // Hourly heartbeat. The follow-up windows (+3d / +10d) are far coarser, so this
 // is plenty frequent for both follow-ups and recharge detection.
@@ -22,15 +23,32 @@ let timer: NodeJS.Timeout | null = null;
 export function startDunningScheduler(): void {
   const tick = async () => {
     try {
-      const r = await runDunningTick();
-      if (r.processed > 0) {
-        console.log(
-          `[billing-service] dunning tick: processed=${r.processed} recovered=${r.recovered} ` +
-            `3d=${r.followup3dSent} 10d=${r.followup10dSent}`
-        );
+      try {
+        const r = await runDunningTick();
+        if (r.processed > 0) {
+          console.log(
+            `[billing-service] dunning tick: processed=${r.processed} recovered=${r.recovered} ` +
+              `3d=${r.followup3dSent} 10d=${r.followup10dSent}`
+          );
+        }
+      } catch (err) {
+        console.error("[billing-service] dunning tick failed:", err);
       }
-    } catch (err) {
-      console.error("[billing-service] dunning tick failed:", err);
+
+      // Month-end forced top-up sweep. Self-gates on the last UTC day of the
+      // month — a cheap date check on every other tick. Isolated from dunning so
+      // a failure in either never blocks the other.
+      try {
+        const s = await runMonthEndSweep();
+        if (s.ranSweep && (s.charged > 0 || s.failed > 0)) {
+          console.log(
+            `[billing-service] month-end sweep: eligible=${s.eligible} ` +
+              `charged=${s.charged} skipped=${s.skipped} failed=${s.failed}`
+          );
+        }
+      } catch (err) {
+        console.error("[billing-service] month-end sweep failed:", err);
+      }
     } finally {
       timer = setTimeout(tick, TICK_INTERVAL_MS);
     }

--- a/src/lib/month-end-sweep.ts
+++ b/src/lib/month-end-sweep.ts
@@ -1,0 +1,224 @@
+/**
+ * Month-end forced top-up sweep.
+ *
+ * Threshold-based postpaid top-up (see lib/topup-tier) lets an org's balance run
+ * NEGATIVE down to a derived credit-line floor; a reload fires only when spend
+ * crosses that floor. A slow spender who never crosses the floor within a
+ * calendar month would go a whole month un-charged. Google/Meta Ads sweep any
+ * outstanding spend on the monthly bill date regardless of amount — this
+ * replicates that: once a month, settle every reload-capable org whose balance is
+ * negative by forcing ONE tier-amount reload back to >= 0.
+ *
+ * Runs from the hourly dunning scheduler (post-listen, never the boot path). It
+ * self-gates on the last calendar day of the month (UTC), so on any other day it
+ * is a single date check and returns immediately.
+ *
+ * Idempotency: a month-bucketed ("YYYY-MM") Stripe idempotency key collapses any
+ * two sweep charges for the same org in the same month into ONE PaymentIntent.
+ * The primary guard is the balance re-check itself — once the first charge lands,
+ * `credited` rises and the org reads non-negative, so later ticks skip it. The
+ * month-bucketed key covers the mirror-sync-lag window: all last-day ticks fall
+ * inside Stripe's ~24h idempotency-key retention, so a same-day double tick (even
+ * across replicas) can never double-charge. No new storage.
+ *
+ * No cost declaration: a reload collects the org's OWN money via Stripe (the org
+ * paid its provider) — it is not a metered platform cost, exactly like the
+ * authorize / usage_apply reloads. Matches that path's absence of a runs-service
+ * cost row.
+ */
+
+import crypto from "crypto";
+import { and, isNotNull } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { billingAccounts } from "../db/schema.js";
+import { computeBalance } from "./balance.js";
+import { tierFor, computeTopupCharge } from "./topup-tier.js";
+import { cmpCents } from "./cents.js";
+import { coalesceReload } from "./reload-coalescer.js";
+import { reloadViaPaymentIntent } from "./reload.js";
+
+// INTERNAL_IDENTITY sentinel — there is no end user on the sweep path. The /v1
+// reload primitives (getCustomerByOrg / listPaymentMethods / createPaymentIntent)
+// still require x-user-id even though they key on x-org-id, so we pass the
+// sentinel exactly like the transfer-brand admin op.
+const SWEEP_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+// A hung stripe-service call must not stall the whole sweep loop.
+const RELOAD_TIMEOUT_MS = 30_000;
+
+/**
+ * True iff `date` is the last calendar day of its month in UTC.
+ *
+ * Adding one UTC day rolls into the next month ONLY on the last day. Date.UTC
+ * normalizes day overflow (day 32 → next month), so this is exact across
+ * 28/29/30/31-day months (and Feb 29 in leap years) with no ms arithmetic.
+ */
+export function isLastDayOfMonth(date: Date): boolean {
+  const m = date.getUTCMonth();
+  const next = new Date(
+    Date.UTC(date.getUTCFullYear(), m, date.getUTCDate() + 1)
+  );
+  return next.getUTCMonth() !== m;
+}
+
+/** "YYYY-MM" bucket (UTC) — the idempotency scope for one calendar month. */
+export function monthBucket(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}
+
+/**
+ * Amount-independent, month-scoped Stripe idempotency key. Any two sweep charges
+ * for the same org in the same month collapse to one PaymentIntent regardless of
+ * the computed amount.
+ */
+export function sweepIdempotencyKey(orgId: string, bucket: string): string {
+  return crypto
+    .createHash("sha256")
+    .update(`month-end-sweep:${orgId}:${bucket}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+function withTimeout<T>(ms: number, p: Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`month-end sweep reload timeout after ${ms}ms`)),
+      ms
+    );
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
+export interface MonthEndSweepResult {
+  /** False when `now` is not the last day of the month — the sweep no-ops. */
+  ranSweep: boolean;
+  /** Auto-topup-enabled accounts examined. */
+  eligible: number;
+  /** Orgs charged one settling reload. */
+  charged: number;
+  /** Orgs skipped (non-negative balance, no card, blocked country, zero charge). */
+  skipped: number;
+  /** Orgs whose reload errored / declined (logged + isolated). */
+  failed: number;
+}
+
+/**
+ * Settle every reload-capable org with a negative balance on the last day of the
+ * month. Per-org failure is logged and skipped — one unreachable org never blocks
+ * the rest (same shape as runDunningTick).
+ */
+export async function runMonthEndSweep(
+  now: Date = new Date()
+): Promise<MonthEndSweepResult> {
+  const result: MonthEndSweepResult = {
+    ranSweep: false,
+    eligible: 0,
+    charged: 0,
+    skipped: 0,
+    failed: 0,
+  };
+
+  if (!isLastDayOfMonth(now)) return result;
+  result.ranSweep = true;
+  const bucket = monthBucket(now);
+
+  // Auto-topup ENABLED accounts only (both config columns non-null ⇒ enabled,
+  // mirroring the usage_apply gate). Reload-capability (chargeable card +
+  // non-blocked issuing country) is re-checked per org below against the live
+  // Stripe snapshot.
+  const enabled = await db
+    .select()
+    .from(billingAccounts)
+    .where(
+      and(
+        isNotNull(billingAccounts.topupAmountCents),
+        isNotNull(billingAccounts.topupThresholdCents)
+      )
+    );
+
+  for (const account of enabled) {
+    result.eligible += 1;
+    try {
+      const snapshot = await computeBalance(account.orgId);
+
+      // Reload-capable guards — mirror usage_apply: chargeable card AND an
+      // issuing country that supports off_session charges (India/RBI excluded).
+      if (!snapshot.hasCardPm || !snapshot.autoReloadSupported) {
+        result.skipped += 1;
+        continue;
+      }
+
+      // Only settle a NEGATIVE balance (outstanding spend on credit that never
+      // crossed the floor). A non-negative org owes nothing this cycle — the
+      // normal floor-crossing path owns anything already past the floor.
+      if (cmpCents(snapshot.balanceCents, "0") >= 0) {
+        result.skipped += 1;
+        continue;
+      }
+
+      // Force ONE reload of tier-amount multiples toward a target of 0, settling
+      // the balance back to >= 0.
+      const tier = tierFor(snapshot.paidTopupsCents);
+      const chargeAmount = computeTopupCharge(
+        snapshot.balanceCents,
+        "0",
+        tier.amountCents
+      );
+      if (chargeAmount <= 0) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const identity = {
+        "x-org-id": account.orgId,
+        "x-user-id": SWEEP_USER_ID,
+      };
+      const outcome = await coalesceReload(account.orgId, () =>
+        withTimeout(
+          RELOAD_TIMEOUT_MS,
+          reloadViaPaymentIntent(
+            identity,
+            chargeAmount,
+            sweepIdempotencyKey(account.orgId, bucket),
+            { reason: "month_end_sweep", month: bucket }
+          )
+        )
+      );
+
+      if (outcome.status === "succeeded") {
+        result.charged += 1;
+        console.log(
+          `[billing-service] month-end sweep: charged org ${account.orgId} ` +
+            `${chargeAmount} cents (${bucket})`
+        );
+      } else {
+        result.failed += 1;
+        console.warn(
+          `[billing-service] month-end sweep: reload ${outcome.status} for org ` +
+            `${account.orgId}: ${outcome.failure_reason ?? ""}`
+        );
+      }
+    } catch (err) {
+      result.failed += 1;
+      console.error(
+        `[billing-service] month-end sweep failed for org ${account.orgId}, ` +
+          `skipping:`,
+        err
+      );
+      continue;
+    }
+  }
+
+  return result;
+}

--- a/src/lib/topup-tier.ts
+++ b/src/lib/topup-tier.ts
@@ -47,3 +47,26 @@ export function tierFor(cumulativePaidCents: string): TopupTier {
   }
   return { thresholdCents: -5000, amountCents: 5000 };
 }
+
+/**
+ * Cents to charge to lift `currentBalanceCents` up to `targetCents`, in whole
+ * multiples of `unitCents` (the tier reload amount). Returns 0 when the balance
+ * is already at/above target. Rounds the multiple UP so one settle fully clears
+ * the deficit past the target.
+ *
+ * Shared by every reload path: authorize (target = threshold + required),
+ * usage_apply (target = threshold), and the month-end sweep (target = "0").
+ */
+export function computeTopupCharge(
+  currentBalanceCents: string,
+  targetCents: string,
+  unitCents: number
+): number {
+  const deficit = new Decimal(targetCents).minus(currentBalanceCents);
+  if (deficit.lessThanOrEqualTo(0)) return 0;
+  const multiples = deficit
+    .dividedBy(unitCents)
+    .toDecimalPlaces(0, Decimal.ROUND_CEIL)
+    .toNumber();
+  return multiples * unitCents;
+}

--- a/src/routes/customer_balance.ts
+++ b/src/routes/customer_balance.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { Decimal } from "decimal.js";
 import crypto from "crypto";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { AuthorizeRequestSchema, UsageApplyRequestSchema } from "../schemas.js";
@@ -17,7 +16,7 @@ import {
   isAutoReloadBlockedCountry,
 } from "../lib/stripe-service-client.js";
 import { computeBalance } from "../lib/balance.js";
-import { tierFor } from "../lib/topup-tier.js";
+import { tierFor, computeTopupCharge } from "../lib/topup-tier.js";
 import { upsertCampaignAuthorizeCost } from "../lib/campaign-costs.js";
 import { openDepletionEpisodeIfDepleted } from "../lib/dunning.js";
 import { reloadViaPaymentIntent } from "../lib/reload.js";
@@ -27,13 +26,6 @@ const router = Router();
 
 const RELOAD_TIMEOUT_MS = 30_000;
 const RELOAD_IDEMPOTENCY_BUCKET_MS = 60_000;
-
-function computeTopupCharge(currentBalance: string, requiredCents: string, topupUnit: number): number {
-  const deficit = new Decimal(requiredCents).minus(currentBalance);
-  if (deficit.lessThanOrEqualTo(0)) return 0;
-  const multiples = deficit.dividedBy(topupUnit).toDecimalPlaces(0, Decimal.ROUND_CEIL).toNumber();
-  return multiples * topupUnit;
-}
 
 function buildIdentity(orgId: string, userId: string, runId: string | undefined, wfHeaders: Record<string, string>) {
   const out: Record<string, string> = {

--- a/tests/integration/month-end-sweep.test.ts
+++ b/tests/integration/month-end-sweep.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import {
+  cleanTestData,
+  insertTestAccount,
+  closeDb,
+} from "../helpers/test-db.js";
+import { setupStripeMocks, customerWithEmail } from "../helpers/mock-stripe.js";
+import {
+  runMonthEndSweep,
+  monthBucket,
+  sweepIdempotencyKey,
+} from "../../src/lib/month-end-sweep.js";
+
+// A last calendar day of the month (UTC) — the sweep trigger. Jan 31.
+const LAST_DAY = new Date(Date.UTC(2026, 0, 31, 12, 0, 0));
+// A non-last day — the sweep must no-op.
+const MID_MONTH = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
+
+const orgA = "00000000-0000-0000-0000-00000000f001";
+const orgB = "00000000-0000-0000-0000-00000000f002";
+const billingEmail = "founder@acme.test";
+
+describe("Month-end forced top-up sweep", () => {
+  let ssMocks: ReturnType<typeof setupStripeMocks>;
+  let setUsage: (orgId: string, cents: string) => void;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    ssMocks = setupStripeMocks();
+    ssMocks.fetchOrgCustomer.mockResolvedValue(customerWithEmail(billingEmail));
+    await cleanTestData();
+
+    // balance = credited − usage. credited = paidTopups (no promos here).
+    // paidTopups is driven per-test via sumSucceededTopupsForOrg; usage per-org
+    // via this map so two orgs can carry different balances in one sweep.
+    const usageByOrg = new Map<string, string>();
+    setUsage = (orgId: string, cents: string) => usageByOrg.set(orgId, cents);
+    const runsClient = await import("../../src/lib/runs-client.js");
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(
+      async (orgId: string) => ({
+        org_id: orgId,
+        spent_cents: usageByOrg.get(orgId) ?? "0.0000000000",
+        as_of: "2026-01-31T00:00:00.000Z",
+      })
+    );
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("AC1: charges a reload-capable, enabled org with a negative balance", async () => {
+    await insertTestAccount({
+      orgId: orgA,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    // paid 0 → tier amount 5000. usage 100 → balance -100 → settle to >= 0.
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    setUsage(orgA, "100.0000000000");
+
+    const res = await runMonthEndSweep(LAST_DAY);
+
+    expect(res.ranSweep).toBe(true);
+    expect(res.eligible).toBe(1);
+    expect(res.charged).toBe(1);
+    expect(res.skipped).toBe(0);
+    expect(res.failed).toBe(0);
+    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+    // One tier-amount multiple (5000) clears the -100 deficit to +4900.
+    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(5000);
+    // Month-scoped idempotency key.
+    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[2]).toBe(
+      sweepIdempotencyKey(orgA, monthBucket(LAST_DAY))
+    );
+  });
+
+  it("AC2: does NOT charge a non-negative balance", async () => {
+    await insertTestAccount({
+      orgId: orgA,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("100.0000000000");
+    setUsage(orgA, "0.0000000000"); // balance +100
+
+    const res = await runMonthEndSweep(LAST_DAY);
+
+    expect(res.charged).toBe(0);
+    expect(res.skipped).toBe(1);
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("AC2: does NOT charge an org with no chargeable card", async () => {
+    await insertTestAccount({
+      orgId: orgA,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    ssMocks.hasChargeablePmForOrg.mockResolvedValue(false);
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    setUsage(orgA, "5000.0000000000"); // deeply negative
+
+    const res = await runMonthEndSweep(LAST_DAY);
+
+    expect(res.charged).toBe(0);
+    expect(res.skipped).toBe(1);
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("AC2: does NOT charge a blocked-country (India) card", async () => {
+    await insertTestAccount({
+      orgId: orgA,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    ssMocks.getOrgCardCountryByOrg.mockResolvedValue("IN");
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    setUsage(orgA, "5000.0000000000");
+
+    const res = await runMonthEndSweep(LAST_DAY);
+
+    expect(res.charged).toBe(0);
+    expect(res.skipped).toBe(1);
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("AC2: does NOT select an org with no auto-topup config", async () => {
+    await insertTestAccount({ orgId: orgA }); // topupAmountCents null → not enabled
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    setUsage(orgA, "5000.0000000000");
+
+    const res = await runMonthEndSweep(LAST_DAY);
+
+    expect(res.eligible).toBe(0);
+    expect(res.charged).toBe(0);
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("AC3: idempotent — after the settle, a second tick reads non-negative and skips", async () => {
+    await insertTestAccount({
+      orgId: orgA,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    setUsage(orgA, "100.0000000000"); // balance -100
+
+    const first = await runMonthEndSweep(LAST_DAY);
+    expect(first.charged).toBe(1);
+
+    // The $50 settle lands → credited rises past usage → balance non-negative.
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("5000.0000000000");
+
+    const second = await runMonthEndSweep(LAST_DAY);
+    expect(second.charged).toBe(0);
+    expect(second.skipped).toBe(1);
+    // Exactly ONE charge across both ticks.
+    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC4: a per-org failure is isolated — the sweep continues for other orgs", async () => {
+    await insertTestAccount({
+      orgId: orgA,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    await insertTestAccount({
+      orgId: orgB,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    // orgA's balance read throws; orgB is a healthy negative balance.
+    ssMocks.fetchOrgCustomer.mockImplementation(async (orgId: string) => {
+      if (orgId === orgA) throw new Error("stripe-service unreachable");
+      return customerWithEmail(billingEmail);
+    });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    setUsage(orgB, "100.0000000000");
+
+    const res = await runMonthEndSweep(LAST_DAY);
+
+    expect(res.eligible).toBe(2);
+    expect(res.failed).toBe(1); // orgA
+    expect(res.charged).toBe(1); // orgB still settled
+    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC5/AC6: no-op on any day that is not the last of the month", async () => {
+    await insertTestAccount({
+      orgId: orgA,
+      topupAmountCents: 1000,
+      topupThresholdCents: 500,
+    });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    setUsage(orgA, "5000.0000000000"); // deeply negative — would charge on the last day
+
+    const res = await runMonthEndSweep(MID_MONTH);
+
+    expect(res.ranSweep).toBe(false);
+    expect(res.eligible).toBe(0);
+    expect(res.charged).toBe(0);
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/month-end-sweep.test.ts
+++ b/tests/unit/month-end-sweep.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  isLastDayOfMonth,
+  monthBucket,
+  sweepIdempotencyKey,
+} from "../../src/lib/month-end-sweep.js";
+
+// All dates are constructed in UTC (Date.UTC) so the assertions are timezone-
+// independent — the sweep gates on the UTC calendar.
+function utc(y: number, monthIndex: number, day: number): Date {
+  return new Date(Date.UTC(y, monthIndex, day));
+}
+
+describe("isLastDayOfMonth — UTC last-day detection", () => {
+  it("31-day month (January): 31 is last, 30 is not", () => {
+    expect(isLastDayOfMonth(utc(2026, 0, 31))).toBe(true);
+    expect(isLastDayOfMonth(utc(2026, 0, 30))).toBe(false);
+  });
+
+  it("30-day month (April): 30 is last, 29 is not", () => {
+    expect(isLastDayOfMonth(utc(2026, 3, 30))).toBe(true);
+    expect(isLastDayOfMonth(utc(2026, 3, 29))).toBe(false);
+  });
+
+  it("28-day February (non-leap 2026): 28 is last", () => {
+    expect(isLastDayOfMonth(utc(2026, 1, 28))).toBe(true);
+    expect(isLastDayOfMonth(utc(2026, 1, 27))).toBe(false);
+  });
+
+  it("29-day February (leap 2024): 29 is last, 28 is NOT", () => {
+    expect(isLastDayOfMonth(utc(2024, 1, 29))).toBe(true);
+    expect(isLastDayOfMonth(utc(2024, 1, 28))).toBe(false);
+  });
+
+  it("December 31 (year rollover) is last", () => {
+    expect(isLastDayOfMonth(utc(2026, 11, 31))).toBe(true);
+    expect(isLastDayOfMonth(utc(2026, 11, 30))).toBe(false);
+  });
+
+  it("time-of-day on the last day does not matter", () => {
+    expect(isLastDayOfMonth(new Date(Date.UTC(2026, 0, 31, 23, 59, 59)))).toBe(true);
+    expect(isLastDayOfMonth(new Date(Date.UTC(2026, 0, 31, 0, 0, 0)))).toBe(true);
+  });
+});
+
+describe("monthBucket — YYYY-MM (UTC)", () => {
+  it("zero-pads the month", () => {
+    expect(monthBucket(utc(2026, 0, 31))).toBe("2026-01");
+    expect(monthBucket(utc(2026, 8, 30))).toBe("2026-09");
+    expect(monthBucket(utc(2026, 11, 31))).toBe("2026-12");
+  });
+});
+
+describe("sweepIdempotencyKey — stable, month-scoped, 32-hex", () => {
+  const org = "00000000-0000-0000-0000-00000000e001";
+
+  it("is deterministic for the same org + bucket", () => {
+    expect(sweepIdempotencyKey(org, "2026-01")).toBe(
+      sweepIdempotencyKey(org, "2026-01")
+    );
+  });
+
+  it("differs across months (so a new month can charge again)", () => {
+    expect(sweepIdempotencyKey(org, "2026-01")).not.toBe(
+      sweepIdempotencyKey(org, "2026-02")
+    );
+  });
+
+  it("differs across orgs", () => {
+    const other = "00000000-0000-0000-0000-00000000e002";
+    expect(sweepIdempotencyKey(org, "2026-01")).not.toBe(
+      sweepIdempotencyKey(other, "2026-01")
+    );
+  });
+
+  it("is 32 hex chars", () => {
+    expect(sweepIdempotencyKey(org, "2026-01")).toMatch(/^[0-9a-f]{32}$/);
+  });
+});


### PR DESCRIPTION
## Month-end forced top-up sweep

Threshold-based postpaid top-up (v0.43.0) lets an org's balance run **negative** down to a derived credit-line floor; a reload fires only on floor-crossing (`authorize` / `usage_apply`). A **slow spender** who never crosses the floor within a calendar month was never charged that month. Google/Meta Ads sweep any outstanding spend on the monthly bill date regardless of amount — this adds the same guarantee: **every org with outstanding spend is charged at least once per calendar month**, and the dashboard's "…or on <last-day-of-month>" line becomes truthful.

### What it does
- **`src/lib/month-end-sweep.ts`** — `runMonthEndSweep(now)` self-gates on the **last UTC day of the month**, selects auto-topup-**enabled** + **reload-capable** orgs (chargeable card + non-blocked issuing country — mirrors the `usage_apply` guards), and for each with `balance < 0` forces **ONE** `reloadViaPaymentIntent` of `computeTopupCharge(balance, "0", tierFor(paid).amountCents)` to settle back to `>= 0`. Reuses `coalesceReload` + a 30s timeout exactly like `usage_apply`/`authorize`.
- **Runs from the existing hourly dunning scheduler**, post-`listen()` (never the boot path), isolated in its own try/catch so dunning and the sweep never block each other.
- **Idempotent, NO new storage** — the **balance re-check** is the primary guard (after the settle, `credited` rises → org reads non-negative → later ticks skip), backed by a **month-bucketed, amount-independent Stripe idempotency key** that collapses same-month double-charges across replicas / mirror-sync lag (all last-day ticks fall inside Stripe's ~24h key retention).
- **Fail-loud per org, isolated** — a per-org error is logged and skipped; one unreachable org never blocks the rest (same shape as `runDunningTick`).
- **No cost declaration** — collects the org's own money via Stripe, exactly like the existing reloads. No runs-service cost row.
- Extracted `computeTopupCharge` into `src/lib/topup-tier.ts` so `authorize`, `usage_apply`, and the sweep share one reload-math source.

### AC coverage
- **AC1** negative-balance reload-capable org → one tier-amount settle to `>= 0` ✅
- **AC2** non-negative / no-card / blocked-country / no-config → not charged ✅
- **AC3** double tick in a month → one charge ✅
- **AC4** per-org failure logged + skipped, sweep continues ✅
- **AC5** runs from scheduler, post-`listen()` ✅
- **AC6** last-day detection correct across 28/29/30/31-day + leap months (UTC) ✅

### Tests
`tests/unit/month-end-sweep.test.ts` (date detection, month bucket, idempotency key) + `tests/integration/month-end-sweep.test.ts` (selection, settle amount, idempotency, failure isolation, non-last-day no-op). Full suite: **283 passed**, build green.

Triage: **feature → staging** (money-sensitive; validate on staging before promotion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
