### PR TITLE
refactor(billing): derive balance from runs' NET usage; stop applying discount (supersede #246)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,12 +150,10 @@ A slow spender whose balance never crosses the floor within a calendar month wou
   "id": "<uuid>",
   "org_id": "<uuid>",
   "credited_cents": "55200.0000000000",      // SUM(succeeded PI.amount_received) + SUM(local_promos.amount_cents)
-  "usage_cents": "38289.2958000000",         // runs-service spent_cents (platform actual+provisioned)
+  "usage_cents": "38289.2958000000",         // runs-service spent_cents (platform actual+provisioned). Already NET of any usage discount (frozen at cost-write in runs-service).
   "balance_cents": "16910.7042000000",       // credited_cents − usage_cents; USE THIS for depletion/budget gates
   "actual_balance_cents": "16920.7042000000", // credited_cents − actualized usage only; display this as the user's credit balance
-  "usage_discount_pct": 50,                  // per-org platform-usage discount (0–100); null when none. See "Per-org usage discount"
-  "net_usage_cents": "19144.6479000000",     // usage_cents × (1 − usage_discount_pct/100) = the NET committed usage balance_cents subtracts. Equals usage_cents when no discount.
-  "net_actual_usage_cents": "...",           // NET actualized usage; the amount actual_balance_cents subtracts. Equals gross actualized usage when no discount.
+  "usage_discount_pct": 50,                  // per-org platform-usage discount (0–100); null when none. EXPOSED for the dashboard banner only — does NOT affect the balance figures (discount is frozen in runs-service). See "Per-org usage discount"
   "topup_amount_cents": 5000,                // DERIVED tier reload amount (tierFor(cumulative paid)); null when auto-topup disabled. NOT the stored daily amount.
   "topup_threshold_cents": -5000,            // DERIVED tier NEGATIVE credit-line floor; auto-topup reloads when balance crosses it. null when disabled. See "Threshold-based postpaid top-up"
   "has_payment_method": true,                // ≥1 chargeable PM: card OR link (GET /v1/payment_methods?type=card, then type=link); NOT invoice_settings.default_payment_method
@@ -180,8 +178,8 @@ Composition (`src/routes/accounts.ts:composeAccountFunds`):
 5. `fetchRunsOrgActualUsageTotal(orgId, identity)` → runs-service `total_expected_cents` from actualized platform costs only
 6. `hasAttachedCardPm(identity, customer.id)` → `has_payment_method` (≥1 chargeable PM: card or link)
 7. `getOrgCardCountry(identity, customer.id)` → `card_country` → `auto_reload_supported = !isAutoReloadBlockedCountry(card_country)` (see "Off_session auto-reload" below)
-8. `getUsageDiscountPct(orgId)` → `usage_discount_pct` (see "Per-org usage discount"); the balance figures subtract NET usage
-9. `credited_cents = paid_topups + local_credits`; `net_usage = usage × (1 − pct/100)`; `balance_cents = credited_cents − net_usage`; `actual_balance_cents = credited_cents − net_actualized_usage`. `usage_cents` stays GROSS (reporting). No discount (`pct` null) → net == gross → every existing field is byte-identical.
+8. `getUsageDiscountPct(orgId)` → `usage_discount_pct` (dashboard banner only; see "Per-org usage discount"). Does NOT enter the balance math — runs-service already served net usage.
+9. `credited_cents = paid_topups + local_credits`; `balance_cents = credited_cents − usage`; `actual_balance_cents = credited_cents − actualized_usage`. runs-service usage is already NET of the discount, so billing subtracts it verbatim (no discount applied here).
 
 ### `GET /public/stats/billing`
 
@@ -227,22 +225,27 @@ Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed liv
 | `PATCH` | `/v1/brands/:brandId/daily-budget` | SET/UPDATE a brand's daily budget (user via gateway, org headers). body `{dailyBudgetCents}` (non-negative; 0 = pause). → `{brandId, orgId, dailyBudgetCents, updatedAt}`. |
 | `GET` | `/v1/usage-discount` | staff READ of this org's platform-usage discount. Auth mirrors credit-grant (`x-api-key` + `x-org-id`). → `{orgId, discountPct, setBy, setAt}`; unset → `discountPct:null`. See "Per-org usage discount". |
 | `PUT` | `/v1/usage-discount` | staff SET/REPLACE the discount. body `{discountPct}` (integer 0–100; out-of-range → 400, no clamp). `setBy = x-email`. → `{orgId, discountPct, setBy, setAt}`. |
-| `DELETE` | `/v1/usage-discount` | staff REMOVE the discount (→ null → full pricing on the next composition; not retroactive). Idempotent. → `{orgId, discountPct:null, setBy:null, setAt:null}`. |
+| `DELETE` | `/v1/usage-discount` | staff REMOVE the discount (→ null → full pricing on new cost writes; not retroactive). Idempotent. → `{orgId, discountPct:null, setBy:null, setAt:null}`. |
+| `GET` | `/internal/accounts/by-org/:orgId/usage-discount` | user-less read of an org's discount pct for runs-service to freeze at cost-write. Service-auth + `:orgId` PATH only — NO `x-org-id`/`x-user-id`/sentinel. → `{orgId, discountPct}`; unset → `discountPct:null`. See "Per-org usage discount". |
 
-## Per-org usage discount (reduces the usage component at balance composition)
+## Per-org usage discount (frozen at cost-write in runs-service — billing does NOT apply it)
 
-Platform staff can give an org a percentage discount on ALL its platform usage. A discounted org effectively pays `(1 − discount_pct/100)` of its GROSS usage over time: the discount REDUCES the usage billing subtracts wherever it composes the spendable balance, so the balance depletes proportionally slower and Stripe topups fire proportionally less often. It is NOT a Stripe coupon and NOT bonus/matching credits — it is a read-side reduction of the usage term. The GROSS usage in runs-service is NEVER touched (reporting still sees the full number).
+Platform staff can give an org a percentage discount on ALL its platform usage. A discounted org effectively pays `(1 − discount_pct/100)` of its GROSS usage. **The discount is applied EXACTLY ONCE, at cost-declaration time, inside runs-service** (which stores a gross and a net amount per cost row, netting once at write). billing-service therefore **STORES the percentage, SERVES it (to runs-service + the dashboard), and NEVER applies it at balance composition** — runs already serves a net usage figure, so billing subtracts that verbatim. Applying it here again would DOUBLE-discount. It is NOT a Stripe coupon and NOT bonus/matching credits.
 
-**State:** one table, `org_usage_discounts` (migration `0026`, hand-journaled) — `org_id` PK, `discount_pct integer` (DB CHECK 0..100), `set_by text` (staff email), `set_at`, `created_at`. ONE row per org; **absence of a row = null = no discount = today's EXACT behavior** (byte-identical numbers). Replaceable (upsert on `org_id`), removable (DELETE → null). `src/lib/usage-discount.ts` owns the read/set/remove + the pure `applyUsageDiscount(grossCents, pct)` helper (`pct` null or 0 → returns gross verbatim; else `gross × (1 − pct/100)` at scale 10).
+> History: PR #246 first applied the discount ON READ at every balance-composition site. The architecture then moved the netting into runs-service (single application at write). This rework (superseding #246 on staging) REMOVED billing's read-side application; the storage + CRUD + exposure are kept. Never reintroduce an `applyUsageDiscount(usage, pct)` multiply on a balance path — that is the double-discount bug.
 
-**Applied at EVERY balance-composition site** — the discount reduces usage, never credited:
-- `computeBalance(orgId)` (`src/lib/balance.ts`) reads `getUsageDiscountPct(orgId)` and returns `balanceCents = credited − netUsage`, plus `discountPct` + `netUsageCents` on the snapshot (`usageCents` stays gross). This one chokepoint feeds authorize, the dunning scheduler, month-end sweep, `GET /internal/campaigns/:id/affordability`, and `GET /internal/accounts/by-org/:orgId/balance` (whose `actual_balance_cents` re-applies the discount to actualized usage via `snapshot.discountPct`).
-- `composeAccountFunds` (`src/routes/accounts.ts`) for `GET /v1/accounts` (+ `balance`, `auto_topup`, `wallet_setup`): `balance_cents`/`actual_balance_cents` subtract net usage; exposes `usage_discount_pct` + `net_usage_cents` + `net_actual_usage_cents` (`usage_cents` stays gross) so the dashboard renders a banner + strikethrough.
-- `POST /v1/customer_balance/usage_apply` discounts the caller-reported `spent_total_cents` before the postpaid threshold check → topups fire proportionally less often.
+**State:** one table, `org_usage_discounts` (migration `0026`, hand-journaled) — `org_id` PK, `discount_pct integer` (DB CHECK 0..100), `set_by text` (staff email), `set_at`, `created_at`. ONE row per org; **absence of a row = null = no discount**. Replaceable (upsert on `org_id`), removable (DELETE → null). `src/lib/usage-discount.ts` owns the read/set/remove. (`applyUsageDiscount(grossCents, pct)` still lives there for tests/reference but is NOT called on any balance path.)
 
-The postpaid TIER (`tierFor`) is derived from cumulative PAID topups, not usage, so it is unaffected; the "fires less often" effect comes entirely from the higher (discount-adjusted) balance crossing the floor later. Removing the discount restores full pricing on the NEXT composition (not retroactive). Fail-loud: an out-of-range percentage is rejected at both the Zod route schema and `setUsageDiscount` (`InvalidUsageDiscountError`) — no clamp, no default.
+**Where the pct is READ (never to reduce a billing-side balance):**
+- `GET /internal/accounts/by-org/:orgId/usage-discount` (`src/routes/internal.ts`) — the user-less read runs-service calls at cost-write to freeze the discount onto each cost row. `{orgId, discountPct}`, service-auth, orgId PATH param.
+- `composeAccountFunds` (`src/routes/accounts.ts`) for `GET /v1/accounts` (+ `balance`, `auto_topup`, `wallet_setup`): reads the pct only to expose `usage_discount_pct` for the dashboard banner. `balance_cents`/`actual_balance_cents` subtract runs' net usage directly; the pct does not enter that math.
+- Staff CRUD `GET/PUT/DELETE /v1/usage-discount` (`src/routes/usage_discount.ts`).
 
-**Follow-up (other repos, not built here):** api-service gateway proxy gating `/v1/usage-discount` to staff; admin-console UI to read/set/remove; dashboard banner + strikethrough rendering from `usage_discount_pct` + `usage_cents` + `net_usage_cents`.
+`computeBalance` (`src/lib/balance.ts`), `usage_apply`, authorize, the dunning scheduler, month-end sweep, affordability, and `GET /internal/accounts/by-org/:orgId/balance` all subtract runs-service usage (already net) verbatim — none read or apply the discount. Removing the discount restores full pricing on NEW cost writes (not retroactive). Fail-loud: an out-of-range percentage is rejected at both the Zod route schema and `setUsageDiscount` (`InvalidUsageDiscountError`) — no clamp, no default.
+
+**Cross-service contract:** runs-service is the discount OWNER at write time. It reads billing's `GET /internal/accounts/by-org/:orgId/usage-discount` and applies the pct once per cost row (gross + net stored). billing only READS runs' net usage — it does NOT modify runs' gross ledger.
+
+**Follow-up (other repos, not built here):** runs-service consuming the internal discount read + storing gross/net per cost row; api-service gateway proxy gating `/v1/usage-discount` to staff; admin-console UI to read/set/remove; dashboard banner rendering from `usage_discount_pct`.
 
 ## Per-brand daily budget (pacing ceiling — NOT affordability)
 

--- a/openapi.json
+++ b/openapi.json
@@ -92,7 +92,7 @@
           },
           "usage_cents": {
             "type": "string",
-            "description": "Platform usage from runs-service, including actualized costs and provisioned holds. Use with balance_cents for spend authorization."
+            "description": "Platform usage from runs-service, including actualized costs and provisioned holds. Already NET of any per-org usage discount (applied once at cost-write in runs-service). Use with balance_cents for spend authorization."
           },
           "balance_cents": {
             "type": "string",
@@ -105,12 +105,6 @@
           "usage_discount_pct": {
             "type": "integer",
             "nullable": true
-          },
-          "net_usage_cents": {
-            "type": "string"
-          },
-          "net_actual_usage_cents": {
-            "type": "string"
           },
           "topup_amount_cents": {
             "type": "integer",
@@ -152,8 +146,6 @@
           "balance_cents",
           "actual_balance_cents",
           "usage_discount_pct",
-          "net_usage_cents",
-          "net_actual_usage_cents",
           "topup_amount_cents",
           "topup_threshold_cents",
           "has_payment_method",
@@ -760,6 +752,23 @@
           "balanceCents",
           "lastRequiredCents",
           "hasHistory"
+        ]
+      },
+      "InternalUsageDiscount": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "discountPct": {
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "required": [
+          "orgId",
+          "discountPct"
         ]
       },
       "ReadBrandDailyBudget": {
@@ -2482,7 +2491,7 @@
       },
       "put": {
         "summary": "Set / replace this org's platform-usage discount (staff)",
-        "description": "Upserts the single usage-discount value for x-org-id (0–100, integer). The org then effectively pays (1 − discountPct/100) of its gross platform usage: the usage billing subtracts at balance composition is reduced, so the balance depletes proportionally slower and auto-topups fire proportionally less often. Gross usage in runs-service is untouched. x-email is recorded as setBy. Out-of-range percentages are rejected (400) — no silent clamp.",
+        "description": "Upserts the single usage-discount value for x-org-id (0–100, integer). The org then effectively pays (1 − discountPct/100) of its gross platform usage. The discount is applied ONCE, at cost-write time, inside runs-service (which reads this value via GET /internal/accounts/by-org/{orgId}/usage-discount): each cost row is stored net, so the org's balance depletes proportionally slower and auto-topups fire proportionally less often. Billing only stores + serves the percentage and never re-applies it at balance composition. x-email is recorded as setBy. Out-of-range percentages are rejected (400) — no silent clamp.",
         "parameters": [
           {
             "schema": {
@@ -2886,6 +2895,63 @@
           },
           "502": {
             "description": "stripe-service or runs-service unavailable (balance compose failed)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/accounts/by-org/{orgId}/usage-discount": {
+      "get": {
+        "summary": "User-less read of an org's platform-usage discount (service-to-service)",
+        "description": "Returns the org's usage-discount percentage keyed by the orgId PATH param, callable with the service x-api-key ONLY — no x-org-id / x-user-id, no sentinel. runs-service calls this at cost-write time to FREEZE the discount onto each cost row (the discount is applied exactly once, there — billing never re-applies it at balance composition). discountPct is null when the org has no discount (full pricing).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "required": true,
+            "name": "orgId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current discount (discountPct null when none)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalUsageDiscount"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "orgId is not a valid UUID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/lib/balance.ts
+++ b/src/lib/balance.ts
@@ -9,7 +9,6 @@
 import { addCents, subCents } from "./cents.js";
 import { sumLocalPromoCreditsForOrg } from "./promos.js";
 import { fetchRunsOrgUsageTotal } from "./runs-client.js";
-import { getUsageDiscountPct, applyUsageDiscount } from "./usage-discount.js";
 import {
   fetchOrgCustomer,
   sumSucceededTopupsForOrg,
@@ -36,16 +35,13 @@ export interface BalanceSnapshot {
    */
   paidTopupsCents: string;
   creditedCents: string;
-  /** GROSS platform usage from runs-service (reporting truth — never discounted). */
-  usageCents: string;
   /**
-   * Per-org usage-discount percentage applied at composition (null = none).
-   * A discounted org subtracts NET usage below, so its balance depletes slower.
+   * Platform usage from runs-service. This is the NET figure: any per-org usage
+   * discount is applied ONCE, at cost-write time, inside runs-service — billing
+   * reads it as-is and never re-applies a discount. See CLAUDE.md "Usage discount".
    */
-  discountPct: number | null;
-  /** NET usage after discount = gross × (1 − pct/100). Equals usageCents when no discount. */
-  netUsageCents: string;
-  /** Spendable balance = creditedCents − netUsageCents (discount-adjusted). */
+  usageCents: string;
+  /** Spendable balance = creditedCents − usageCents (net usage from runs). */
   balanceCents: string;
 }
 
@@ -61,20 +57,19 @@ export interface BalanceSnapshot {
  */
 export async function computeBalance(orgId: string): Promise<BalanceSnapshot> {
   const customer = await fetchOrgCustomer(orgId);
-  const [paidTopups, localCredits, runsUsage, hasCardPm, cardCountry, discountPct] =
+  const [paidTopups, localCredits, runsUsage, hasCardPm, cardCountry] =
     await Promise.all([
       sumSucceededTopupsForOrg(orgId),
       sumLocalPromoCreditsForOrg(orgId),
       fetchRunsOrgUsageTotal(orgId, {}),
       hasChargeablePmForOrg(orgId),
       getOrgCardCountryByOrg(orgId),
-      getUsageDiscountPct(orgId),
     ]);
   const creditedCents = addCents(paidTopups, localCredits);
-  // Discount reduces the usage billing subtracts (gross usage stays reporting
-  // truth). netUsage === gross when discountPct is null → byte-identical balance.
-  const netUsageCents = applyUsageDiscount(runsUsage.spent_cents, discountPct);
-  const balanceCents = subCents(creditedCents, netUsageCents);
+  // runsUsage.spent_cents is already NET of any per-org usage discount (frozen at
+  // cost-write in runs-service). Billing subtracts it verbatim — applying a
+  // discount here again would double-count it.
+  const balanceCents = subCents(creditedCents, runsUsage.spent_cents);
   return {
     customer,
     hasCardPm,
@@ -83,8 +78,6 @@ export async function computeBalance(orgId: string): Promise<BalanceSnapshot> {
     paidTopupsCents: paidTopups,
     creditedCents,
     usageCents: runsUsage.spent_cents,
-    discountPct,
-    netUsageCents,
     balanceCents,
   };
 }

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -10,7 +10,7 @@ import { addCents, isDepleted, subCents } from "../lib/cents.js";
 import { tierFor } from "../lib/topup-tier.js";
 import { fetchRunsOrgActualUsageTotal, fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
 import { grantFirstLoadMatch, sumLocalPromoCreditsForOrg } from "../lib/promos.js";
-import { getUsageDiscountPct, applyUsageDiscount } from "../lib/usage-discount.js";
+import { getUsageDiscountPct } from "../lib/usage-discount.js";
 import { reloadViaPaymentIntent } from "../lib/reload.js";
 import {
   getCustomerByOrg,
@@ -48,8 +48,6 @@ async function composeAccountFunds(
   balanceCents: string;
   actualBalanceCents: string;
   discountPct: number | null;
-  netUsageCents: string;
-  netActualUsageCents: string;
   paidTopupsCents: string;
   hasPaymentMethod: boolean;
   cardCountry: string | null;
@@ -67,21 +65,18 @@ async function composeAccountFunds(
       getUsageDiscountPct(orgId),
     ]);
   const creditedCents = addCents(paidTopups, localCredits);
-  // Discount reduces the usage subtracted from credited (gross usage_cents stays
-  // reporting truth). Both net values equal their gross when discountPct is null,
-  // so balance_cents / actual_balance_cents are byte-identical without a discount.
-  const netUsageCents = applyUsageDiscount(runsUsage.spent_cents, discountPct);
-  const netActualUsageCents = applyUsageDiscount(actualRunsUsage.spent_cents, discountPct);
-  const balanceCents = subCents(creditedCents, netUsageCents);
-  const actualBalanceCents = subCents(creditedCents, netActualUsageCents);
+  // runs-service usage is already NET of the org's usage discount (frozen at
+  // cost-write). Billing subtracts it verbatim — no discount is applied here. The
+  // discount pct is still read + exposed (usage_discount_pct) for the dashboard
+  // banner, but it does NOT change these balance figures.
+  const balanceCents = subCents(creditedCents, runsUsage.spent_cents);
+  const actualBalanceCents = subCents(creditedCents, actualRunsUsage.spent_cents);
   return {
     creditedCents,
     usageCents: runsUsage.spent_cents,
     balanceCents,
     actualBalanceCents,
     discountPct,
-    netUsageCents,
-    netActualUsageCents,
     paidTopupsCents: paidTopups,
     hasPaymentMethod: hasCardPm,
     cardCountry,
@@ -97,8 +92,6 @@ function buildAccountResponse(
     balanceCents: string;
     actualBalanceCents: string;
     discountPct: number | null;
-    netUsageCents: string;
-    netActualUsageCents: string;
     paidTopupsCents: string;
     hasPaymentMethod: boolean;
     cardCountry: string | null;
@@ -120,14 +113,12 @@ function buildAccountResponse(
     usage_cents: funds.usageCents,
     balance_cents: funds.balanceCents,
     actual_balance_cents: funds.actualBalanceCents,
-    // Per-org platform-usage discount. null = no discount (usage_cents is the net
-    // usage, balance_cents/actual_balance_cents unchanged). When set, usage_cents
-    // stays GROSS (reporting) and net_usage_cents / net_actual_usage_cents are the
-    // discounted usage the balance figures already subtract — the dashboard renders
-    // the banner (usage_discount_pct) + strikethrough (gross usage_cents vs net).
+    // Per-org platform-usage discount percentage (0–100), or null when none. This
+    // is EXPOSED for the customer dashboard banner only — it does NOT affect the
+    // balance figures above. The discount is applied ONCE, at cost-write time, in
+    // runs-service, so usage_cents (and thus balance_cents/actual_balance_cents) is
+    // already net. Billing never re-applies it. See CLAUDE.md "Usage discount".
     usage_discount_pct: funds.discountPct,
-    net_usage_cents: funds.netUsageCents,
-    net_actual_usage_cents: funds.netActualUsageCents,
     topup_amount_cents: tier ? tier.amountCents : null,
     topup_threshold_cents: tier ? tier.thresholdCents : null,
     has_payment_method: funds.hasPaymentMethod,

--- a/src/routes/customer_balance.ts
+++ b/src/routes/customer_balance.ts
@@ -8,7 +8,6 @@ import { findOrCreateAccount } from "../lib/account.js";
 import { traceEvent } from "../lib/trace-event.js";
 import { addCents, subCents, gte as gteCents, parseNonNegativeCents } from "../lib/cents.js";
 import { sumLocalPromoCreditsForOrg } from "../lib/promos.js";
-import { getUsageDiscountPct, applyUsageDiscount } from "../lib/usage-discount.js";
 import {
   getCustomerByOrg,
   sumSucceededTopupsForCustomer,
@@ -341,18 +340,17 @@ router.post("/v1/customer_balance/usage_apply", requireOrgHeaders, async (req, r
       return;
     }
 
-    const [paidTopups, localCredits, discountPct] = await Promise.all([
+    const [paidTopups, localCredits] = await Promise.all([
       sumSucceededTopupsForCustomer(identity, customer.id),
       sumLocalPromoCreditsForOrg(orgId),
-      getUsageDiscountPct(orgId),
     ]);
 
     const creditedCents = addCents(paidTopups, localCredits);
-    // Discount the reported spend before the threshold check so a discounted org's
-    // balance depletes slower → auto-topup fires proportionally less often. Gross
-    // spend is unchanged when discountPct is null (byte-identical topup cadence).
-    const netSpentCents = applyUsageDiscount(spentTotalCents, discountPct);
-    const balanceCents = subCents(creditedCents, netSpentCents);
+    // spent_total_cents is reported by runs-service after its cost write, so it is
+    // already NET of any per-org usage discount (the discount is applied once, at
+    // cost-write). Billing subtracts it verbatim — re-applying the discount here
+    // would double-count it.
+    const balanceCents = subCents(creditedCents, spentTotalCents);
 
     // Threshold-based postpaid: the effective (amount, threshold) come from the
     // derived tier (a function of cumulative paid topups), NOT the stored daily

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -21,7 +21,7 @@ import { runDunningTick } from "../lib/dunning.js";
 import { getCampaignAuthorizeCost } from "../lib/campaign-costs.js";
 import { computeBalance } from "../lib/balance.js";
 import { fetchRunsOrgActualUsageTotal } from "../lib/runs-client.js";
-import { applyUsageDiscount } from "../lib/usage-discount.js";
+import { getUsageDiscountPct } from "../lib/usage-discount.js";
 import { gte as gteCents, isDepleted, subCents } from "../lib/cents.js";
 
 const router = Router();
@@ -386,17 +386,38 @@ router.get("/internal/accounts/by-org/:orgId/balance", async (req, res) => {
     snapshot.autoReloadSupported;
 
   res.json({
-    // balance_cents is already discount-adjusted (computeBalance subtracts net
-    // usage). actual_balance_cents must apply the same discount to the actualized
-    // usage — snapshot.discountPct is the org's live pct (null → gross unchanged).
+    // Both usage figures from runs-service are already NET of the org's usage
+    // discount (frozen at cost-write). Billing subtracts them verbatim and applies
+    // no discount here. balance_cents = credited − committed usage;
+    // actual_balance_cents = credited − actualized usage.
     balance_cents: snapshot.balanceCents,
-    actual_balance_cents: subCents(
-      snapshot.creditedCents,
-      applyUsageDiscount(actualUsage.spent_cents, snapshot.discountPct)
-    ),
+    actual_balance_cents: subCents(snapshot.creditedCents, actualUsage.spent_cents),
     depleted: isDepleted(snapshot.balanceCents),
     has_auto_topup: hasAutoTopup,
   });
+});
+
+// GET /internal/accounts/by-org/:orgId/usage-discount
+//
+// User-less read of an org's platform-usage discount percentage, keyed by the
+// orgId PATH param and guarded by requireApiKey ONLY — no x-org-id / x-user-id,
+// no sentinel. runs-service calls this at cost-write time to FREEZE the discount
+// onto each cost row (the discount is applied exactly once, there — billing never
+// re-applies it at balance composition). Mirrors the staff GET /v1/usage-discount
+// value (same discountPct semantics) but is a pure service-to-service read with no
+// gateway staff-gating and no audit fields.
+//
+// → { orgId, discountPct } where discountPct is null when the org has no discount
+// (full pricing). 400 on a non-UUID orgId.
+router.get("/internal/accounts/by-org/:orgId/usage-discount", async (req, res) => {
+  const { orgId } = req.params;
+  if (!UUID_RE.test(orgId)) {
+    res.status(400).json({ error: "orgId must be a valid UUID" });
+    return;
+  }
+
+  const discountPct = await getUsageDiscountPct(orgId);
+  res.json({ orgId, discountPct });
 });
 
 // POST /internal/dunning/tick — manually run one dunning scheduler pass.

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -20,7 +20,7 @@ export const ErrorResponseSchema = z
 const CentsStringSchema = z.string();
 const UsageCentsSchema = CentsStringSchema.openapi({
   description:
-    "Platform usage from runs-service, including actualized costs and provisioned holds. Use with balance_cents for spend authorization.",
+    "Platform usage from runs-service, including actualized costs and provisioned holds. Already NET of any per-org usage discount (applied once at cost-write in runs-service). Use with balance_cents for spend authorization.",
 });
 const SpendableBalanceCentsSchema = CentsStringSchema.openapi({
   description:
@@ -47,15 +47,12 @@ export const BillingAccountSchema = z
     actual_balance_cents: ActualBalanceCentsSchema,
     /**
      * Per-org platform-usage discount percentage (0–100), or null when none.
-     * null → no discount: usage_cents is the net usage and balance figures are
-     * unchanged. When set, usage_cents stays GROSS (reporting) and the balance
-     * figures already subtract the discounted (net) usage below.
+     * EXPOSED for the customer dashboard banner only — it does NOT affect the
+     * balance figures. The discount is applied ONCE, at cost-write time, inside
+     * runs-service, so usage_cents (and thus balance_cents/actual_balance_cents) is
+     * already net. Billing never re-applies it.
      */
     usage_discount_pct: z.number().int().nullable(),
-    /** NET committed usage after discount = usage_cents × (1 − pct/100); equals usage_cents when no discount. */
-    net_usage_cents: CentsStringSchema,
-    /** NET actualized usage after discount; the amount actual_balance_cents subtracts from credited. */
-    net_actual_usage_cents: CentsStringSchema,
     topup_amount_cents: z.number().int().nullable(),
     topup_threshold_cents: z.number().int().nullable(),
     has_payment_method: z.boolean(),
@@ -305,11 +302,21 @@ export const SetUsageDiscountRequestSchema = z
     /**
      * Platform-usage discount percentage, integer 0–100. Out-of-range is
      * rejected (400) — no silent clamp, no default. The org then pays
-     * (1 − discountPct/100) of its gross usage at balance composition.
+     * (1 − discountPct/100) of its gross usage. The discount is applied ONCE, at
+     * cost-write time, inside runs-service (which reads this value); billing only
+     * stores + serves it and never re-applies it at balance composition.
      */
     discountPct: z.number().int().min(0).max(100),
   })
   .openapi("SetUsageDiscountRequest");
+
+export const InternalUsageDiscountSchema = z
+  .object({
+    orgId: z.string().uuid(),
+    /** Current discount percentage (0–100); null when no discount is set (full pricing). */
+    discountPct: z.number().int().nullable(),
+  })
+  .openapi("InternalUsageDiscount");
 
 export const UsageDiscountResponseSchema = z
   .object({
@@ -962,11 +969,13 @@ registry.registerPath({
   summary: "Set / replace this org's platform-usage discount (staff)",
   description:
     "Upserts the single usage-discount value for x-org-id (0–100, integer). The org " +
-    "then effectively pays (1 − discountPct/100) of its gross platform usage: the " +
-    "usage billing subtracts at balance composition is reduced, so the balance " +
-    "depletes proportionally slower and auto-topups fire proportionally less often. " +
-    "Gross usage in runs-service is untouched. x-email is recorded as setBy. " +
-    "Out-of-range percentages are rejected (400) — no silent clamp.",
+    "then effectively pays (1 − discountPct/100) of its gross platform usage. The " +
+    "discount is applied ONCE, at cost-write time, inside runs-service (which reads " +
+    "this value via GET /internal/accounts/by-org/{orgId}/usage-discount): each cost " +
+    "row is stored net, so the org's balance depletes proportionally slower and " +
+    "auto-topups fire proportionally less often. Billing only stores + serves the " +
+    "percentage and never re-applies it at balance composition. x-email is recorded " +
+    "as setBy. Out-of-range percentages are rejected (400) — no silent clamp.",
   request: {
     headers: adminGrantHeaders,
     body: {
@@ -1167,6 +1176,36 @@ registry.registerPath({
     },
     502: {
       description: "stripe-service or runs-service unavailable (balance compose failed)",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/internal/accounts/by-org/{orgId}/usage-discount",
+  summary: "User-less read of an org's platform-usage discount (service-to-service)",
+  description:
+    "Returns the org's usage-discount percentage keyed by the orgId PATH param, " +
+    "callable with the service x-api-key ONLY — no x-org-id / x-user-id, no sentinel. " +
+    "runs-service calls this at cost-write time to FREEZE the discount onto each cost " +
+    "row (the discount is applied exactly once, there — billing never re-applies it at " +
+    "balance composition). discountPct is null when the org has no discount (full pricing).",
+  request: {
+    headers: internalHeaders,
+    params: z.object({ orgId: z.string().uuid() }),
+  },
+  responses: {
+    200: {
+      description: "Current discount (discountPct null when none)",
+      content: { "application/json": { schema: InternalUsageDiscountSchema } },
+    },
+    400: {
+      description: "orgId is not a valid UUID",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    401: {
+      description: "Unauthorized",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/integration/usage-discount.test.ts
+++ b/tests/integration/usage-discount.test.ts
@@ -140,7 +140,7 @@ describe("Staff usage-discount CRUD (/v1/usage-discount)", () => {
   });
 });
 
-describe("Usage discount reduces the usage component at balance composition", () => {
+describe("Usage discount is NOT applied at balance composition (frozen in runs-service)", () => {
   const app = createTestApp();
   let ssMocks: ReturnType<typeof setupStripeMocks>;
   let setUsage: (c: string) => void;
@@ -156,6 +156,7 @@ describe("Usage discount reduces the usage component at balance composition", ()
     let actualUsage = "0.0000000000";
     setUsage = (c) => { usage = c; };
     setActualUsage = (c) => { actualUsage = c; };
+    // runs-service serves NET usage (discount already applied at cost-write).
     vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(async () => ({
       org_id: orgId,
       spent_cents: usage,
@@ -170,27 +171,29 @@ describe("Usage discount reduces the usage component at balance composition", ()
     await cleanTestData();
   });
 
-  it("GET /v1/accounts: usage_cents stays GROSS, balance uses net usage, exposes discount + net", async () => {
+  it("GET /v1/accounts: exposes usage_discount_pct but balance subtracts runs usage verbatim (no billing-side discount, no net_* fields)", async () => {
     await insertTestAccount({ orgId });
     await insertTestUsageDiscount({ orgId, discountPct: 50 });
     ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("1000.0000000000");
-    setUsage("100.0000000000");
-    setActualUsage("80.0000000000");
+    // runs already served net usage; billing does not touch it.
+    setUsage("50.0000000000");
+    setActualUsage("40.0000000000");
 
     const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId, userId));
 
     expect(res.status).toBe(200);
-    // Gross reporting number is untouched.
-    expect(res.body.usage_cents).toBe("100.0000000000");
+    // Discount pct is exposed for the dashboard banner.
     expect(res.body.usage_discount_pct).toBe(50);
-    expect(res.body.net_usage_cents).toBe("50.0000000000");
-    expect(res.body.net_actual_usage_cents).toBe("40.0000000000");
-    // Balance subtracts NET usage → 1000 − 50 = 950 (vs 900 without discount).
+    // No billing-side discount math: usage_cents = runs usage; balance = credited − usage.
+    expect(res.body.usage_cents).toBe("50.0000000000");
     expect(res.body.balance_cents).toBe("950.0000000000");
     expect(res.body.actual_balance_cents).toBe("960.0000000000");
+    // Superseded #246 net fields are gone.
+    expect(res.body.net_usage_cents).toBeUndefined();
+    expect(res.body.net_actual_usage_cents).toBeUndefined();
   });
 
-  it("GET /v1/accounts: no discount → byte-identical existing fields + null pct", async () => {
+  it("GET /v1/accounts: no discount → null pct, balance unchanged", async () => {
     await insertTestAccount({ orgId });
     ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("1000.0000000000");
     setUsage("100.0000000000");
@@ -201,12 +204,26 @@ describe("Usage discount reduces the usage component at balance composition", ()
     expect(res.status).toBe(200);
     expect(res.body.usage_discount_pct).toBeNull();
     expect(res.body.usage_cents).toBe("100.0000000000");
-    expect(res.body.net_usage_cents).toBe("100.0000000000");
     expect(res.body.balance_cents).toBe("900.0000000000");
     expect(res.body.actual_balance_cents).toBe("900.0000000000");
   });
 
-  it("GET /internal/accounts/by-org/:orgId/balance discounts both balance figures", async () => {
+  it("GET /v1/accounts: a set discount does NOT change balance vs no discount (same runs usage)", async () => {
+    await insertTestAccount({ orgId });
+    await insertTestUsageDiscount({ orgId, discountPct: 50 });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("1000.0000000000");
+    setUsage("100.0000000000");
+    setActualUsage("100.0000000000");
+
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId, userId));
+
+    expect(res.status).toBe(200);
+    // Identical balance to the no-discount case above — billing applies nothing.
+    expect(res.body.balance_cents).toBe("900.0000000000");
+    expect(res.body.actual_balance_cents).toBe("900.0000000000");
+  });
+
+  it("GET /internal/accounts/by-org/:orgId/balance subtracts runs usage verbatim (discount ignored)", async () => {
     await insertTestAccount({ orgId });
     await insertTestUsageDiscount({ orgId, discountPct: 50 });
     ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("100.0000000000");
@@ -218,13 +235,13 @@ describe("Usage discount reduces the usage component at balance composition", ()
       .set(apiKey);
 
     expect(res.status).toBe(200);
-    // 100 − (80 × 0.5) = 60 (vs 20 without discount).
-    expect(res.body.balance_cents).toBe("60.0000000000");
-    expect(res.body.actual_balance_cents).toBe("60.0000000000");
+    // 100 − 80 = 20; the 50% discount is NOT applied here (would have been 60 under #246).
+    expect(res.body.balance_cents).toBe("20.0000000000");
+    expect(res.body.actual_balance_cents).toBe("20.0000000000");
     expect(res.body.depleted).toBe(false);
   });
 
-  it("authorize: a discount makes an otherwise-insufficient run sufficient", async () => {
+  it("authorize: a discount does NOT change the sufficiency verdict (billing applies nothing)", async () => {
     await insertTestAccount({ orgId }); // no topup config → credit-line floor "0"
     await insertTestUsageDiscount({ orgId, discountPct: 50 });
     ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("100.0000000000");
@@ -239,18 +256,20 @@ describe("Usage discount reduces the usage component at balance composition", ()
       .send({ items: [{ costName: "x", quantity: 1 }] });
 
     expect(res.status).toBe(200);
-    // net usage 40 → balance 60; 60 − 30 = 30 >= 0 → sufficient (gross would be −10).
-    expect(res.body.sufficient).toBe(true);
-    expect(res.body.balance_cents).toBe("60.0000000000");
+    // balance 100 − 80 = 20; 20 − 30 = −10 < 0 → insufficient. The discount is NOT
+    // applied (under #246 net usage 40 → balance 60 would have been sufficient).
+    expect(res.body.sufficient).toBe(false);
+    expect(res.body.balance_cents).toBe("20.0000000000");
   });
 
-  it("usage_apply: a discount keeps balance above the floor → no topup fires", async () => {
+  it("usage_apply: spent_total_cents (already net from runs) is used verbatim; discount does not suppress the topup", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 5000, topupThresholdCents: 5000 });
     await insertTestUsageDiscount({ orgId, discountPct: 50 });
     ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
-    // paid 0 → start tier floor -5000. Gross spend 6000 would blow past it and
-    // reload; net spend 3000 keeps balance −3000 (above floor) → no reload.
+    // paid 0 → start tier floor -5000. runs reports net spend 6000 → balance −6000
+    // (past the floor) → reload fires. Billing does NOT re-discount the 6000.
     ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+    ssMocks.reloadViaPaymentIntent.mockResolvedValue({ status: "succeeded", payment_intent_id: "pi_x" });
 
     const res = await request(app)
       .post("/v1/customer_balance/usage_apply")
@@ -258,7 +277,50 @@ describe("Usage discount reduces the usage component at balance composition", ()
       .send({ spent_total_cents: "6000.0000000000" });
 
     expect(res.status).toBe(202);
-    expect(res.body).toEqual({ acknowledged: true, topup_triggered: false });
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(res.body).toEqual({ acknowledged: true, topup_triggered: true });
+    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalled();
+  });
+});
+
+describe("Internal usage-discount read for runs-service (GET /internal/accounts/by-org/:orgId/usage-discount)", () => {
+  const app = createTestApp();
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    setupStripeMocks();
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+  });
+
+  it("returns discountPct=null when the org has no discount", async () => {
+    const res = await request(app)
+      .get(`/internal/accounts/by-org/${orgId}/usage-discount`)
+      .set(apiKey);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ orgId, discountPct: null });
+  });
+
+  it("returns the stored discountPct (user-less, orgId in PATH)", async () => {
+    await insertTestUsageDiscount({ orgId, discountPct: 40, setBy: "staff@distribute.you" });
+    const res = await request(app)
+      .get(`/internal/accounts/by-org/${orgId}/usage-discount`)
+      .set(apiKey);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ orgId, discountPct: 40 });
+  });
+
+  it("401 without service auth", async () => {
+    const res = await request(app).get(`/internal/accounts/by-org/${orgId}/usage-discount`);
+    expect(res.status).toBe(401);
+  });
+
+  it("400 on a non-UUID orgId", async () => {
+    const res = await request(app)
+      .get("/internal/accounts/by-org/not-a-uuid/usage-discount")
+      .set(apiKey);
+    expect(res.status).toBe(400);
   });
 });


### PR DESCRIPTION
## What

The per-org usage discount is now **frozen at cost-declaration time in runs-service** (which stores a gross and a net amount per cost row, applying the org's discount once, at write). billing-service must therefore **no longer apply the discount itself** — otherwise it is applied twice (double discount). This reworks PR #246 (already on staging) so the discount is applied **exactly once**, in runs-service.

## Changes

**Removed (superseded #246 balance-composition logic):**
- No `applyUsageDiscount()` on ANY balance path. `computeBalance`, `composeAccountFunds`, `usage_apply`, and the internal by-org balance now subtract runs-service usage **verbatim** (runs already serves net).
- Dropped `net_usage_cents` / `net_actual_usage_cents` from `GET /v1/accounts` (billing no longer computes a separate net; `usage_cents` IS net). No dashboard consumer reads them yet (grep-confirmed).

**Kept (requirement #1):**
- Discount storage (`org_usage_discounts`, migration `0026`).
- Staff `GET`/`PUT`/`DELETE /v1/usage-discount` CRUD.
- `usage_discount_pct` on `GET /v1/accounts` (the customer dashboard banner reads it) — now clearly documented as *exposed only, does not affect balance*.

**Added (requirement #2):**
- User-less `GET /internal/accounts/by-org/:orgId/usage-discount` (service-auth + `:orgId` PATH param, no `x-org-id`/`x-user-id`/sentinel) → `{ orgId, discountPct }`. runs-service calls this at cost-write time to freeze the discount onto each cost row.

## End state / AC

- A discounted org's balance / next-charge reflect the discount **exactly once** (via runs' net usage), not twice.
- Removing the composition multiply leaves a **non-discounted org behaviorally byte-identical** to before this whole feature.
- The discount percentage is readable **user-less** (so runs can call it at cost-write).
- The org account read still exposes `usage_discount_pct` for the dashboard banner.
- billing only **READS** runs' net usage — it never modifies runs' gross ledger.

## Runs-service dependency (other repo, not built here)

The producer side (runs-service reading `GET /internal/accounts/by-org/:orgId/usage-discount` at cost-write + storing gross/net per row + serving net usage) is not yet built. Until it lands, runs serves gross = net (no discount at write), so a non-discounted org is unaffected and this PR is safe to ship. When runs starts serving net, the discount takes effect through the single write-side application.

## Tests

314 tests green (29 files). `tsc` + openapi regen clean. The #246 "discount reduces balance" tests were rewritten to assert the discount does **not** change billing's balance figures + coverage for the new internal read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
