### PR TITLE
fix(billing): conform internal usage-discount read to deployed features-service contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed liv
 | `GET` | `/v1/usage-discount` | staff READ of this org's platform-usage discount. Auth mirrors credit-grant (`x-api-key` + `x-org-id`). → `{orgId, discountPct, setBy, setAt}`; unset → `discountPct:null`. See "Per-org usage discount". |
 | `PUT` | `/v1/usage-discount` | staff SET/REPLACE the discount. body `{discountPct}` (integer 0–100; out-of-range → 400, no clamp). `setBy = x-email`. → `{orgId, discountPct, setBy, setAt}`. |
 | `DELETE` | `/v1/usage-discount` | staff REMOVE the discount (→ null → full pricing on new cost writes; not retroactive). Idempotent. → `{orgId, discountPct:null, setBy:null, setAt:null}`. |
-| `GET` | `/internal/accounts/by-org/:orgId/usage-discount` | user-less read of an org's discount pct for runs-service to freeze at cost-write. Service-auth + `:orgId` PATH only — NO `x-org-id`/`x-user-id`/sentinel. → `{orgId, discountPct}`; unset → `discountPct:null`. See "Per-org usage discount". |
+| `GET` | `/internal/accounts/by-org/:orgId/usage-discount` | user-less read of an org's discount pct (runs-service freezes it at cost-write; features-service #510 reads it for net-priced metrics). Service-auth + `:orgId` PATH only — NO `x-org-id`/`x-user-id`/sentinel. → `{orgId, discount_percent}` (number 0–100); no discount → `discount_percent:0` (NOT null, NOT 404). Shape matches the deployed features-service reader. See "Per-org usage discount". |
 
 ## Per-org usage discount (frozen at cost-write in runs-service — billing does NOT apply it)
 
@@ -237,7 +237,7 @@ Platform staff can give an org a percentage discount on ALL its platform usage. 
 **State:** one table, `org_usage_discounts` (migration `0026`, hand-journaled) — `org_id` PK, `discount_pct integer` (DB CHECK 0..100), `set_by text` (staff email), `set_at`, `created_at`. ONE row per org; **absence of a row = null = no discount**. Replaceable (upsert on `org_id`), removable (DELETE → null). `src/lib/usage-discount.ts` owns the read/set/remove. (`applyUsageDiscount(grossCents, pct)` still lives there for tests/reference but is NOT called on any balance path.)
 
 **Where the pct is READ (never to reduce a billing-side balance):**
-- `GET /internal/accounts/by-org/:orgId/usage-discount` (`src/routes/internal.ts`) — the user-less read runs-service calls at cost-write to freeze the discount onto each cost row. `{orgId, discountPct}`, service-auth, orgId PATH param.
+- `GET /internal/accounts/by-org/:orgId/usage-discount` (`src/routes/internal.ts`) — the user-less read runs-service calls at cost-write to freeze the discount onto each cost row (and features-service #510 reads for net-priced metrics). `{orgId, discount_percent}` (number 0–100; no discount → `0`, NOT null/404 — matches the deployed features-service reader), service-auth, orgId PATH param.
 - `composeAccountFunds` (`src/routes/accounts.ts`) for `GET /v1/accounts` (+ `balance`, `auto_topup`, `wallet_setup`): reads the pct only to expose `usage_discount_pct` for the dashboard banner. `balance_cents`/`actual_balance_cents` subtract runs' net usage directly; the pct does not enter that math.
 - Staff CRUD `GET/PUT/DELETE /v1/usage-discount` (`src/routes/usage_discount.ts`).
 

--- a/openapi.json
+++ b/openapi.json
@@ -761,14 +761,15 @@
             "type": "string",
             "format": "uuid"
           },
-          "discountPct": {
+          "discount_percent": {
             "type": "integer",
-            "nullable": true
+            "minimum": 0,
+            "maximum": 100
           }
         },
         "required": [
           "orgId",
-          "discountPct"
+          "discount_percent"
         ]
       },
       "ReadBrandDailyBudget": {
@@ -2909,7 +2910,7 @@
     "/internal/accounts/by-org/{orgId}/usage-discount": {
       "get": {
         "summary": "User-less read of an org's platform-usage discount (service-to-service)",
-        "description": "Returns the org's usage-discount percentage keyed by the orgId PATH param, callable with the service x-api-key ONLY — no x-org-id / x-user-id, no sentinel. runs-service calls this at cost-write time to FREEZE the discount onto each cost row (the discount is applied exactly once, there — billing never re-applies it at balance composition). discountPct is null when the org has no discount (full pricing).",
+        "description": "Returns the org's usage-discount percentage keyed by the orgId PATH param, callable with the service x-api-key ONLY — no x-org-id / x-user-id, no sentinel. Consumed by runs-service (to FREEZE the discount onto each cost row at cost-write, the single application point — billing never re-applies it at balance composition) and features-service PR #510 (net-priced cost metrics). A known org with NO discount returns discount_percent = 0 (NOT null, NOT 404). Shape matches the deployed features-service reader.",
         "parameters": [
           {
             "schema": {

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -401,14 +401,18 @@ router.get("/internal/accounts/by-org/:orgId/balance", async (req, res) => {
 //
 // User-less read of an org's platform-usage discount percentage, keyed by the
 // orgId PATH param and guarded by requireApiKey ONLY — no x-org-id / x-user-id,
-// no sentinel. runs-service calls this at cost-write time to FREEZE the discount
-// onto each cost row (the discount is applied exactly once, there — billing never
-// re-applies it at balance composition). Mirrors the staff GET /v1/usage-discount
-// value (same discountPct semantics) but is a pure service-to-service read with no
-// gateway staff-gating and no audit fields.
+// no sentinel. Two service-to-service consumers:
+//   - runs-service calls it at cost-write time to FREEZE the discount onto each
+//     cost row (the discount is applied exactly once, there — billing never
+//     re-applies it at balance composition).
+//   - features-service (PR #510, already deployed) reads it to render net-priced
+//     cost metrics.
 //
-// → { orgId, discountPct } where discountPct is null when the org has no discount
-// (full pricing). 400 on a non-UUID orgId.
+// Contract is dictated by the deployed features-service reader (billing-discount-
+// client.ts): → { discount_percent: number } in [0, 100]. A known org with NO
+// discount returns discount_percent = 0 (NOT null, NOT 404) so a non-discounted
+// org resolves to "0% off" = no change. The `orgId` echo is additive. 400 on a
+// non-UUID orgId.
 router.get("/internal/accounts/by-org/:orgId/usage-discount", async (req, res) => {
   const { orgId } = req.params;
   if (!UUID_RE.test(orgId)) {
@@ -417,7 +421,7 @@ router.get("/internal/accounts/by-org/:orgId/usage-discount", async (req, res) =
   }
 
   const discountPct = await getUsageDiscountPct(orgId);
-  res.json({ orgId, discountPct });
+  res.json({ orgId, discount_percent: discountPct ?? 0 });
 });
 
 // POST /internal/dunning/tick — manually run one dunning scheduler pass.

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -313,8 +313,13 @@ export const SetUsageDiscountRequestSchema = z
 export const InternalUsageDiscountSchema = z
   .object({
     orgId: z.string().uuid(),
-    /** Current discount percentage (0–100); null when no discount is set (full pricing). */
-    discountPct: z.number().int().nullable(),
+    /**
+     * Current discount percentage (0–100). A known org with NO discount returns 0
+     * (NOT null, NOT 404) so a non-discounted org resolves to "0% off" = no change.
+     * Field name + zero-not-null semantics match the deployed features-service
+     * reader (PR #510 billing-discount-client.ts).
+     */
+    discount_percent: z.number().int().min(0).max(100),
   })
   .openapi("InternalUsageDiscount");
 
@@ -1188,9 +1193,11 @@ registry.registerPath({
   description:
     "Returns the org's usage-discount percentage keyed by the orgId PATH param, " +
     "callable with the service x-api-key ONLY — no x-org-id / x-user-id, no sentinel. " +
-    "runs-service calls this at cost-write time to FREEZE the discount onto each cost " +
-    "row (the discount is applied exactly once, there — billing never re-applies it at " +
-    "balance composition). discountPct is null when the org has no discount (full pricing).",
+    "Consumed by runs-service (to FREEZE the discount onto each cost row at cost-write, " +
+    "the single application point — billing never re-applies it at balance composition) " +
+    "and features-service PR #510 (net-priced cost metrics). A known org with NO discount " +
+    "returns discount_percent = 0 (NOT null, NOT 404). Shape matches the deployed " +
+    "features-service reader.",
   request: {
     headers: internalHeaders,
     params: z.object({ orgId: z.string().uuid() }),

--- a/tests/integration/usage-discount.test.ts
+++ b/tests/integration/usage-discount.test.ts
@@ -295,21 +295,21 @@ describe("Internal usage-discount read for runs-service (GET /internal/accounts/
     await cleanTestData();
   });
 
-  it("returns discountPct=null when the org has no discount", async () => {
+  it("returns discount_percent=0 when the org has no discount (NOT null, NOT 404)", async () => {
     const res = await request(app)
       .get(`/internal/accounts/by-org/${orgId}/usage-discount`)
       .set(apiKey);
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ orgId, discountPct: null });
+    expect(res.body).toEqual({ orgId, discount_percent: 0 });
   });
 
-  it("returns the stored discountPct (user-less, orgId in PATH)", async () => {
+  it("returns the stored discount_percent (user-less, orgId in PATH)", async () => {
     await insertTestUsageDiscount({ orgId, discountPct: 40, setBy: "staff@distribute.you" });
     const res = await request(app)
       .get(`/internal/accounts/by-org/${orgId}/usage-discount`)
       .set(apiKey);
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ orgId, discountPct: 40 });
+    expect(res.body).toEqual({ orgId, discount_percent: 40 });
   });
 
   it("401 without service auth", async () => {


### PR DESCRIPTION
## What

Conformance fix for the internal usage-discount read added in #249. That endpoint returned `{ orgId, discountPct: null }` for a non-discounted org, but the **already-deployed consumer** (features-service PR #510 `src/lib/billing-discount-client.ts`, merged to main) reads a different shape:

```
GET /internal/accounts/by-org/:orgId/usage-discount → { discount_percent: number }  // [0,100]
```

and requires a **known org with no discount to return `discount_percent: 0`** (NOT null, NOT 404) so it resolves to "0% off" = no change.

With the #249 shape the consumer reads `data.discount_percent = undefined` → `Number(undefined) = NaN` → throws → **every `pricing=net` request 502s**.

## Fix

Conform the producer to the deployed consumer contract (producer owns the path, but the consumer already shipped the field name + zero-not-null semantics, so billing conforms rather than forcing a consumer rename PR):

- Return `{ orgId, discount_percent: pct ?? 0 }` (number, `0` when unset).
- `InternalUsageDiscountSchema` + openapi → `discount_percent` number in [0,100].
- CLAUDE.md endpoint ref + section updated.
- Tests assert `discount_percent` 0 (no discount) / 40 (set).

runs-service (not yet built) will read the same `discount_percent` contract at cost-write.

## Why this wasn't caught in #249

Missed the "grep the consumer for the name it already expects before naming a producer field" check — features-service #510 had already merged the reader. This is the corrective PR.

## Tests

Usage-discount suite green (21). `tsc` + openapi regen clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
