### PR TITLE
feat(billing): per-org platform-usage discount at balance composition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,9 @@ A slow spender whose balance never crosses the floor within a calendar month wou
   "usage_cents": "38289.2958000000",         // runs-service spent_cents (platform actual+provisioned)
   "balance_cents": "16910.7042000000",       // credited_cents − usage_cents; USE THIS for depletion/budget gates
   "actual_balance_cents": "16920.7042000000", // credited_cents − actualized usage only; display this as the user's credit balance
+  "usage_discount_pct": 50,                  // per-org platform-usage discount (0–100); null when none. See "Per-org usage discount"
+  "net_usage_cents": "19144.6479000000",     // usage_cents × (1 − usage_discount_pct/100) = the NET committed usage balance_cents subtracts. Equals usage_cents when no discount.
+  "net_actual_usage_cents": "...",           // NET actualized usage; the amount actual_balance_cents subtracts. Equals gross actualized usage when no discount.
   "topup_amount_cents": 5000,                // DERIVED tier reload amount (tierFor(cumulative paid)); null when auto-topup disabled. NOT the stored daily amount.
   "topup_threshold_cents": -5000,            // DERIVED tier NEGATIVE credit-line floor; auto-topup reloads when balance crosses it. null when disabled. See "Threshold-based postpaid top-up"
   "has_payment_method": true,                // ≥1 chargeable PM: card OR link (GET /v1/payment_methods?type=card, then type=link); NOT invoice_settings.default_payment_method
@@ -177,7 +180,8 @@ Composition (`src/routes/accounts.ts:composeAccountFunds`):
 5. `fetchRunsOrgActualUsageTotal(orgId, identity)` → runs-service `total_expected_cents` from actualized platform costs only
 6. `hasAttachedCardPm(identity, customer.id)` → `has_payment_method` (≥1 chargeable PM: card or link)
 7. `getOrgCardCountry(identity, customer.id)` → `card_country` → `auto_reload_supported = !isAutoReloadBlockedCountry(card_country)` (see "Off_session auto-reload" below)
-8. `credited_cents = paid_topups + local_credits`; `balance_cents = credited_cents − usage`; `actual_balance_cents = credited_cents − actualized_usage`
+8. `getUsageDiscountPct(orgId)` → `usage_discount_pct` (see "Per-org usage discount"); the balance figures subtract NET usage
+9. `credited_cents = paid_topups + local_credits`; `net_usage = usage × (1 − pct/100)`; `balance_cents = credited_cents − net_usage`; `actual_balance_cents = credited_cents − net_actualized_usage`. `usage_cents` stays GROSS (reporting). No discount (`pct` null) → net == gross → every existing field is byte-identical.
 
 ### `GET /public/stats/billing`
 
@@ -221,6 +225,24 @@ Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed liv
 | `GET` | `/internal/campaigns/:campaignId/affordability` | READ-ONLY pre-flight gate (campaign-service). → `{affordable, balanceCents, lastRequiredCents, hasHistory}`. ZERO side effects. See "Campaign affordability gate" below. |
 | `GET` | `/internal/brands/:brandId/daily-budget` | READ this org's current daily budget for a brand (service auth + `x-org-id`). → `{brandId, dailyBudgetCents, updatedAt}`; unset for that org → `dailyBudgetCents:null, updatedAt:null`. See "Per-brand daily budget" below. |
 | `PATCH` | `/v1/brands/:brandId/daily-budget` | SET/UPDATE a brand's daily budget (user via gateway, org headers). body `{dailyBudgetCents}` (non-negative; 0 = pause). → `{brandId, orgId, dailyBudgetCents, updatedAt}`. |
+| `GET` | `/v1/usage-discount` | staff READ of this org's platform-usage discount. Auth mirrors credit-grant (`x-api-key` + `x-org-id`). → `{orgId, discountPct, setBy, setAt}`; unset → `discountPct:null`. See "Per-org usage discount". |
+| `PUT` | `/v1/usage-discount` | staff SET/REPLACE the discount. body `{discountPct}` (integer 0–100; out-of-range → 400, no clamp). `setBy = x-email`. → `{orgId, discountPct, setBy, setAt}`. |
+| `DELETE` | `/v1/usage-discount` | staff REMOVE the discount (→ null → full pricing on the next composition; not retroactive). Idempotent. → `{orgId, discountPct:null, setBy:null, setAt:null}`. |
+
+## Per-org usage discount (reduces the usage component at balance composition)
+
+Platform staff can give an org a percentage discount on ALL its platform usage. A discounted org effectively pays `(1 − discount_pct/100)` of its GROSS usage over time: the discount REDUCES the usage billing subtracts wherever it composes the spendable balance, so the balance depletes proportionally slower and Stripe topups fire proportionally less often. It is NOT a Stripe coupon and NOT bonus/matching credits — it is a read-side reduction of the usage term. The GROSS usage in runs-service is NEVER touched (reporting still sees the full number).
+
+**State:** one table, `org_usage_discounts` (migration `0026`, hand-journaled) — `org_id` PK, `discount_pct integer` (DB CHECK 0..100), `set_by text` (staff email), `set_at`, `created_at`. ONE row per org; **absence of a row = null = no discount = today's EXACT behavior** (byte-identical numbers). Replaceable (upsert on `org_id`), removable (DELETE → null). `src/lib/usage-discount.ts` owns the read/set/remove + the pure `applyUsageDiscount(grossCents, pct)` helper (`pct` null or 0 → returns gross verbatim; else `gross × (1 − pct/100)` at scale 10).
+
+**Applied at EVERY balance-composition site** — the discount reduces usage, never credited:
+- `computeBalance(orgId)` (`src/lib/balance.ts`) reads `getUsageDiscountPct(orgId)` and returns `balanceCents = credited − netUsage`, plus `discountPct` + `netUsageCents` on the snapshot (`usageCents` stays gross). This one chokepoint feeds authorize, the dunning scheduler, month-end sweep, `GET /internal/campaigns/:id/affordability`, and `GET /internal/accounts/by-org/:orgId/balance` (whose `actual_balance_cents` re-applies the discount to actualized usage via `snapshot.discountPct`).
+- `composeAccountFunds` (`src/routes/accounts.ts`) for `GET /v1/accounts` (+ `balance`, `auto_topup`, `wallet_setup`): `balance_cents`/`actual_balance_cents` subtract net usage; exposes `usage_discount_pct` + `net_usage_cents` + `net_actual_usage_cents` (`usage_cents` stays gross) so the dashboard renders a banner + strikethrough.
+- `POST /v1/customer_balance/usage_apply` discounts the caller-reported `spent_total_cents` before the postpaid threshold check → topups fire proportionally less often.
+
+The postpaid TIER (`tierFor`) is derived from cumulative PAID topups, not usage, so it is unaffected; the "fires less often" effect comes entirely from the higher (discount-adjusted) balance crossing the floor later. Removing the discount restores full pricing on the NEXT composition (not retroactive). Fail-loud: an out-of-range percentage is rejected at both the Zod route schema and `setUsageDiscount` (`InvalidUsageDiscountError`) — no clamp, no default.
+
+**Follow-up (other repos, not built here):** api-service gateway proxy gating `/v1/usage-discount` to staff; admin-console UI to read/set/remove; dashboard banner + strikethrough rendering from `usage_discount_pct` + `usage_cents` + `net_usage_cents`.
 
 ## Per-brand daily budget (pacing ceiling — NOT affordability)
 

--- a/drizzle/0026_org_usage_discounts.sql
+++ b/drizzle/0026_org_usage_discounts.sql
@@ -1,0 +1,25 @@
+-- Per-org usage discount (staff-managed platform-usage discount).
+--
+-- A discounted org effectively pays (1 - discount_pct/100) of its GROSS platform
+-- usage: the usage component billing subtracts at balance composition is reduced
+-- by discount_pct, so the spendable balance depletes proportionally slower and
+-- Stripe topups fire proportionally less often. The GROSS usage in runs-service
+-- is untouched (reporting still sees the full number).
+--
+-- ONE value per org (org_id PRIMARY KEY), replaceable (upsert) and removable
+-- (DELETE row -> null -> no discount = today's exact behavior). granted audit:
+-- set_by (staff email) + set_at.
+--
+-- Nullable-by-absence: no row = no discount. A CHECK enforces 0..100 at the DB
+-- level (fail loud; the route also validates, no silent clamp).
+--
+-- Idempotent -- safe to re-run (drizzle migrator + the hand-built test schema).
+
+CREATE TABLE IF NOT EXISTS "org_usage_discounts" (
+  "org_id" uuid PRIMARY KEY,
+  "discount_pct" integer NOT NULL,
+  "set_by" text,
+  "set_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "org_usage_discount_pct_range" CHECK ("discount_pct" >= 0 AND "discount_pct" <= 100)
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1790416800000,
       "tag": "0025_admin_grants",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1790503200000,
+      "tag": "0026_org_usage_discounts",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -102,6 +102,16 @@
             "type": "string",
             "description": "User-facing credit balance: credited funds minus actualized platform usage only. Provisioned holds are not subtracted here because they may later actualize or cancel."
           },
+          "usage_discount_pct": {
+            "type": "integer",
+            "nullable": true
+          },
+          "net_usage_cents": {
+            "type": "string"
+          },
+          "net_actual_usage_cents": {
+            "type": "string"
+          },
           "topup_amount_cents": {
             "type": "integer",
             "nullable": true
@@ -141,6 +151,9 @@
           "usage_cents",
           "balance_cents",
           "actual_balance_cents",
+          "usage_discount_pct",
+          "net_usage_cents",
+          "net_actual_usage_cents",
           "topup_amount_cents",
           "topup_threshold_cents",
           "has_payment_method",
@@ -633,6 +646,46 @@
         },
         "required": [
           "grants"
+        ]
+      },
+      "UsageDiscountResponse": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "discountPct": {
+            "type": "integer",
+            "nullable": true
+          },
+          "setBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "setAt": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "orgId",
+          "discountPct",
+          "setBy",
+          "setAt"
+        ]
+      },
+      "SetUsageDiscountRequest": {
+        "type": "object",
+        "properties": {
+          "discountPct": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          }
+        },
+        "required": [
+          "discountPct"
         ]
       },
       "PromoCode": {
@@ -2355,6 +2408,179 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CreditGrantsListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid x-org-id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/usage-discount": {
+      "get": {
+        "summary": "Read this org's platform-usage discount (staff)",
+        "description": "Returns the current usage-discount percentage for x-org-id, or discountPct=null when no discount is set (full pricing). Includes the audit (setBy / setAt). Staff-gated on the gateway, mirroring the credit-grant path (x-api-key + x-org-id).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Staff email behind the grant; recorded as grantedBy."
+            },
+            "required": false,
+            "name": "x-email",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current discount (discountPct null when none)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageDiscountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid x-org-id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Set / replace this org's platform-usage discount (staff)",
+        "description": "Upserts the single usage-discount value for x-org-id (0–100, integer). The org then effectively pays (1 − discountPct/100) of its gross platform usage: the usage billing subtracts at balance composition is reduced, so the balance depletes proportionally slower and auto-topups fire proportionally less often. Gross usage in runs-service is untouched. x-email is recorded as setBy. Out-of-range percentages are rejected (400) — no silent clamp.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Staff email behind the grant; recorded as grantedBy."
+            },
+            "required": false,
+            "name": "x-email",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetUsageDiscountRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Discount set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageDiscountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid discountPct (must be an integer 0–100) or invalid x-org-id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove this org's platform-usage discount (staff)",
+        "description": "Deletes the usage discount for x-org-id (→ null → full pricing). Restores full pricing on the NEXT balance composition (not retroactive). Idempotent: removing a non-existent discount still returns 200 with discountPct=null.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "x-org-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Staff email behind the grant; recorded as grantedBy."
+            },
+            "required": false,
+            "name": "x-email",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Discount removed (discountPct null)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageDiscountResponse"
                 }
               }
             }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -253,6 +253,29 @@ export const brandDailyBudgets = pgTable(
 export type BrandDailyBudget = typeof brandDailyBudgets.$inferSelect;
 export type NewBrandDailyBudget = typeof brandDailyBudgets.$inferInsert;
 
+// org_usage_discounts: per-org platform-usage discount (staff-managed).
+// ONE row per org (org_id PK); absence of a row = no discount = today's exact
+// behavior. discount_pct is an integer 0..100 (DB CHECK + route validation, no
+// silent clamp). At balance composition, billing subtracts NET usage =
+// gross_usage × (1 − discount_pct/100), so a discounted org's spendable balance
+// depletes proportionally slower and its Stripe topups fire proportionally less
+// often. The GROSS usage in runs-service is NEVER overwritten (reporting sees
+// the full number). Replaceable (upsert) + removable (DELETE → null). set_by /
+// set_at record which staff member set it and when. Migration 0026.
+export const orgUsageDiscounts = pgTable("org_usage_discounts", {
+  orgId: uuid("org_id").primaryKey(),
+  discountPct: integer("discount_pct").notNull(),
+  // Staff email behind the discount (null when set by a service with no email).
+  setBy: text("set_by"),
+  setAt: timestamp("set_at", { withTimezone: true }).notNull().defaultNow(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+export type OrgUsageDiscount = typeof orgUsageDiscounts.$inferSelect;
+export type NewOrgUsageDiscount = typeof orgUsageDiscounts.$inferInsert;
+
 // Dunning eventTypes — byte-equal to the templates registered by the dashboard
 // app (distribute.you#1420). LOCKED contract; do not rename.
 export const DUNNING_EVENT_T0 = "credit-depleted";

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import internalRoutes from "./routes/internal.js";
 import creditsRoutes from "./routes/credits.js";
 import promoCodesRoutes from "./routes/promo_codes.js";
 import brandBudgetsRoutes from "./routes/brand_budgets.js";
+import usageDiscountRoutes from "./routes/usage_discount.js";
 import { requireApiKey } from "./middleware/auth.js";
 import { startDunningScheduler } from "./lib/dunning-scheduler.js";
 
@@ -48,6 +49,7 @@ app.use(internalRoutes);
 app.use(creditsRoutes);
 app.use(promoCodesRoutes);
 app.use(brandBudgetsRoutes);
+app.use(usageDiscountRoutes);
 app.use(accountsRoutes);
 app.use(customerBalanceRoutes);
 app.use(checkoutRoutes);

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -9,6 +9,7 @@
 import { addCents, subCents } from "./cents.js";
 import { sumLocalPromoCreditsForOrg } from "./promos.js";
 import { fetchRunsOrgUsageTotal } from "./runs-client.js";
+import { getUsageDiscountPct, applyUsageDiscount } from "./usage-discount.js";
 import {
   fetchOrgCustomer,
   sumSucceededTopupsForOrg,
@@ -35,7 +36,16 @@ export interface BalanceSnapshot {
    */
   paidTopupsCents: string;
   creditedCents: string;
+  /** GROSS platform usage from runs-service (reporting truth — never discounted). */
   usageCents: string;
+  /**
+   * Per-org usage-discount percentage applied at composition (null = none).
+   * A discounted org subtracts NET usage below, so its balance depletes slower.
+   */
+  discountPct: number | null;
+  /** NET usage after discount = gross × (1 − pct/100). Equals usageCents when no discount. */
+  netUsageCents: string;
+  /** Spendable balance = creditedCents − netUsageCents (discount-adjusted). */
   balanceCents: string;
 }
 
@@ -51,15 +61,20 @@ export interface BalanceSnapshot {
  */
 export async function computeBalance(orgId: string): Promise<BalanceSnapshot> {
   const customer = await fetchOrgCustomer(orgId);
-  const [paidTopups, localCredits, runsUsage, hasCardPm, cardCountry] = await Promise.all([
-    sumSucceededTopupsForOrg(orgId),
-    sumLocalPromoCreditsForOrg(orgId),
-    fetchRunsOrgUsageTotal(orgId, {}),
-    hasChargeablePmForOrg(orgId),
-    getOrgCardCountryByOrg(orgId),
-  ]);
+  const [paidTopups, localCredits, runsUsage, hasCardPm, cardCountry, discountPct] =
+    await Promise.all([
+      sumSucceededTopupsForOrg(orgId),
+      sumLocalPromoCreditsForOrg(orgId),
+      fetchRunsOrgUsageTotal(orgId, {}),
+      hasChargeablePmForOrg(orgId),
+      getOrgCardCountryByOrg(orgId),
+      getUsageDiscountPct(orgId),
+    ]);
   const creditedCents = addCents(paidTopups, localCredits);
-  const balanceCents = subCents(creditedCents, runsUsage.spent_cents);
+  // Discount reduces the usage billing subtracts (gross usage stays reporting
+  // truth). netUsage === gross when discountPct is null → byte-identical balance.
+  const netUsageCents = applyUsageDiscount(runsUsage.spent_cents, discountPct);
+  const balanceCents = subCents(creditedCents, netUsageCents);
   return {
     customer,
     hasCardPm,
@@ -68,6 +83,8 @@ export async function computeBalance(orgId: string): Promise<BalanceSnapshot> {
     paidTopupsCents: paidTopups,
     creditedCents,
     usageCents: runsUsage.spent_cents,
+    discountPct,
+    netUsageCents,
     balanceCents,
   };
 }

--- a/src/lib/usage-discount.ts
+++ b/src/lib/usage-discount.ts
@@ -1,0 +1,126 @@
+/**
+ * Per-org platform-usage discount.
+ *
+ * A discounted org effectively pays (1 − pct/100) of its GROSS platform usage.
+ * The discount is applied ON READ wherever billing composes an org's spendable
+ * balance — it REDUCES the usage component billing subtracts, so the balance
+ * depletes proportionally slower and Stripe topups fire proportionally less
+ * often. The GROSS usage in runs-service is never touched (reporting sees the
+ * full number).
+ *
+ * ONE value per org (org_usage_discounts.org_id PK). Absence of a row = null =
+ * no discount = today's exact behavior. Replaceable (upsert), removable (delete
+ * → null, not retroactive — restores full pricing on the next composition).
+ *
+ * Fail-loud: an out-of-range percentage throws (the route also validates via
+ * Zod); no silent clamp, no fallback default.
+ */
+
+import { Decimal } from "decimal.js";
+import { eq } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { orgUsageDiscounts } from "../db/schema.js";
+
+// Match the fractional-cents scale used everywhere (numeric(16,10)).
+const SCALE = 10;
+
+export class InvalidUsageDiscountError extends Error {
+  constructor(value: unknown) {
+    super(
+      `usage discount percentage must be an integer 0–100, got ${String(value)}`
+    );
+    this.name = "InvalidUsageDiscountError";
+  }
+}
+
+export interface UsageDiscount {
+  discountPct: number;
+  /** Staff email behind the discount; null when none was recorded. */
+  setBy: string | null;
+  /** ISO-8601 timestamp the discount was last set. */
+  setAt: string;
+}
+
+/**
+ * The org's usage-discount percentage, or null when unset (no discount).
+ * The single value read on every balance-composition path.
+ */
+export async function getUsageDiscountPct(orgId: string): Promise<number | null> {
+  const [row] = await db
+    .select({ discountPct: orgUsageDiscounts.discountPct })
+    .from(orgUsageDiscounts)
+    .where(eq(orgUsageDiscounts.orgId, orgId))
+    .limit(1);
+  return row ? row.discountPct : null;
+}
+
+/** The full discount row (pct + audit), or null when unset. */
+export async function getUsageDiscount(orgId: string): Promise<UsageDiscount | null> {
+  const [row] = await db
+    .select()
+    .from(orgUsageDiscounts)
+    .where(eq(orgUsageDiscounts.orgId, orgId))
+    .limit(1);
+  if (!row) return null;
+  return {
+    discountPct: row.discountPct,
+    setBy: row.setBy,
+    setAt: row.setAt.toISOString(),
+  };
+}
+
+/**
+ * Set / replace an org's usage discount. Upsert on org_id — ONE value per org.
+ * Fail-loud on an out-of-range percentage (never clamps).
+ */
+export async function setUsageDiscount(
+  orgId: string,
+  discountPct: number,
+  setBy: string | null
+): Promise<UsageDiscount> {
+  if (!Number.isInteger(discountPct) || discountPct < 0 || discountPct > 100) {
+    throw new InvalidUsageDiscountError(discountPct);
+  }
+  const now = new Date();
+  const [row] = await db
+    .insert(orgUsageDiscounts)
+    .values({ orgId, discountPct, setBy, setAt: now })
+    .onConflictDoUpdate({
+      target: orgUsageDiscounts.orgId,
+      set: { discountPct, setBy, setAt: now },
+    })
+    .returning();
+  return {
+    discountPct: row.discountPct,
+    setBy: row.setBy,
+    setAt: row.setAt.toISOString(),
+  };
+}
+
+/**
+ * Remove an org's usage discount (→ null, restoring full pricing on the next
+ * composition — not retroactive). Idempotent: returns true iff a row existed.
+ */
+export async function removeUsageDiscount(orgId: string): Promise<boolean> {
+  const removed = await db
+    .delete(orgUsageDiscounts)
+    .where(eq(orgUsageDiscounts.orgId, orgId))
+    .returning({ orgId: orgUsageDiscounts.orgId });
+  return removed.length > 0;
+}
+
+/**
+ * Net usage after applying the org's discount: gross × (1 − pct/100).
+ *
+ * pct null or 0 → returns the gross string UNCHANGED (byte-identical to
+ * pre-discount behavior — the whole point of backward compatibility). Otherwise
+ * returns a canonical fixed-scale string.
+ */
+export function applyUsageDiscount(
+  grossUsageCents: string,
+  discountPct: number | null
+): string {
+  if (discountPct == null || discountPct === 0) return grossUsageCents;
+  const factor = new Decimal(100 - discountPct).dividedBy(100);
+  return new Decimal(grossUsageCents).times(factor).toFixed(SCALE);
+}

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -10,6 +10,7 @@ import { addCents, isDepleted, subCents } from "../lib/cents.js";
 import { tierFor } from "../lib/topup-tier.js";
 import { fetchRunsOrgActualUsageTotal, fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
 import { grantFirstLoadMatch, sumLocalPromoCreditsForOrg } from "../lib/promos.js";
+import { getUsageDiscountPct, applyUsageDiscount } from "../lib/usage-discount.js";
 import { reloadViaPaymentIntent } from "../lib/reload.js";
 import {
   getCustomerByOrg,
@@ -46,28 +47,41 @@ async function composeAccountFunds(
   usageCents: string;
   balanceCents: string;
   actualBalanceCents: string;
+  discountPct: number | null;
+  netUsageCents: string;
+  netActualUsageCents: string;
   paidTopupsCents: string;
   hasPaymentMethod: boolean;
   cardCountry: string | null;
   autoReloadSupported: boolean;
 }> {
   const customer = await getCustomerByOrg(identity);
-  const [paidTopups, localCredits, runsUsage, actualRunsUsage, hasCardPm, cardCountry] = await Promise.all([
-    sumSucceededTopupsForCustomer(identity, customer.id),
-    sumLocalPromoCreditsForOrg(orgId),
-    fetchRunsOrgUsageTotal(orgId, identity),
-    fetchRunsOrgActualUsageTotal(orgId, identity),
-    hasAttachedCardPm(identity, customer.id),
-    getOrgCardCountry(identity, customer.id),
-  ]);
+  const [paidTopups, localCredits, runsUsage, actualRunsUsage, hasCardPm, cardCountry, discountPct] =
+    await Promise.all([
+      sumSucceededTopupsForCustomer(identity, customer.id),
+      sumLocalPromoCreditsForOrg(orgId),
+      fetchRunsOrgUsageTotal(orgId, identity),
+      fetchRunsOrgActualUsageTotal(orgId, identity),
+      hasAttachedCardPm(identity, customer.id),
+      getOrgCardCountry(identity, customer.id),
+      getUsageDiscountPct(orgId),
+    ]);
   const creditedCents = addCents(paidTopups, localCredits);
-  const balanceCents = subCents(creditedCents, runsUsage.spent_cents);
-  const actualBalanceCents = subCents(creditedCents, actualRunsUsage.spent_cents);
+  // Discount reduces the usage subtracted from credited (gross usage_cents stays
+  // reporting truth). Both net values equal their gross when discountPct is null,
+  // so balance_cents / actual_balance_cents are byte-identical without a discount.
+  const netUsageCents = applyUsageDiscount(runsUsage.spent_cents, discountPct);
+  const netActualUsageCents = applyUsageDiscount(actualRunsUsage.spent_cents, discountPct);
+  const balanceCents = subCents(creditedCents, netUsageCents);
+  const actualBalanceCents = subCents(creditedCents, netActualUsageCents);
   return {
     creditedCents,
     usageCents: runsUsage.spent_cents,
     balanceCents,
     actualBalanceCents,
+    discountPct,
+    netUsageCents,
+    netActualUsageCents,
     paidTopupsCents: paidTopups,
     hasPaymentMethod: hasCardPm,
     cardCountry,
@@ -82,6 +96,9 @@ function buildAccountResponse(
     usageCents: string;
     balanceCents: string;
     actualBalanceCents: string;
+    discountPct: number | null;
+    netUsageCents: string;
+    netActualUsageCents: string;
     paidTopupsCents: string;
     hasPaymentMethod: boolean;
     cardCountry: string | null;
@@ -103,6 +120,14 @@ function buildAccountResponse(
     usage_cents: funds.usageCents,
     balance_cents: funds.balanceCents,
     actual_balance_cents: funds.actualBalanceCents,
+    // Per-org platform-usage discount. null = no discount (usage_cents is the net
+    // usage, balance_cents/actual_balance_cents unchanged). When set, usage_cents
+    // stays GROSS (reporting) and net_usage_cents / net_actual_usage_cents are the
+    // discounted usage the balance figures already subtract — the dashboard renders
+    // the banner (usage_discount_pct) + strikethrough (gross usage_cents vs net).
+    usage_discount_pct: funds.discountPct,
+    net_usage_cents: funds.netUsageCents,
+    net_actual_usage_cents: funds.netActualUsageCents,
     topup_amount_cents: tier ? tier.amountCents : null,
     topup_threshold_cents: tier ? tier.thresholdCents : null,
     has_payment_method: funds.hasPaymentMethod,

--- a/src/routes/customer_balance.ts
+++ b/src/routes/customer_balance.ts
@@ -8,6 +8,7 @@ import { findOrCreateAccount } from "../lib/account.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { addCents, subCents, gte as gteCents, parseNonNegativeCents } from "../lib/cents.js";
 import { sumLocalPromoCreditsForOrg } from "../lib/promos.js";
+import { getUsageDiscountPct, applyUsageDiscount } from "../lib/usage-discount.js";
 import {
   getCustomerByOrg,
   sumSucceededTopupsForCustomer,
@@ -340,13 +341,18 @@ router.post("/v1/customer_balance/usage_apply", requireOrgHeaders, async (req, r
       return;
     }
 
-    const [paidTopups, localCredits] = await Promise.all([
+    const [paidTopups, localCredits, discountPct] = await Promise.all([
       sumSucceededTopupsForCustomer(identity, customer.id),
       sumLocalPromoCreditsForOrg(orgId),
+      getUsageDiscountPct(orgId),
     ]);
 
     const creditedCents = addCents(paidTopups, localCredits);
-    const balanceCents = subCents(creditedCents, spentTotalCents);
+    // Discount the reported spend before the threshold check so a discounted org's
+    // balance depletes slower → auto-topup fires proportionally less often. Gross
+    // spend is unchanged when discountPct is null (byte-identical topup cadence).
+    const netSpentCents = applyUsageDiscount(spentTotalCents, discountPct);
+    const balanceCents = subCents(creditedCents, netSpentCents);
 
     // Threshold-based postpaid: the effective (amount, threshold) come from the
     // derived tier (a function of cumulative paid topups), NOT the stored daily

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -21,6 +21,7 @@ import { runDunningTick } from "../lib/dunning.js";
 import { getCampaignAuthorizeCost } from "../lib/campaign-costs.js";
 import { computeBalance } from "../lib/balance.js";
 import { fetchRunsOrgActualUsageTotal } from "../lib/runs-client.js";
+import { applyUsageDiscount } from "../lib/usage-discount.js";
 import { gte as gteCents, isDepleted, subCents } from "../lib/cents.js";
 
 const router = Router();
@@ -385,8 +386,14 @@ router.get("/internal/accounts/by-org/:orgId/balance", async (req, res) => {
     snapshot.autoReloadSupported;
 
   res.json({
+    // balance_cents is already discount-adjusted (computeBalance subtracts net
+    // usage). actual_balance_cents must apply the same discount to the actualized
+    // usage — snapshot.discountPct is the org's live pct (null → gross unchanged).
     balance_cents: snapshot.balanceCents,
-    actual_balance_cents: subCents(snapshot.creditedCents, actualUsage.spent_cents),
+    actual_balance_cents: subCents(
+      snapshot.creditedCents,
+      applyUsageDiscount(actualUsage.spent_cents, snapshot.discountPct)
+    ),
     depleted: isDepleted(snapshot.balanceCents),
     has_auto_topup: hasAutoTopup,
   });

--- a/src/routes/usage_discount.ts
+++ b/src/routes/usage_discount.ts
@@ -1,0 +1,107 @@
+import { Router } from "express";
+import { SetUsageDiscountRequestSchema } from "../schemas.js";
+import {
+  getUsageDiscount,
+  setUsageDiscount,
+  removeUsageDiscount,
+  InvalidUsageDiscountError,
+} from "../lib/usage-discount.js";
+
+const router = Router();
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Staff-managed per-org platform-usage discount. Auth mirrors the credit-grant
+// path (POST /v1/credits/grant): x-api-key (service via gateway, enforced app-
+// wide by requireApiKey) + x-org-id (target org UUID); the gateway gates these to
+// staff. x-email is the staff member (recorded as setBy on a set). ONE value per
+// org — replaceable (PUT) and removable (DELETE → null).
+function resolveOrgId(
+  req: import("express").Request,
+  res: import("express").Response
+): string | null {
+  const orgId = req.headers["x-org-id"] as string | undefined;
+  if (!orgId) {
+    console.error(`[billing-400] ${req.method} ${req.path}: missing x-org-id`);
+    res.status(400).json({ error: "x-org-id header is required" });
+    return null;
+  }
+  if (!UUID_RE.test(orgId)) {
+    console.error(
+      `[billing-400] ${req.method} ${req.path}: invalid x-org-id="${orgId}" (not a UUID)`
+    );
+    res.status(400).json({ error: "x-org-id must be a valid UUID" });
+    return null;
+  }
+  return orgId;
+}
+
+// GET /v1/usage-discount — read this org's usage discount.
+// → { orgId, discountPct, setBy, setAt } (discountPct/setBy/setAt null when unset).
+router.get("/v1/usage-discount", async (req, res) => {
+  const orgId = resolveOrgId(req, res);
+  if (!orgId) return;
+
+  const discount = await getUsageDiscount(orgId);
+  res.json({
+    orgId,
+    discountPct: discount ? discount.discountPct : null,
+    setBy: discount ? discount.setBy : null,
+    setAt: discount ? discount.setAt : null,
+  });
+});
+
+// PUT /v1/usage-discount — set / replace this org's usage discount.
+// Body: { discountPct: integer 0–100 }. setBy = x-email.
+// Fail loud: out-of-range / missing discountPct → 400 (no clamp, no default).
+router.put("/v1/usage-discount", async (req, res) => {
+  const orgId = resolveOrgId(req, res);
+  if (!orgId) return;
+
+  const parsed = SetUsageDiscountRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.issues[0].message });
+    return;
+  }
+
+  const setBy = (req.headers["x-email"] as string | undefined) ?? null;
+
+  let discount;
+  try {
+    discount = await setUsageDiscount(orgId, parsed.data.discountPct, setBy);
+  } catch (err) {
+    if (err instanceof InvalidUsageDiscountError) {
+      res.status(400).json({ error: err.message });
+      return;
+    }
+    throw err;
+  }
+
+  console.log(
+    `[billing-service] usage discount set: org=${orgId} pct=${discount.discountPct} by=${setBy ?? "(unknown)"}`
+  );
+
+  res.json({
+    orgId,
+    discountPct: discount.discountPct,
+    setBy: discount.setBy,
+    setAt: discount.setAt,
+  });
+});
+
+// DELETE /v1/usage-discount — remove this org's usage discount (→ null).
+// Idempotent: no discount → still 200 with discountPct null. Not retroactive.
+router.delete("/v1/usage-discount", async (req, res) => {
+  const orgId = resolveOrgId(req, res);
+  if (!orgId) return;
+
+  const removed = await removeUsageDiscount(orgId);
+  console.log(
+    `[billing-service] usage discount ${removed ? "removed" : "remove (no-op, none set)"}: org=${orgId}`
+  );
+
+  res.json({ orgId, discountPct: null, setBy: null, setAt: null });
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -45,6 +45,17 @@ export const BillingAccountSchema = z
     balance_cents: SpendableBalanceCentsSchema,
     /** User-facing balance = credited_cents − actualized usage only. */
     actual_balance_cents: ActualBalanceCentsSchema,
+    /**
+     * Per-org platform-usage discount percentage (0–100), or null when none.
+     * null → no discount: usage_cents is the net usage and balance figures are
+     * unchanged. When set, usage_cents stays GROSS (reporting) and the balance
+     * figures already subtract the discounted (net) usage below.
+     */
+    usage_discount_pct: z.number().int().nullable(),
+    /** NET committed usage after discount = usage_cents × (1 − pct/100); equals usage_cents when no discount. */
+    net_usage_cents: CentsStringSchema,
+    /** NET actualized usage after discount; the amount actual_balance_cents subtracts from credited. */
+    net_actual_usage_cents: CentsStringSchema,
     topup_amount_cents: z.number().int().nullable(),
     topup_threshold_cents: z.number().int().nullable(),
     has_payment_method: z.boolean(),
@@ -286,6 +297,31 @@ export const CreditGrantsListResponseSchema = z
     grants: z.array(CreditGrantItemSchema),
   })
   .openapi("CreditGrantsListResponse");
+
+// --- Per-org usage discount (staff-managed, single replaceable value) ---
+
+export const SetUsageDiscountRequestSchema = z
+  .object({
+    /**
+     * Platform-usage discount percentage, integer 0–100. Out-of-range is
+     * rejected (400) — no silent clamp, no default. The org then pays
+     * (1 − discountPct/100) of its gross usage at balance composition.
+     */
+    discountPct: z.number().int().min(0).max(100),
+  })
+  .openapi("SetUsageDiscountRequest");
+
+export const UsageDiscountResponseSchema = z
+  .object({
+    orgId: z.string().uuid(),
+    /** Current discount percentage (0–100); null when no discount is set. */
+    discountPct: z.number().int().nullable(),
+    /** Staff email that set the discount; null when unset or none recorded. */
+    setBy: z.string().nullable(),
+    /** ISO-8601 timestamp the discount was last set; null when unset. */
+    setAt: z.string().nullable(),
+  })
+  .openapi("UsageDiscountResponse");
 
 // --- Internal account teardown (client-service org cascade delete) ---
 
@@ -891,6 +927,77 @@ registry.registerPath({
       content: {
         "application/json": { schema: CreditGrantsListResponseSchema },
       },
+    },
+    400: {
+      description: "Missing or invalid x-org-id",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/v1/usage-discount",
+  summary: "Read this org's platform-usage discount (staff)",
+  description:
+    "Returns the current usage-discount percentage for x-org-id, or discountPct=null " +
+    "when no discount is set (full pricing). Includes the audit (setBy / setAt). " +
+    "Staff-gated on the gateway, mirroring the credit-grant path (x-api-key + x-org-id).",
+  request: { headers: adminGrantHeaders },
+  responses: {
+    200: {
+      description: "Current discount (discountPct null when none)",
+      content: { "application/json": { schema: UsageDiscountResponseSchema } },
+    },
+    400: {
+      description: "Missing or invalid x-org-id",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "put",
+  path: "/v1/usage-discount",
+  summary: "Set / replace this org's platform-usage discount (staff)",
+  description:
+    "Upserts the single usage-discount value for x-org-id (0–100, integer). The org " +
+    "then effectively pays (1 − discountPct/100) of its gross platform usage: the " +
+    "usage billing subtracts at balance composition is reduced, so the balance " +
+    "depletes proportionally slower and auto-topups fire proportionally less often. " +
+    "Gross usage in runs-service is untouched. x-email is recorded as setBy. " +
+    "Out-of-range percentages are rejected (400) — no silent clamp.",
+  request: {
+    headers: adminGrantHeaders,
+    body: {
+      content: { "application/json": { schema: SetUsageDiscountRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Discount set",
+      content: { "application/json": { schema: UsageDiscountResponseSchema } },
+    },
+    400: {
+      description: "Invalid discountPct (must be an integer 0–100) or invalid x-org-id",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "delete",
+  path: "/v1/usage-discount",
+  summary: "Remove this org's platform-usage discount (staff)",
+  description:
+    "Deletes the usage discount for x-org-id (→ null → full pricing). Restores full " +
+    "pricing on the NEXT balance composition (not retroactive). Idempotent: removing " +
+    "a non-existent discount still returns 200 with discountPct=null.",
+  request: { headers: adminGrantHeaders },
+  responses: {
+    200: {
+      description: "Discount removed (discountPct null)",
+      content: { "application/json": { schema: UsageDiscountResponseSchema } },
     },
     400: {
       description: "Missing or invalid x-org-id",

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -11,6 +11,7 @@ import internalRoutes from "../../src/routes/internal.js";
 import creditsRoutes from "../../src/routes/credits.js";
 import promoCodesRoutes from "../../src/routes/promo_codes.js";
 import brandBudgetsRoutes from "../../src/routes/brand_budgets.js";
+import usageDiscountRoutes from "../../src/routes/usage_discount.js";
 import { requireApiKey } from "../../src/middleware/auth.js";
 
 export function createTestApp() {
@@ -26,6 +27,7 @@ export function createTestApp() {
   app.use(creditsRoutes);
   app.use(promoCodesRoutes);
   app.use(brandBudgetsRoutes);
+  app.use(usageDiscountRoutes);
   app.use(accountsRoutes);
   app.use(customerBalanceRoutes);
   app.use(checkoutRoutes);

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -7,6 +7,7 @@ import {
   creditDepletionEpisodes,
   campaignAuthorizeCosts,
   brandDailyBudgets,
+  orgUsageDiscounts,
   WELCOME_PROMO_CODE,
   INVITE_REWARD_CODE,
   INVITE_WELCOME_CODE,
@@ -28,6 +29,7 @@ export async function cleanTestData() {
   await db.delete(creditDepletionEpisodes);
   await db.delete(campaignAuthorizeCosts);
   await db.delete(brandDailyBudgets);
+  await db.delete(orgUsageDiscounts);
   await db.delete(localPromos);
   await db.delete(billingAccounts);
   // Keep seeded codes (welcome + invite_reward + invite_welcome +
@@ -174,6 +176,22 @@ export async function insertTestCampaignCost(data: {
       campaignId: data.campaignId,
       orgId: data.orgId,
       lastAuthorizeRequiredCents: data.lastAuthorizeRequiredCents,
+    })
+    .returning();
+  return row;
+}
+
+export async function insertTestUsageDiscount(data: {
+  orgId: string;
+  discountPct: number;
+  setBy?: string | null;
+}) {
+  const [row] = await db
+    .insert(orgUsageDiscounts)
+    .values({
+      orgId: data.orgId,
+      discountPct: data.discountPct,
+      setBy: data.setBy ?? null,
     })
     .returning();
   return row;

--- a/tests/integration/usage-discount.test.ts
+++ b/tests/integration/usage-discount.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+// Single file-scope pool teardown — two describe blocks share ONE pg pool, so
+// only close it once after both finish (a per-describe closeDb ends the pool
+// early and the second block's queries fail with CONNECTION_ENDED).
+import request from "supertest";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import {
+  cleanTestData,
+  insertTestAccount,
+  insertTestUsageDiscount,
+  closeDb,
+} from "../helpers/test-db.js";
+import { setupStripeMocks, customerWithDefaultPM } from "../helpers/mock-stripe.js";
+
+const orgId = "00000000-0000-0000-0000-0000000dd001";
+const userId = "00000000-0000-0000-0000-000000000099";
+const apiKey = { "X-API-Key": "test-api-key" };
+
+function orgHeaders(email?: string) {
+  const h: Record<string, string> = {
+    "X-API-Key": "test-api-key",
+    "x-org-id": orgId,
+    "Content-Type": "application/json",
+  };
+  if (email) h["x-email"] = email;
+  return h;
+}
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe("Staff usage-discount CRUD (/v1/usage-discount)", () => {
+  const app = createTestApp();
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    setupStripeMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+  });
+
+  it("GET returns discountPct=null when no discount is set", async () => {
+    const res = await request(app).get("/v1/usage-discount").set(orgHeaders());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ orgId, discountPct: null, setBy: null, setAt: null });
+  });
+
+  it("PUT sets a discount and records setBy; GET reflects it", async () => {
+    const put = await request(app)
+      .put("/v1/usage-discount")
+      .set(orgHeaders("staff@distribute.you"))
+      .send({ discountPct: 50 });
+    expect(put.status).toBe(200);
+    expect(put.body.orgId).toBe(orgId);
+    expect(put.body.discountPct).toBe(50);
+    expect(put.body.setBy).toBe("staff@distribute.you");
+    expect(typeof put.body.setAt).toBe("string");
+
+    const get = await request(app).get("/v1/usage-discount").set(orgHeaders());
+    expect(get.status).toBe(200);
+    expect(get.body.discountPct).toBe(50);
+    expect(get.body.setBy).toBe("staff@distribute.you");
+  });
+
+  it("PUT replaces the single value (no stacking)", async () => {
+    await request(app).put("/v1/usage-discount").set(orgHeaders()).send({ discountPct: 30 });
+    await request(app).put("/v1/usage-discount").set(orgHeaders()).send({ discountPct: 70 });
+
+    const get = await request(app).get("/v1/usage-discount").set(orgHeaders());
+    expect(get.body.discountPct).toBe(70);
+  });
+
+  it("accepts boundary values 0 and 100", async () => {
+    const zero = await request(app).put("/v1/usage-discount").set(orgHeaders()).send({ discountPct: 0 });
+    expect(zero.status).toBe(200);
+    expect(zero.body.discountPct).toBe(0);
+
+    const hundred = await request(app).put("/v1/usage-discount").set(orgHeaders()).send({ discountPct: 100 });
+    expect(hundred.status).toBe(200);
+    expect(hundred.body.discountPct).toBe(100);
+  });
+
+  it("DELETE removes the discount (→ null); GET returns null", async () => {
+    await insertTestUsageDiscount({ orgId, discountPct: 40, setBy: "x@y.z" });
+
+    const del = await request(app).delete("/v1/usage-discount").set(orgHeaders());
+    expect(del.status).toBe(200);
+    expect(del.body).toEqual({ orgId, discountPct: null, setBy: null, setAt: null });
+
+    const get = await request(app).get("/v1/usage-discount").set(orgHeaders());
+    expect(get.body.discountPct).toBeNull();
+  });
+
+  it("DELETE is idempotent when no discount exists", async () => {
+    const del = await request(app).delete("/v1/usage-discount").set(orgHeaders());
+    expect(del.status).toBe(200);
+    expect(del.body.discountPct).toBeNull();
+  });
+
+  it("rejects an out-of-range percentage (fail loud, no clamp)", async () => {
+    const over = await request(app).put("/v1/usage-discount").set(orgHeaders()).send({ discountPct: 150 });
+    expect(over.status).toBe(400);
+
+    const neg = await request(app).put("/v1/usage-discount").set(orgHeaders()).send({ discountPct: -10 });
+    expect(neg.status).toBe(400);
+
+    // Nothing was persisted by a rejected request.
+    const get = await request(app).get("/v1/usage-discount").set(orgHeaders());
+    expect(get.body.discountPct).toBeNull();
+  });
+
+  it("rejects a non-integer percentage", async () => {
+    const res = await request(app).put("/v1/usage-discount").set(orgHeaders()).send({ discountPct: 12.5 });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a missing discountPct (no default)", async () => {
+    const res = await request(app).put("/v1/usage-discount").set(orgHeaders()).send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("401 without service auth (GET/PUT/DELETE)", async () => {
+    expect((await request(app).get("/v1/usage-discount").set({ "x-org-id": orgId })).status).toBe(401);
+    expect(
+      (await request(app).put("/v1/usage-discount").set({ "x-org-id": orgId }).send({ discountPct: 10 })).status
+    ).toBe(401);
+    expect((await request(app).delete("/v1/usage-discount").set({ "x-org-id": orgId })).status).toBe(401);
+  });
+
+  it("400 when x-org-id is missing or not a UUID", async () => {
+    expect((await request(app).get("/v1/usage-discount").set(apiKey)).status).toBe(400);
+    expect(
+      (await request(app).put("/v1/usage-discount").set({ ...apiKey, "x-org-id": "nope" }).send({ discountPct: 10 }))
+        .status
+    ).toBe(400);
+  });
+});
+
+describe("Usage discount reduces the usage component at balance composition", () => {
+  const app = createTestApp();
+  let ssMocks: ReturnType<typeof setupStripeMocks>;
+  let setUsage: (c: string) => void;
+  let setActualUsage: (c: string) => void;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    ssMocks = setupStripeMocks();
+    await cleanTestData();
+
+    const runsClient = await import("../../src/lib/runs-client.js");
+    let usage = "0.0000000000";
+    let actualUsage = "0.0000000000";
+    setUsage = (c) => { usage = c; };
+    setActualUsage = (c) => { actualUsage = c; };
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(async () => ({
+      org_id: orgId,
+      spent_cents: usage,
+      as_of: "2026-07-01T00:00:00.000Z",
+    }));
+    vi.spyOn(runsClient, "fetchRunsOrgActualUsageTotal").mockImplementation(async () => ({
+      spent_cents: actualUsage,
+    }));
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+  });
+
+  it("GET /v1/accounts: usage_cents stays GROSS, balance uses net usage, exposes discount + net", async () => {
+    await insertTestAccount({ orgId });
+    await insertTestUsageDiscount({ orgId, discountPct: 50 });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("1000.0000000000");
+    setUsage("100.0000000000");
+    setActualUsage("80.0000000000");
+
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId, userId));
+
+    expect(res.status).toBe(200);
+    // Gross reporting number is untouched.
+    expect(res.body.usage_cents).toBe("100.0000000000");
+    expect(res.body.usage_discount_pct).toBe(50);
+    expect(res.body.net_usage_cents).toBe("50.0000000000");
+    expect(res.body.net_actual_usage_cents).toBe("40.0000000000");
+    // Balance subtracts NET usage → 1000 − 50 = 950 (vs 900 without discount).
+    expect(res.body.balance_cents).toBe("950.0000000000");
+    expect(res.body.actual_balance_cents).toBe("960.0000000000");
+  });
+
+  it("GET /v1/accounts: no discount → byte-identical existing fields + null pct", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("1000.0000000000");
+    setUsage("100.0000000000");
+    setActualUsage("100.0000000000");
+
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId, userId));
+
+    expect(res.status).toBe(200);
+    expect(res.body.usage_discount_pct).toBeNull();
+    expect(res.body.usage_cents).toBe("100.0000000000");
+    expect(res.body.net_usage_cents).toBe("100.0000000000");
+    expect(res.body.balance_cents).toBe("900.0000000000");
+    expect(res.body.actual_balance_cents).toBe("900.0000000000");
+  });
+
+  it("GET /internal/accounts/by-org/:orgId/balance discounts both balance figures", async () => {
+    await insertTestAccount({ orgId });
+    await insertTestUsageDiscount({ orgId, discountPct: 50 });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("100.0000000000");
+    setUsage("80.0000000000");
+    setActualUsage("80.0000000000");
+
+    const res = await request(app)
+      .get(`/internal/accounts/by-org/${orgId}/balance`)
+      .set(apiKey);
+
+    expect(res.status).toBe(200);
+    // 100 − (80 × 0.5) = 60 (vs 20 without discount).
+    expect(res.body.balance_cents).toBe("60.0000000000");
+    expect(res.body.actual_balance_cents).toBe("60.0000000000");
+    expect(res.body.depleted).toBe(false);
+  });
+
+  it("authorize: a discount makes an otherwise-insufficient run sufficient", async () => {
+    await insertTestAccount({ orgId }); // no topup config → credit-line floor "0"
+    await insertTestUsageDiscount({ orgId, discountPct: 50 });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("100.0000000000");
+    setUsage("80.0000000000");
+
+    const costsClient = await import("../../src/lib/costs-client.js");
+    vi.spyOn(costsClient, "resolveRequiredCents").mockResolvedValue("30.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/authorize")
+      .set(getAuthHeaders(orgId, userId))
+      .send({ items: [{ costName: "x", quantity: 1 }] });
+
+    expect(res.status).toBe(200);
+    // net usage 40 → balance 60; 60 − 30 = 30 >= 0 → sufficient (gross would be −10).
+    expect(res.body.sufficient).toBe(true);
+    expect(res.body.balance_cents).toBe("60.0000000000");
+  });
+
+  it("usage_apply: a discount keeps balance above the floor → no topup fires", async () => {
+    await insertTestAccount({ orgId, topupAmountCents: 5000, topupThresholdCents: 5000 });
+    await insertTestUsageDiscount({ orgId, discountPct: 50 });
+    ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
+    // paid 0 → start tier floor -5000. Gross spend 6000 would blow past it and
+    // reload; net spend 3000 keeps balance −3000 (above floor) → no reload.
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+
+    const res = await request(app)
+      .post("/v1/customer_balance/usage_apply")
+      .set(getAuthHeaders(orgId, userId))
+      .send({ spent_total_cents: "6000.0000000000" });
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ acknowledged: true, topup_triggered: false });
+    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -141,6 +141,18 @@ beforeAll(async () => {
       PRIMARY KEY ("org_id", "brand_id")
   `;
 
+  // org_usage_discounts (per-org platform-usage discount, migration 0026).
+  await sql`
+    CREATE TABLE IF NOT EXISTS "org_usage_discounts" (
+      "org_id" uuid PRIMARY KEY,
+      "discount_pct" integer NOT NULL,
+      "set_by" text,
+      "set_at" timestamp with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+      CONSTRAINT "org_usage_discount_pct_range" CHECK ("discount_pct" >= 0 AND "discount_pct" <= 100)
+    )
+  `;
+
   // Seed platform-issued grant promo codes (matches migrations 0017 + 0025).
   await sql`
     INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")

--- a/tests/unit/usage-discount.test.ts
+++ b/tests/unit/usage-discount.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { applyUsageDiscount } from "../../src/lib/usage-discount.js";
+
+describe("applyUsageDiscount", () => {
+  it("returns gross verbatim when discount is null (byte-identical, no reformat)", () => {
+    expect(applyUsageDiscount("40.0000000000", null)).toBe("40.0000000000");
+    // Whatever string runs-service returned is passed through untouched.
+    expect(applyUsageDiscount("13.37", null)).toBe("13.37");
+  });
+
+  it("returns gross verbatim when discount is 0 (explicit no-op discount)", () => {
+    expect(applyUsageDiscount("40.0000000000", 0)).toBe("40.0000000000");
+  });
+
+  it("halves usage at 50%", () => {
+    expect(applyUsageDiscount("100.0000000000", 50)).toBe("50.0000000000");
+  });
+
+  it("zeroes usage at 100%", () => {
+    expect(applyUsageDiscount("100.0000000000", 100)).toBe("0.0000000000");
+  });
+
+  it("applies a 25% discount (keeps 75%)", () => {
+    expect(applyUsageDiscount("200.0000000000", 25)).toBe("150.0000000000");
+  });
+
+  it("preserves fractional-cents precision (non-tie rounding)", () => {
+    // 33.3333333333 × 0.9 = 29.99999999997 → rounds up at scale 10 (7 > 5),
+    // deterministic regardless of the global Decimal rounding mode.
+    expect(applyUsageDiscount("33.3333333333", 10)).toBe("30.0000000000");
+  });
+
+  it("applies a 1% discount", () => {
+    expect(applyUsageDiscount("100.0000000000", 1)).toBe("99.0000000000");
+  });
+});


### PR DESCRIPTION
## What

Staff can give an org a **0–100% discount on ALL its platform usage**, managed from the internal admin console. The discount REDUCES the usage component wherever billing composes the spendable balance, so a discounted org effectively pays `(1 − pct/100)` of its gross usage over time: its balance depletes proportionally slower and its Stripe topups fire proportionally less often. The GROSS usage in runs-service is never touched — reporting still sees the full number.

## How

- **`org_usage_discounts` table** (migration `0026`, hand-journaled): `org_id` PK, `discount_pct integer` (DB CHECK 0..100), `set_by`/`set_at` audit. ONE row per org — absence = null = no discount = today's exact behavior. Replaceable (upsert), removable (DELETE → null, not retroactive).
- **`src/lib/usage-discount.ts`**: get/set/remove + pure `applyUsageDiscount(gross, pct)` (pct null/0 → gross verbatim; else `gross × (1 − pct/100)` at scale 10).
- **Applied at every balance-composition site** (usage reduced, credited untouched):
  - `computeBalance` → feeds authorize, dunning scheduler, month-end sweep, `/internal/campaigns/:id/affordability`, `/internal/accounts/by-org/:orgId/balance`.
  - `composeAccountFunds` → `GET /v1/accounts` (+ balance/auto_topup/wallet_setup).
  - `usage_apply` → discounts the reported spend before the postpaid threshold check.
- **`GET /v1/accounts`** now returns `usage_discount_pct`, `net_usage_cents`, `net_actual_usage_cents` (`usage_cents` stays GROSS) so the dashboard renders a banner + strikethrough.
- **Staff `GET`/`PUT`/`DELETE /v1/usage-discount`** — auth mirrors the credit-grant path (`x-api-key` + `x-org-id`, `setBy = x-email`). Fail-loud: out-of-range → 400 (no clamp, no default).

## Backward-compat

Additive + fully backward-compatible: a **null/absent discount yields byte-identical existing fields and behavior** (the vast majority of orgs). New fields on `/v1/accounts` are additive.

## Tests

309 existing + 23 new (unit `applyUsageDiscount` + integration CRUD/auth/validation + effect on `/v1/accounts`, authorize, usage_apply, internal by-org balance) — all green. `tsc` + openapi regen clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)