### PR TITLE
hotfix: Compose billing balance from runs NET usage (discount reflected in Available/Confirmed/Provisioned)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,8 +174,10 @@ Composition (`src/routes/accounts.ts:composeAccountFunds`):
 1. `getCustomerByOrg(identity)` → Stripe customer (for `id`)
 2. `sumSucceededTopupsForCustomer(identity, customer.id)` → paginates `GET /v1/payment_intents?customer=cus_X` and sums `amount_received` where `status='succeeded'`
 3. `sumLocalPromoCreditsForOrg(orgId)` → SUM `local_promos.amount_cents`
-4. `fetchRunsOrgUsageTotal(orgId, identity)` → runs-service `spent_cents`
-5. `fetchRunsOrgActualUsageTotal(orgId, identity)` → runs-service `total_expected_cents` from actualized platform costs only
+4. `fetchRunsOrgUsageTotal(orgId, identity)` → reads runs-service **`net_spent_cents`** (the frozen-NET usage total, `SUM(COALESCE(net, gross))`), NOT the gross `spent_cents`. Returned to callers as `spent_cents` (billing's "usage" = the discounted amount the org owes).
+5. `fetchRunsOrgActualUsageTotal(orgId, identity)` → reads runs-service **`net_total_expected_cents`** (the frozen-NET actualized total), NOT the gross `total_expected_cents`, from actualized platform costs only.
+
+> **Why net, not gross (bug #262):** the per-org usage discount is frozen per cost row at write time IN runs-service (gross + net stored). billing reads the NET org totals and subtracts them verbatim — the discount is applied exactly once (in runs), never re-applied here, and pre-discount rows read net == gross so it is non-retroactive. Reading the gross `spent_cents`/`total_expected_cents` fields (the pre-#249 wiring) left the dashboard Available + Confirmed/Provisioned lines at GROSS while the brand Overview showed net. ALWAYS read the `net_*` runs fields for balance composition.
 6. `hasAttachedCardPm(identity, customer.id)` → `has_payment_method` (≥1 chargeable PM: card or link)
 7. `getOrgCardCountry(identity, customer.id)` → `card_country` → `auto_reload_supported = !isAutoReloadBlockedCountry(card_country)` (see "Off_session auto-reload" below)
 8. `getUsageDiscountPct(orgId)` → `usage_discount_pct` (dashboard banner only; see "Per-org usage discount"). Does NOT enter the balance math — runs-service already served net usage.

--- a/src/lib/runs-client.ts
+++ b/src/lib/runs-client.ts
@@ -4,12 +4,29 @@ import { fetchWithRetry } from "./fetch-retry.js";
 
 export interface RunsOrgUsageTotalResult {
   org_id: string;
+  /**
+   * The NET platform usage (per-org usage discount frozen at cost-write in
+   * runs-service). Sourced from the runs `net_spent_cents` field, NOT the gross
+   * `spent_cents`. Billing subtracts this verbatim for the spendable balance — the
+   * discount is applied exactly once, in runs, so re-applying here would double it.
+   * Historical (pre-discount) rows read net == gross in runs, so this is
+   * non-retroactive by construction.
+   */
   spent_cents: string;
+  as_of: string;
+}
+
+/** Raw runs-service /internal/org-usage-total body (gross + frozen net). */
+interface RunsOrgUsageTotalResponse {
+  org_id: string;
+  spent_cents: string;
+  net_spent_cents: string;
   as_of: string;
 }
 
 interface RunsExpectedTotalsResponse {
   total_expected_cents: string;
+  net_total_expected_cents: string;
   runs: Array<{
     run_id: string;
     expected_cents: string;
@@ -17,6 +34,12 @@ interface RunsExpectedTotalsResponse {
 }
 
 export interface RunsOrgActualUsageTotalResult {
+  /**
+   * NET actualized usage (frozen per-row net, COALESCE(net, gross)). Sourced from
+   * the runs `net_total_expected_cents` field, NOT the gross `total_expected_cents`.
+   * Used for actual_balance_cents / the dashboard "Confirmed charges" line so it
+   * agrees with the net spendable balance and the brand Overview.
+   */
   spent_cents: string;
 }
 
@@ -30,9 +53,13 @@ function getRunsServiceConfig() {
 /**
  * Fetch canonical org usage total from runs-service.
  *
- * The runs-service contract owns usage detail. `spent_cents` includes
- * platform costs in `actual` and `provisioned` states, excludes cancelled
- * and org/BYOK costs, and preserves fractional cents as a decimal string.
+ * The runs-service contract owns usage detail. The runs body carries both a GROSS
+ * `spent_cents` and a frozen NET `net_spent_cents` (per-org usage discount applied
+ * once, at cost-write, inside runs). Billing reads the NET figure — the org owes
+ * (and is depleted / reloaded against) the discounted amount. Both cover platform
+ * costs in `actual` and `provisioned` states, exclude cancelled and org/BYOK costs,
+ * and preserve fractional cents as a decimal string. Fail-loud if the net field is
+ * absent (a runs-service too old to serve it).
  */
 export async function fetchRunsOrgUsageTotal(
   orgId: string,
@@ -60,7 +87,14 @@ export async function fetchRunsOrgUsageTotal(
     );
   }
 
-  return (await res.json()) as RunsOrgUsageTotalResult;
+  const body = (await res.json()) as RunsOrgUsageTotalResponse;
+  if (body.net_spent_cents == null) {
+    throw new Error(
+      `runs-service org-usage-total missing net_spent_cents for org ${orgId}`
+    );
+  }
+  // Return the NET figure as spent_cents — billing's usage is the discounted amount.
+  return { org_id: body.org_id, spent_cents: body.net_spent_cents, as_of: body.as_of };
 }
 
 /**
@@ -68,7 +102,10 @@ export async function fetchRunsOrgUsageTotal(
  *
  * This excludes provisioned holds, so consumers can display money that has
  * actually been spent without changing `fetchRunsOrgUsageTotal`, which remains
- * the source for authorization/depletion availability.
+ * the source for authorization/depletion availability. Reads the NET actualized
+ * total (`net_total_expected_cents`, frozen per-row net) so actual_balance_cents /
+ * the dashboard "Confirmed charges" line is discounted consistently with the net
+ * spendable balance. Fail-loud if the net field is absent.
  */
 export async function fetchRunsOrgActualUsageTotal(
   orgId: string,
@@ -97,5 +134,10 @@ export async function fetchRunsOrgActualUsageTotal(
   }
 
   const body = (await res.json()) as RunsExpectedTotalsResponse;
-  return { spent_cents: body.total_expected_cents };
+  if (body.net_total_expected_cents == null) {
+    throw new Error(
+      `runs-service runs-expected-totals missing net_total_expected_cents for org ${orgId}`
+    );
+  }
+  return { spent_cents: body.net_total_expected_cents };
 }

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -222,6 +222,43 @@ describe("Accounts endpoints", () => {
       expect(res.body.actual_balance_cents).toBe("55000.0000000000");
     });
 
+    it("composes balance on NET usage (mid-history discount) with additive bonus credits", async () => {
+      // Repro: org with a 50% usage discount set mid-history. runs-service freezes
+      // the per-row net at cost-write (pre-discount rows: net == gross; post-discount
+      // rows: net == gross*(1−pct)) and serves the NET totals, which the runs-client
+      // returns as spent_cents. Billing subtracts them verbatim — the discount is
+      // applied exactly once (in runs), never here. Free/welcome credits stay ADDITIVE
+      // on top: the discount and the bonus BOTH apply.
+      //
+      // Numbers mirror the prod repro org 5fefaf5a…: gross usage $65.40, NET usage
+      // $53.16 (Overview "Total spent"); gross actualized $33.24, NET actualized $27.84.
+      // Auto-create grants the $2 welcome bonus; paid topups seed the rest of credited.
+      ssMocks.hasAttachedCardPm.mockResolvedValue(false);
+      ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("6700.0000000000");
+      fetchRunsOrgUsageTotalSpy.mockResolvedValue({
+        org_id: orgId,
+        spent_cents: "5315.7879745674", // NET (post-discount), NOT gross 6540.03
+        as_of: "2026-07-13T00:00:00.000Z",
+      });
+      fetchRunsOrgActualUsageTotalSpy.mockResolvedValue({
+        spent_cents: "2783.9414137504", // NET actualized, NOT gross 3324.08
+      });
+
+      const res = await request(app)
+        .get("/v1/accounts")
+        .set(getAuthHeaders(orgId));
+
+      expect(res.status).toBe(200);
+      // credited = 6700 paid + 200 welcome bonus (additive on top of the net discount).
+      expect(res.body.credited_cents).toBe("6900.0000000000");
+      // usage reflects NET, not gross.
+      expect(res.body.usage_cents).toBe("5315.7879745674");
+      // Available = credited − NET usage (bonus counted on top).
+      expect(res.body.balance_cents).toBe("1584.2120254326");
+      // Confirmed line = credited − NET actualized.
+      expect(res.body.actual_balance_cents).toBe("4116.0585862496");
+    });
+
     it("returns 502 when runs-service unavailable", async () => {
       await insertTestAccount({ orgId });
       fetchRunsOrgUsageTotalSpy.mockRejectedValue(new Error("runs-service down"));

--- a/tests/unit/runs-client-net.test.ts
+++ b/tests/unit/runs-client-net.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as fetchRetry from "../../src/lib/fetch-retry.js";
+import {
+  fetchRunsOrgUsageTotal,
+  fetchRunsOrgActualUsageTotal,
+} from "../../src/lib/runs-client.js";
+
+const ORG = "5fefaf5a-8d50-4c5f-aa4b-3d35bcd1de93";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("runs-client reads NET usage (per-org usage discount frozen in runs)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("fetchRunsOrgUsageTotal returns net_spent_cents, NOT gross spent_cents", async () => {
+    // Mid-history discount: gross = pre-discount + post-discount (undiscounted);
+    // net = pre-discount (net == gross) + post-discount * (1 − pct). runs freezes
+    // the per-row net at cost-write, so the two totals diverge only over discounted
+    // rows and pre-discount usage stays at full price (non-retroactive).
+    const spy = vi
+      .spyOn(fetchRetry, "fetchWithRetry")
+      .mockResolvedValue(
+        jsonResponse({
+          org_id: ORG,
+          spent_cents: "6540.0330618610", // GROSS — must NOT be used
+          net_spent_cents: "5315.7879745674", // NET — must be used
+          as_of: "2026-07-13T00:00:00.000Z",
+        })
+      );
+
+    const result = await fetchRunsOrgUsageTotal(ORG, {});
+
+    expect(result.spent_cents).toBe("5315.7879745674");
+    expect(result.spent_cents).not.toBe("6540.0330618610");
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("/internal/org-usage-total?org_id="),
+      expect.anything()
+    );
+  });
+
+  it("fetchRunsOrgUsageTotal fails loud when net_spent_cents is absent", async () => {
+    vi.spyOn(fetchRetry, "fetchWithRetry").mockResolvedValue(
+      jsonResponse({
+        org_id: ORG,
+        spent_cents: "6540.0330618610",
+        as_of: "2026-07-13T00:00:00.000Z",
+      })
+    );
+
+    await expect(fetchRunsOrgUsageTotal(ORG, {})).rejects.toThrow(
+      /missing net_spent_cents/
+    );
+  });
+
+  it("fetchRunsOrgActualUsageTotal returns net_total_expected_cents, NOT gross", async () => {
+    vi.spyOn(fetchRetry, "fetchWithRetry").mockResolvedValue(
+      jsonResponse({
+        total_expected_cents: "3324.0849137504", // GROSS actualized — must NOT be used
+        net_total_expected_cents: "2783.9414137504", // NET actualized — must be used
+        runs: [],
+      })
+    );
+
+    const result = await fetchRunsOrgActualUsageTotal(ORG, {});
+
+    expect(result.spent_cents).toBe("2783.9414137504");
+    expect(result.spent_cents).not.toBe("3324.0849137504");
+  });
+
+  it("fetchRunsOrgActualUsageTotal fails loud when net_total_expected_cents is absent", async () => {
+    vi.spyOn(fetchRetry, "fetchWithRetry").mockResolvedValue(
+      jsonResponse({
+        total_expected_cents: "3324.0849137504",
+        runs: [],
+      })
+    );
+
+    await expect(fetchRunsOrgActualUsageTotal(ORG, {})).rejects.toThrow(
+      /missing net_total_expected_cents/
+    );
+  });
+});


### PR DESCRIPTION
Automated by release.sh