### PR TITLE
feat(billing): invoice_creation on top-up checkout → Stripe invoices in portal

### DIFF
--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -325,6 +325,12 @@ export interface CheckoutSessionBody {
     metadata: Record<string, string>;
     setup_future_usage?: "off_session" | "on_session";
   };
+  /**
+   * Payment-mode only: when enabled, Stripe auto-creates a finalized Invoice + hosted
+   * PDF for the charge, so it appears in the customer portal's "Invoice history" tab.
+   * Omitted for setup mode (no charge).
+   */
+  invoice_creation?: { enabled: boolean };
 }
 
 export async function createCheckoutSession(

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -86,6 +86,11 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
             metadata: { org_id: orgId },
             setup_future_usage: "off_session",
           },
+          // Auto-create a finalized Stripe Invoice + PDF for the top-up charge so it
+          // shows up in the customer portal's "Invoice history" tab. Payment mode only;
+          // the off-session auto-topup charges (customer_balance usage_apply) are raw
+          // PaymentIntents and are NOT invoiced by this — separate future work.
+          invoice_creation: { enabled: true },
         };
         if (isEmbedded) {
           // Embedded Checkout: mounted in an in-app modal iframe. No redirect URLs —

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -65,6 +65,7 @@ describe("POST /v1/checkout-sessions", () => {
           metadata: { org_id: orgId },
           setup_future_usage: "off_session",
         },
+        invoice_creation: { enabled: true },
       }
     );
   });
@@ -194,6 +195,7 @@ describe("POST /v1/checkout-sessions", () => {
     const sentBody = ssMocks.createCheckoutSession.mock.calls[0][1];
     expect(sentBody).not.toHaveProperty("line_items");
     expect(sentBody).not.toHaveProperty("payment_intent_data");
+    expect(sentBody).not.toHaveProperty("invoice_creation");
   });
 
   it("setup-mode: does NOT write a topup amount to the account", async () => {
@@ -294,6 +296,7 @@ describe("POST /v1/checkout-sessions", () => {
           metadata: { org_id: orgId },
           setup_future_usage: "off_session",
         },
+        invoice_creation: { enabled: true },
       }
     );
     // No redirect URLs on an embedded session.


### PR DESCRIPTION
## What
Set `invoice_creation:{enabled:true}` on the `mode:"payment"` Checkout session so Stripe auto-creates a finalized Invoice + hosted PDF per manual top-up. They then appear in the customer portal's "Invoice history" tab.

## Why
Top-ups previously created only a PaymentIntent/Charge (no Invoice object) → the portal Invoice History was always empty. The distribute.you dashboard just shipped a "View invoices" button opening that portal.

## Scope
- `src/routes/checkout.ts` — payment-mode body only.
- `src/lib/stripe-service-client.ts` — added optional `invoice_creation` to the body type.
- stripe-service `/v1/checkout/sessions` schema is `.passthrough()` → already forwards it, no stripe-service change.
- Setup-mode card capture unchanged; off-session auto-topup charges (usage_apply PaymentIntents) NOT invoiced (separate future work). Future top-ups only, no retroactive backfill.

## Verify
- `pnpm build` green (tsc + openapi regen).
- 318 tests pass (checkout body assertions updated + setup-mode negative guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)