### PR TITLE
feat(billing): invoice off-session auto-topup reloads via stripe-service invoice endpoint

### DIFF
--- a/src/lib/month-end-sweep.ts
+++ b/src/lib/month-end-sweep.ts
@@ -35,7 +35,7 @@ import { computeBalance } from "./balance.js";
 import { tierFor, computeTopupCharge } from "./topup-tier.js";
 import { cmpCents } from "./cents.js";
 import { coalesceReload } from "./reload-coalescer.js";
-import { reloadViaPaymentIntent } from "./reload.js";
+import { reloadViaInvoice } from "./reload.js";
 
 // INTERNAL_IDENTITY sentinel — there is no end user on the sweep path. The /v1
 // reload primitives (getCustomerByOrg / listPaymentMethods / createPaymentIntent)
@@ -187,7 +187,7 @@ export async function runMonthEndSweep(
       const outcome = await coalesceReload(account.orgId, () =>
         withTimeout(
           RELOAD_TIMEOUT_MS,
-          reloadViaPaymentIntent(
+          reloadViaInvoice(
             identity,
             chargeAmount,
             sweepIdempotencyKey(account.orgId, bucket),

--- a/src/lib/reload.ts
+++ b/src/lib/reload.ts
@@ -1,54 +1,89 @@
 /**
- * Reload flow: compose a Stripe PaymentIntent via stripe-service.
+ * Off-session auto-topup reload: charge the org's stored card so it produces a
+ * FINALIZED, PAID Stripe INVOICE (hosted invoice + PDF in the customer's billing
+ * portal), not a bare uninvoiced PaymentIntent.
  *
- * stripe-service exposes only the Stripe-shape primitive (POST /v1/payment_intents).
- * Billing flattens Stripe's status enum into the {succeeded|failed} contract that
- * authorize/usage_apply consume.
+ * Interactive Checkout top-ups already invoice (checkout.ts invoice_creation).
+ * This closes the gap for the AUTOMATIC path: stripe-service exposes
+ * `POST /internal/invoices/by-org/{orgId}` (stripe-service#89) which drives Stripe
+ * draft-invoice → line-item → finalize → pay-off_session and returns the paid
+ * Invoice. billing flattens Stripe's invoice status into the {succeeded|failed}
+ * ReloadOutcome that authorize / usage_apply / month-end-sweep / wallet_setup
+ * consume — the SAME contract the former `createPaymentIntent` reload returned, so
+ * no caller changes shape.
  *
- * Picks an explicit `payment_method` via stripe-service `GET /v1/payment_methods`:
- * first an attached `card`, then a `link` PM as fallback. Both are chargeable
- * off_session — Stripe documents charging a saved `type:link` PM with
- * `off_session:true, confirm:true` exactly like a card
- * (https://docs.stripe.com/payments/link/save-and-reuse). A Checkout setup-mode flow
- * that offers card+link saves the PM as `type:link` for Link-enabled emails, so a
- * card-only pick used to throw for those orgs (Link-only) and silently disable reload.
+ * Payment method: an explicit `card` PM is resolved billing-side (first card, then
+ * a `link` fallback) and passed to stripe-service, mirroring the former reload's
+ * pick order. Both are chargeable off_session — Stripe documents charging a saved
+ * `type:link` PM with `off_session:true` exactly like a card
+ * (https://docs.stripe.com/payments/link/save-and-reuse). Passing an explicit id
+ * avoids the customer-default PM, which may be a Link/wallet PM Stripe refuses to
+ * charge off_session.
+ *
+ * Accounting: the invoice's underlying PaymentIntent is snapshotted into
+ * stripe-service's mirror on pay, so billing's `sumSucceededTopups*` counts this
+ * top-up as a paid topup identically to the former bare-PI reload — no double- or
+ * under-count of credited/balance.
  */
 
 import {
-  createPaymentIntent,
+  createOffSessionInvoiceForOrg,
   getCustomerByOrg,
   listPaymentMethods,
   type IdentityHeaders,
-  type StripePaymentIntent,
+  type StripeInvoice,
 } from "./stripe-service-client.js";
 import type { ReloadOutcome } from "./reload-coalescer.js";
 
 const RELOAD_CURRENCY = "usd";
+/** Invoice line-item + invoice description (min length 1 required by stripe-service). */
+const RELOAD_DESCRIPTION = "Distribute credit top-up";
 
-function flattenStatus(pi: StripePaymentIntent): ReloadOutcome {
-  if (pi.status === "succeeded") {
-    return { status: "succeeded", payment_intent_id: pi.id };
+function flattenInvoiceStatus(invoice: StripeInvoice): ReloadOutcome {
+  const paymentIntentId =
+    typeof invoice.payment_intent === "string"
+      ? invoice.payment_intent
+      : invoice.payment_intent?.id;
+  if (invoice.status === "paid" || invoice.paid === true) {
+    return { status: "succeeded", payment_intent_id: paymentIntentId };
   }
-  const reason = pi.last_payment_error?.message ?? `pi.status=${pi.status}`;
-  return { status: "failed", payment_intent_id: pi.id, failure_reason: reason };
+  // stripe-service throws (non-2xx) on a declined off_session charge, so this
+  // branch is defensive — a 200 with a non-paid status is still a failed reload.
+  return {
+    status: "failed",
+    payment_intent_id: paymentIntentId,
+    failure_reason: `invoice.status=${invoice.status ?? "unknown"}`,
+  };
 }
 
 /**
- * Charge `amountCents` against the first chargeable PM attached to the org's customer
- * — a `card` if present, otherwise a `link` PM. Synchronous: Stripe processes the
- * charge inline because confirm:true off_session:true.
+ * Charge `amountCents` off_session against the org's first chargeable PM (card,
+ * then link) via the stripe-service off-session INVOICE endpoint, producing a
+ * finalized paid invoice. Synchronous: stripe-service finalizes + pays inline and
+ * returns the paid Invoice.
  *
- * Caller MUST pass an idempotency key to ensure retries collapse.
+ * `identity` must carry `x-org-id` (the org whose customer is charged) and, for the
+ * PM lookup, `x-user-id` (the `/v1/payment_methods` read requires it — real user,
+ * or the sweep/internal sentinel). The invoice charge itself is user-less (orgId is
+ * in the path).
  *
- * Throws only if the customer has NO chargeable PM at all (no card and no link).
- * Caller's try/catch surfaces this as topup_triggered=false.
+ * Caller MUST pass an idempotency key so retries collapse (stripe-service derives
+ * per-Stripe-step keys from it — no duplicate invoice, no double charge).
+ *
+ * Throws if the customer has NO chargeable PM (no card and no link), or if the
+ * off_session charge is declined / stripe-service errors (fail-loud). Caller's
+ * try/catch surfaces this as topup_triggered=false / a 502.
  */
-export async function reloadViaPaymentIntent(
+export async function reloadViaInvoice(
   identity: IdentityHeaders,
   amountCents: number,
   idempotencyKey: string,
   metadata?: Record<string, string>
 ): Promise<ReloadOutcome> {
+  const orgId = identity["x-org-id"];
+  if (!orgId) {
+    throw new Error("reloadViaInvoice: identity is missing x-org-id");
+  }
   const customer = await getCustomerByOrg(identity);
   const cards = await listPaymentMethods(identity, {
     customer: customer.id,
@@ -67,18 +102,16 @@ export async function reloadViaPaymentIntent(
       "customer has no chargeable payment_method (card or link) attached for off_session reload"
     );
   }
-  const pi = await createPaymentIntent(
-    identity,
+  const invoice = await createOffSessionInvoiceForOrg(
+    orgId,
     {
       amount: amountCents,
       currency: RELOAD_CURRENCY,
-      customer: customer.id,
+      description: RELOAD_DESCRIPTION,
       payment_method: pm.id,
-      confirm: true,
-      off_session: true,
       metadata,
     },
     idempotencyKey
   );
-  return flattenStatus(pi);
+  return flattenInvoiceStatus(invoice);
 }

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -62,6 +62,30 @@ export interface StripePaymentIntentList {
   has_more: boolean;
 }
 
+/**
+ * Subset of the Stripe Invoice object billing-service reads back from the
+ * off-session invoiced-charge endpoint. stripe-service returns the paid Invoice
+ * verbatim; only these fields are consumed to flatten the reload outcome.
+ *
+ * `payment_intent` is the invoice's underlying PaymentIntent (string id, or the
+ * expanded object). stripe-service snapshots that PI into its mirror synchronously
+ * on pay, so the billing-side `sumSucceededTopups*` sum reflects this top-up
+ * immediately — the invoiced reload counts as a paid topup identically to the
+ * former bare-PI reload (no double-count, no under-count).
+ */
+export interface StripeInvoice {
+  id: string;
+  object: "invoice";
+  /** "paid" on a successful off-session charge. */
+  status: string | null;
+  paid?: boolean;
+  amount_paid?: number;
+  currency?: string;
+  payment_intent?: string | { id: string } | null;
+  hosted_invoice_url?: string | null;
+  metadata?: Record<string, string>;
+}
+
 export interface StripePaymentMethod {
   id: string;
   object: "payment_method";
@@ -546,4 +570,45 @@ export async function getOrgCardCountryByOrg(orgId: string): Promise<string | nu
     {}
   );
   return cards.data[0]?.card?.country ?? null;
+}
+
+/**
+ * Create + pay a finalized OFF-SESSION Stripe invoice for the org's customer via
+ * the user-less `POST /internal/invoices/by-org/{orgId}` route (stripe-service#89).
+ * X-API-Key only — orgId is in the path, NO x-user-id / x-org-id / sentinel.
+ *
+ * stripe-service drives Stripe end-to-end (draft invoice → line item → finalize →
+ * pay off_session) and returns the paid Invoice verbatim (hosted invoice + PDF,
+ * visible in the customer's billing portal invoice list). This replaces the bare
+ * off_session PaymentIntent reload so EVERY auto-topup produces an invoice document.
+ *
+ * `Idempotency-Key` is REQUIRED: stripe-service derives a per-Stripe-step key from
+ * it, so a retry for the same logical top-up never double-charges or duplicates the
+ * invoice. Pass the SAME key billing already computes per reload (reloadIdempotencyKey
+ * / sweepIdempotencyKey / initialLoadIdempotencyKey).
+ *
+ * Prefer passing an explicit card `payment_method` — the customer's Stripe default
+ * may be a Link/wallet PM Stripe refuses to charge off_session.
+ *
+ * Fail-loud: a declined off_session charge (or any Stripe error) propagates as a
+ * non-2xx → `call` throws. 404 when the org has no Stripe customer.
+ */
+export async function createOffSessionInvoiceForOrg(
+  orgId: string,
+  body: {
+    amount: number;
+    currency: string;
+    description: string;
+    payment_method?: string;
+    metadata?: Record<string, string>;
+  },
+  idempotencyKey: string
+): Promise<StripeInvoice> {
+  return call<StripeInvoice>(
+    "POST",
+    `/internal/invoices/by-org/${encodeURIComponent(orgId)}`,
+    {},
+    body,
+    { "Idempotency-Key": idempotencyKey }
+  );
 }

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -11,7 +11,7 @@ import { tierFor } from "../lib/topup-tier.js";
 import { fetchRunsOrgActualUsageTotal, fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
 import { grantFirstLoadMatch, sumLocalPromoCreditsForOrg } from "../lib/promos.js";
 import { getUsageDiscountPct } from "../lib/usage-discount.js";
-import { reloadViaPaymentIntent } from "../lib/reload.js";
+import { reloadViaInvoice } from "../lib/reload.js";
 import {
   getCustomerByOrg,
   sumSucceededTopupsForCustomer,
@@ -348,7 +348,7 @@ router.post("/v1/accounts/wallet_setup", requireOrgHeaders, async (req, res) => 
     try {
       initialLoad = await withTimeout(
         INITIAL_LOAD_TIMEOUT_MS,
-        reloadViaPaymentIntent(
+        reloadViaInvoice(
           identity,
           initial_load_amount_cents,
           initialLoadIdempotencyKey(orgId, initial_load_amount_cents),

--- a/src/routes/customer_balance.ts
+++ b/src/routes/customer_balance.ts
@@ -19,7 +19,7 @@ import { computeBalance } from "../lib/balance.js";
 import { tierFor, computeTopupCharge, resolvePostpaidTier } from "../lib/topup-tier.js";
 import { upsertCampaignAuthorizeCost } from "../lib/campaign-costs.js";
 import { openDepletionEpisodeIfDepleted } from "../lib/dunning.js";
-import { reloadViaPaymentIntent } from "../lib/reload.js";
+import { reloadViaInvoice } from "../lib/reload.js";
 import { coalesceReload } from "../lib/reload-coalescer.js";
 
 const router = Router();
@@ -226,7 +226,7 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
       reloadResult = await coalesceReload(orgId, () =>
         withTimeout(
           RELOAD_TIMEOUT_MS,
-          reloadViaPaymentIntent(identity, chargeAmount, reloadIdempotencyKey(orgId, chargeAmount))
+          reloadViaInvoice(identity, chargeAmount, reloadIdempotencyKey(orgId, chargeAmount))
         )
       );
     } catch (err) {
@@ -378,7 +378,7 @@ router.post("/v1/customer_balance/usage_apply", requireOrgHeaders, async (req, r
       const result = await coalesceReload(orgId, () =>
         withTimeout(
           RELOAD_TIMEOUT_MS,
-          reloadViaPaymentIntent(identity, chargeAmount, reloadIdempotencyKey(orgId, chargeAmount))
+          reloadViaInvoice(identity, chargeAmount, reloadIdempotencyKey(orgId, chargeAmount))
         )
       );
       topupTriggered = result.status === "succeeded";

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -23,7 +23,7 @@ export interface StripeServiceMocks {
   createCheckoutSession: ReturnType<typeof vi.fn>;
   createPortalSession: ReturnType<typeof vi.fn>;
   getStats: ReturnType<typeof vi.fn>;
-  reloadViaPaymentIntent: ReturnType<typeof vi.fn>;
+  reloadViaInvoice: ReturnType<typeof vi.fn>;
 }
 
 const MOCK_CUSTOMER_ID = "cus_mock_123";
@@ -52,7 +52,7 @@ export function customerWithEmail(
  * defaults. Returns the mock collection so individual tests can assert calls
  * or override return values.
  *
- * `reloadViaPaymentIntent` is mocked at the helper layer (lib/reload.ts) — that
+ * `reloadViaInvoice` is mocked at the helper layer (lib/reload.ts) — that
  * keeps test ergonomics close to the old `reload` mock.
  */
 export function setupStripeMocks(): StripeServiceMocks {
@@ -126,7 +126,7 @@ export function setupStripeMocks(): StripeServiceMocks {
       monthly_growth: [],
       weekly_growth: [],
     }),
-    reloadViaPaymentIntent: vi.fn().mockResolvedValue({
+    reloadViaInvoice: vi.fn().mockResolvedValue({
       status: "succeeded",
       payment_intent_id: "pi_mock",
     }),
@@ -154,7 +154,7 @@ export function setupStripeMocks(): StripeServiceMocks {
   vi.spyOn(ssClient, "listCustomersByMetadata").mockImplementation(mocks.listCustomersByMetadata);
   vi.spyOn(ssClient, "updateCustomer").mockImplementation(mocks.updateCustomer);
   vi.spyOn(ssClient, "getStats").mockImplementation(mocks.getStats);
-  vi.spyOn(reload, "reloadViaPaymentIntent").mockImplementation(mocks.reloadViaPaymentIntent);
+  vi.spyOn(reload, "reloadViaInvoice").mockImplementation(mocks.reloadViaInvoice);
 
   return mocks;
 }

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -471,7 +471,7 @@ describe("Accounts endpoints", () => {
         expect(res.body.first_load_match_applied).toBe(true);
         expect(res.body.first_load_match_cents).toBe(expectedBonus);
         expect(res.body.balance_cents).toBe(expectedBalance);
-        expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledWith(
+        expect(ssMocks.reloadViaInvoice).toHaveBeenCalledWith(
           expect.objectContaining({ "x-org-id": orgId }),
           load,
           expect.any(String),
@@ -530,7 +530,7 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("topup_threshold_cents");
-      expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+      expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
     });
 
     it("rejects wallet setup when no payment method is attached", async () => {
@@ -547,7 +547,7 @@ describe("Accounts endpoints", () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("Payment method required");
-      expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+      expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/integration/authorize-runs-total.test.ts
+++ b/tests/integration/authorize-runs-total.test.ts
@@ -69,7 +69,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     // available = 0 + 100 − 40 = 60
     expect(res.body.balance_cents).toBe("60.0000000000");
     expect(res.body.required_cents).toBe("10.0000000000");
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("insufficient + no topup config → returns sufficient:false without reload", async () => {
@@ -83,7 +83,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
 
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(false);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("negative balance still within the credit line → sufficient:true, NO reload (postpaid)", async () => {
@@ -106,7 +106,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(true);
     expect(res.body.balance_cents).toBe("-4000.0000000000");
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("crossing the floor → reloads the TIER amount (not the stored daily amount) and re-evaluates", async () => {
@@ -131,8 +131,8 @@ describe("Customer balance authorize — composed paid topups + local − usage"
 
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(true);
-    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
-    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(5000);
+    expect(ssMocks.reloadViaInvoice).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaInvoice.mock.calls[0]?.[1]).toBe(5000);
   });
 
   it("tier scales with cumulative paid: $200-tier org crossing floor reloads $200", async () => {
@@ -156,8 +156,8 @@ describe("Customer balance authorize — composed paid topups + local − usage"
 
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(true);
-    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
-    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(20000);
+    expect(ssMocks.reloadViaInvoice).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaInvoice.mock.calls[0]?.[1]).toBe(20000);
   });
 
   it("crossing the floor + card attached but no default PM → fires reload (regression)", async () => {
@@ -182,8 +182,8 @@ describe("Customer balance authorize — composed paid topups + local − usage"
 
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(true);
-    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
-    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(5000);
+    expect(ssMocks.reloadViaInvoice).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaInvoice.mock.calls[0]?.[1]).toBe(5000);
   });
 
   it("insufficient + topup + no card attached → graceful sufficient:false, no reload", async () => {
@@ -198,7 +198,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
 
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(false);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("insufficient + topup + India card → sufficient:false, no reload attempted", async () => {
@@ -216,7 +216,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
 
     expect(res.status).toBe(200);
     expect(res.body.sufficient).toBe(false);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("PM lookup errors (stripe-service down) → 502, never silent no-PM", async () => {
@@ -230,7 +230,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
       .send(authorizeBody);
 
     expect(res.status).toBe(502);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("reload status=failed (past the floor) → sufficient:false", async () => {
@@ -242,7 +242,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
       spent_cents: "5000.0000000000",
       as_of: "x",
     });
-    ssMocks.reloadViaPaymentIntent.mockResolvedValue({
+    ssMocks.reloadViaInvoice.mockResolvedValue({
       status: "failed",
       failure_reason: "card_declined",
     });
@@ -265,7 +265,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
       spent_cents: "5000.0000000000",
       as_of: "x",
     });
-    ssMocks.reloadViaPaymentIntent.mockRejectedValue(new Error("SS down"));
+    ssMocks.reloadViaInvoice.mockRejectedValue(new Error("SS down"));
 
     const res = await request(app)
       .post("/v1/customer_balance/authorize")
@@ -285,7 +285,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
       as_of: "x",
     });
 
-    ssMocks.reloadViaPaymentIntent.mockImplementation(
+    ssMocks.reloadViaInvoice.mockImplementation(
       () =>
         new Promise<{ status: "succeeded"; payment_intent_id: string }>((resolve) => {
           setTimeout(() => resolve({ status: "succeeded", payment_intent_id: "pi_x" }), 100);
@@ -305,7 +305,7 @@ describe("Customer balance authorize — composed paid topups + local − usage"
     for (const r of results) {
       expect(r.status).toBe(200);
     }
-    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaInvoice).toHaveBeenCalledTimes(1);
   });
 
   it("fails loud when runs-service unavailable", async () => {

--- a/tests/integration/campaign-affordability.test.ts
+++ b/tests/integration/campaign-affordability.test.ts
@@ -212,7 +212,7 @@ describe("GET /internal/campaigns/:campaignId/affordability (read-only gate)", (
 
     expect(res.status).toBe(200);
     expect(res.body.affordable).toBe(false);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
     expect(await listEpisodes(orgId)).toHaveLength(0);
   });
 

--- a/tests/integration/dunning.test.ts
+++ b/tests/integration/dunning.test.ts
@@ -390,14 +390,14 @@ describe("Out-of-credit dunning engine (issue #147)", () => {
     expect(res.body.sufficient).toBe(true);
     expect(await listEpisodes(orgId)).toHaveLength(0);
     expect(sendEmailSpy).not.toHaveBeenCalled();
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("18: auto-topup org crosses the floor + reload fails → opens episode, sends T0", async () => {
     await insertTestAccount({ orgId, topupAmountCents: 5000, topupThresholdCents: 1000 });
     setBalance("0.0000000000");
     setUsage("5001.0000000000"); // balance -5001, past the -5000 floor
-    ssMocks.reloadViaPaymentIntent.mockResolvedValue({
+    ssMocks.reloadViaInvoice.mockResolvedValue({
       status: "failed",
       failure_reason: "card_declined",
     });

--- a/tests/integration/internal-balance-by-org.test.ts
+++ b/tests/integration/internal-balance-by-org.test.ts
@@ -59,7 +59,7 @@ describe("GET /internal/accounts/by-org/:orgId/balance (user-less balance read)"
     expect(res.status).toBe(404);
     // Pure read: no balance compose for a non-existent account.
     expect(ssMocks.fetchOrgCustomer).not.toHaveBeenCalled();
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("200 with same shape as /v1/accounts/balance (credited − usage)", async () => {
@@ -81,7 +81,7 @@ describe("GET /internal/accounts/by-org/:orgId/balance (user-less balance read)"
     // User-less balance path: keyed off orgId ONLY (no x-user-id / sentinel).
     expect(ssMocks.fetchOrgCustomer).toHaveBeenCalledWith(orgId);
     // Pure read: never reloads.
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("has_auto_topup=true when topup configured + chargeable card + supported country", async () => {
@@ -98,7 +98,7 @@ describe("GET /internal/accounts/by-org/:orgId/balance (user-less balance read)"
     expect(res.status).toBe(200);
     expect(res.body.has_auto_topup).toBe(true);
     // Pure read: still never reloads, even for an auto-topup-enabled org.
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("has_auto_topup=false when topup configured but no chargeable card", async () => {

--- a/tests/integration/month-end-sweep.test.ts
+++ b/tests/integration/month-end-sweep.test.ts
@@ -67,11 +67,11 @@ describe("Month-end forced top-up sweep", () => {
     expect(res.charged).toBe(1);
     expect(res.skipped).toBe(0);
     expect(res.failed).toBe(0);
-    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaInvoice).toHaveBeenCalledTimes(1);
     // One tier-amount multiple (5000) clears the -100 deficit to +4900.
-    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(5000);
+    expect(ssMocks.reloadViaInvoice.mock.calls[0]?.[1]).toBe(5000);
     // Month-scoped idempotency key.
-    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[2]).toBe(
+    expect(ssMocks.reloadViaInvoice.mock.calls[0]?.[2]).toBe(
       sweepIdempotencyKey(orgA, monthBucket(LAST_DAY))
     );
   });
@@ -89,7 +89,7 @@ describe("Month-end forced top-up sweep", () => {
 
     expect(res.charged).toBe(0);
     expect(res.skipped).toBe(1);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("AC2: does NOT charge an org with no chargeable card", async () => {
@@ -106,7 +106,7 @@ describe("Month-end forced top-up sweep", () => {
 
     expect(res.charged).toBe(0);
     expect(res.skipped).toBe(1);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("AC2: does NOT charge a blocked-country (India) card", async () => {
@@ -123,7 +123,7 @@ describe("Month-end forced top-up sweep", () => {
 
     expect(res.charged).toBe(0);
     expect(res.skipped).toBe(1);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("AC2: does NOT select an org with no auto-topup config", async () => {
@@ -135,7 +135,7 @@ describe("Month-end forced top-up sweep", () => {
 
     expect(res.eligible).toBe(0);
     expect(res.charged).toBe(0);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("AC3: idempotent — after the settle, a second tick reads non-negative and skips", async () => {
@@ -157,7 +157,7 @@ describe("Month-end forced top-up sweep", () => {
     expect(second.charged).toBe(0);
     expect(second.skipped).toBe(1);
     // Exactly ONE charge across both ticks.
-    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaInvoice).toHaveBeenCalledTimes(1);
   });
 
   it("AC4: a per-org failure is isolated — the sweep continues for other orgs", async () => {
@@ -184,7 +184,7 @@ describe("Month-end forced top-up sweep", () => {
     expect(res.eligible).toBe(2);
     expect(res.failed).toBe(1); // orgA
     expect(res.charged).toBe(1); // orgB still settled
-    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaInvoice).toHaveBeenCalledTimes(1);
   });
 
   it("AC5/AC6: no-op on any day that is not the last of the month", async () => {
@@ -201,6 +201,6 @@ describe("Month-end forced top-up sweep", () => {
     expect(res.ranSweep).toBe(false);
     expect(res.eligible).toBe(0);
     expect(res.charged).toBe(0);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/promo.test.ts
+++ b/tests/integration/promo.test.ts
@@ -43,7 +43,7 @@ describe("Promotion code endpoints", () => {
       // No welcome on this account (inserted manually) → only the promo.
       expect(res.body.local_credits_total_cents).toBe("800.0000000000");
       expect(ssMocks.getCustomerByOrg).not.toHaveBeenCalled();
-      expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+      expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
     });
 
     it("auto-creates billing account with welcome + applies promo on top", async () => {

--- a/tests/integration/usage-apply.test.ts
+++ b/tests/integration/usage-apply.test.ts
@@ -41,7 +41,7 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
 
     expect(res.status).toBe(202);
     expect(res.body).toEqual({ acknowledged: true, topup_triggered: false });
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("no reload while the negative balance is within the credit line (postpaid)", async () => {
@@ -61,7 +61,7 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
 
     expect(res.status).toBe(202);
     expect(res.body).toEqual({ acknowledged: true, topup_triggered: false });
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("triggers reload when balance crosses the floor; charges the TIER amount not the stored daily", async () => {
@@ -81,9 +81,9 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
 
     expect(res.status).toBe(202);
     expect(res.body).toEqual({ acknowledged: true, topup_triggered: true });
-    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaInvoice).toHaveBeenCalledTimes(1);
     // Charge is the tier amount (5000), NOT the stored daily topup_amount (1000).
-    expect(ssMocks.reloadViaPaymentIntent.mock.calls[0]?.[1]).toBe(5000);
+    expect(ssMocks.reloadViaInvoice.mock.calls[0]?.[1]).toBe(5000);
   });
 
   it("triggers reload when card attached but no default PM (regression)", async () => {
@@ -104,7 +104,7 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
 
     expect(res.status).toBe(202);
     expect(res.body).toEqual({ acknowledged: true, topup_triggered: true });
-    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalledTimes(1);
+    expect(ssMocks.reloadViaInvoice).toHaveBeenCalledTimes(1);
   });
 
   it("does not topup when no card attached", async () => {
@@ -123,7 +123,7 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
 
     expect(res.status).toBe(202);
     expect(res.body).toEqual({ acknowledged: true, topup_triggered: false });
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("does not topup for an India-issued card (off_session mandate unsupported)", async () => {
@@ -143,7 +143,7 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
 
     expect(res.status).toBe(202);
     expect(res.body).toEqual({ acknowledged: true, topup_triggered: false });
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("does not topup when no topup config", async () => {
@@ -156,7 +156,7 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
 
     expect(res.status).toBe(202);
     expect(res.body.topup_triggered).toBe(false);
-    expect(ssMocks.reloadViaPaymentIntent).not.toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).not.toHaveBeenCalled();
   });
 
   it("topup_triggered=false when reload returns failed", async () => {
@@ -167,7 +167,7 @@ describe("POST /v1/customer_balance/usage_apply — proactive topup hint", () =>
     });
     ssMocks.getCustomerByOrg.mockResolvedValue(customerWithDefaultPM());
     ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
-    ssMocks.reloadViaPaymentIntent.mockResolvedValue({
+    ssMocks.reloadViaInvoice.mockResolvedValue({
       status: "failed",
       failure_reason: "decline",
     });

--- a/tests/integration/usage-discount.test.ts
+++ b/tests/integration/usage-discount.test.ts
@@ -269,7 +269,7 @@ describe("Usage discount is NOT applied at balance composition (frozen in runs-s
     // paid 0 → start tier floor -5000. runs reports net spend 6000 → balance −6000
     // (past the floor) → reload fires. Billing does NOT re-discount the 6000.
     ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
-    ssMocks.reloadViaPaymentIntent.mockResolvedValue({ status: "succeeded", payment_intent_id: "pi_x" });
+    ssMocks.reloadViaInvoice.mockResolvedValue({ status: "succeeded", payment_intent_id: "pi_x" });
 
     const res = await request(app)
       .post("/v1/customer_balance/usage_apply")
@@ -278,7 +278,7 @@ describe("Usage discount is NOT applied at balance composition (frozen in runs-s
 
     expect(res.status).toBe(202);
     expect(res.body).toEqual({ acknowledged: true, topup_triggered: true });
-    expect(ssMocks.reloadViaPaymentIntent).toHaveBeenCalled();
+    expect(ssMocks.reloadViaInvoice).toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/reload.test.ts
+++ b/tests/unit/reload.test.ts
@@ -1,14 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as ssClient from "../../src/lib/stripe-service-client.js";
-import { reloadViaPaymentIntent } from "../../src/lib/reload.js";
+import { reloadViaInvoice } from "../../src/lib/reload.js";
 
 const CUSTOMER_ID = "cus_mock";
+const ORG_ID = "org_test";
 const IDEMPOTENCY_KEY = "ik_test_123";
 
 function buildCustomer(): ssClient.StripeCustomer {
   return {
     id: CUSTOMER_ID,
     object: "customer",
+    email: null,
     metadata: {},
     invoice_settings: { default_payment_method: "pm_link_default" },
   };
@@ -22,36 +24,34 @@ function buildPMList(data: ssClient.StripePaymentMethod[]): ssClient.StripePayme
   return { object: "list", url: "/v1/payment_methods", data, has_more: false };
 }
 
-function buildPI(
-  id: string,
-  status: ssClient.StripePaymentIntent["status"],
-  amount_received: number | null = null
-): ssClient.StripePaymentIntent {
+function buildInvoice(
+  status: string | null,
+  payment_intent: ssClient.StripeInvoice["payment_intent"] = "pi_mock"
+): ssClient.StripeInvoice {
   return {
-    id,
-    object: "payment_intent",
-    amount: amount_received ?? 0,
-    amount_received,
-    currency: "usd",
-    customer: CUSTOMER_ID,
+    id: "in_mock",
+    object: "invoice",
     status,
-    last_payment_error: null,
+    paid: status === "paid",
+    amount_paid: 2500,
+    currency: "usd",
+    payment_intent,
   };
 }
 
-describe("reloadViaPaymentIntent", () => {
+describe("reloadViaInvoice", () => {
   let getCustomerByOrg: ReturnType<typeof vi.spyOn>;
   let listPaymentMethods: ReturnType<typeof vi.spyOn>;
-  let createPaymentIntent: ReturnType<typeof vi.spyOn>;
+  let createOffSessionInvoiceForOrg: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     getCustomerByOrg = vi
       .spyOn(ssClient, "getCustomerByOrg")
       .mockResolvedValue(buildCustomer());
     listPaymentMethods = vi.spyOn(ssClient, "listPaymentMethods");
-    createPaymentIntent = vi
-      .spyOn(ssClient, "createPaymentIntent")
-      .mockResolvedValue(buildPI("pi_mock", "succeeded", 2500));
+    createOffSessionInvoiceForOrg = vi
+      .spyOn(ssClient, "createOffSessionInvoiceForOrg")
+      .mockResolvedValue(buildInvoice("paid", "pi_mock"));
   });
 
   afterEach(() => {
@@ -63,17 +63,16 @@ describe("reloadViaPaymentIntent", () => {
       buildPMList([buildPM("pm_card_1", "card"), buildPM("pm_link_1", "link")])
     );
 
-    await reloadViaPaymentIntent({ "x-org-id": "org_test" }, 2500, IDEMPOTENCY_KEY);
+    await reloadViaInvoice({ "x-org-id": ORG_ID }, 2500, IDEMPOTENCY_KEY);
 
-    expect(createPaymentIntent).toHaveBeenCalledTimes(1);
-    const [, body] = createPaymentIntent.mock.calls[0]!;
+    expect(createOffSessionInvoiceForOrg).toHaveBeenCalledTimes(1);
+    const [orgId, body] = createOffSessionInvoiceForOrg.mock.calls[0]!;
+    expect(orgId).toBe(ORG_ID);
     expect(body).toMatchObject({
       amount: 2500,
       currency: "usd",
-      customer: CUSTOMER_ID,
+      description: "Distribute credit top-up",
       payment_method: "pm_card_1",
-      confirm: true,
-      off_session: true,
     });
   });
 
@@ -82,9 +81,9 @@ describe("reloadViaPaymentIntent", () => {
       buildPMList([buildPM("pm_card_only", "card")])
     );
 
-    await reloadViaPaymentIntent({ "x-org-id": "org_test" }, 1000, IDEMPOTENCY_KEY);
+    await reloadViaInvoice({ "x-org-id": ORG_ID }, 1000, IDEMPOTENCY_KEY);
 
-    const [, body] = createPaymentIntent.mock.calls[0]!;
+    const [, body] = createOffSessionInvoiceForOrg.mock.calls[0]!;
     expect(body.payment_method).toBe("pm_card_only");
   });
 
@@ -92,9 +91,9 @@ describe("reloadViaPaymentIntent", () => {
     listPaymentMethods.mockResolvedValue(buildPMList([]));
 
     await expect(
-      reloadViaPaymentIntent({ "x-org-id": "org_test" }, 2500, IDEMPOTENCY_KEY)
+      reloadViaInvoice({ "x-org-id": ORG_ID }, 2500, IDEMPOTENCY_KEY)
     ).rejects.toThrow(/no chargeable payment_method \(card or link\)/);
-    expect(createPaymentIntent).not.toHaveBeenCalled();
+    expect(createOffSessionInvoiceForOrg).not.toHaveBeenCalled();
   });
 
   it("falls back to a link PM when the customer has no card (Link-only org)", async () => {
@@ -107,43 +106,64 @@ describe("reloadViaPaymentIntent", () => {
       )
     );
 
-    await reloadViaPaymentIntent({ "x-org-id": "org_test" }, 2500, IDEMPOTENCY_KEY);
+    await reloadViaInvoice({ "x-org-id": ORG_ID }, 2500, IDEMPOTENCY_KEY);
 
     expect(listPaymentMethods).toHaveBeenCalledTimes(2);
-    const [, body] = createPaymentIntent.mock.calls[0]!;
-    expect(body).toMatchObject({
-      payment_method: "pm_link_only",
-      confirm: true,
-      off_session: true,
-    });
+    const [, body] = createOffSessionInvoiceForOrg.mock.calls[0]!;
+    expect(body.payment_method).toBe("pm_link_only");
   });
 
-  it("flattens a succeeded PI to {status:succeeded, payment_intent_id}", async () => {
-    listPaymentMethods.mockResolvedValue(buildPMList([buildPM("pm_card", "card")]));
-    createPaymentIntent.mockResolvedValue(buildPI("pi_xyz", "succeeded", 2500));
+  it("throws when identity is missing x-org-id (no charge attempted)", async () => {
+    await expect(
+      reloadViaInvoice({}, 2500, IDEMPOTENCY_KEY)
+    ).rejects.toThrow(/missing x-org-id/);
+    expect(getCustomerByOrg).not.toHaveBeenCalled();
+    expect(createOffSessionInvoiceForOrg).not.toHaveBeenCalled();
+  });
 
-    const result = await reloadViaPaymentIntent(
-      { "x-org-id": "org_test" },
-      2500,
-      IDEMPOTENCY_KEY
-    );
+  it("flattens a paid invoice to {status:succeeded, payment_intent_id}", async () => {
+    listPaymentMethods.mockResolvedValue(buildPMList([buildPM("pm_card", "card")]));
+    createOffSessionInvoiceForOrg.mockResolvedValue(buildInvoice("paid", "pi_xyz"));
+
+    const result = await reloadViaInvoice({ "x-org-id": ORG_ID }, 2500, IDEMPOTENCY_KEY);
 
     expect(result).toEqual({ status: "succeeded", payment_intent_id: "pi_xyz" });
   });
 
-  it("forwards the idempotency key unchanged to createPaymentIntent", async () => {
+  it("reads payment_intent from an expanded invoice.payment_intent object", async () => {
+    listPaymentMethods.mockResolvedValue(buildPMList([buildPM("pm_card", "card")]));
+    createOffSessionInvoiceForOrg.mockResolvedValue(buildInvoice("paid", { id: "pi_expanded" }));
+
+    const result = await reloadViaInvoice({ "x-org-id": ORG_ID }, 2500, IDEMPOTENCY_KEY);
+
+    expect(result).toEqual({ status: "succeeded", payment_intent_id: "pi_expanded" });
+  });
+
+  it("forwards the idempotency key unchanged to the invoice endpoint", async () => {
     listPaymentMethods.mockResolvedValue(buildPMList([buildPM("pm_card", "card")]));
 
-    await reloadViaPaymentIntent({ "x-org-id": "org_test" }, 2500, IDEMPOTENCY_KEY);
+    await reloadViaInvoice({ "x-org-id": ORG_ID }, 2500, IDEMPOTENCY_KEY);
 
-    const [, , forwardedKey] = createPaymentIntent.mock.calls[0]!;
+    const [, , forwardedKey] = createOffSessionInvoiceForOrg.mock.calls[0]!;
     expect(forwardedKey).toBe(IDEMPOTENCY_KEY);
+  });
+
+  it("forwards caller metadata to the invoice endpoint", async () => {
+    listPaymentMethods.mockResolvedValue(buildPMList([buildPM("pm_card", "card")]));
+
+    await reloadViaInvoice({ "x-org-id": ORG_ID }, 2500, IDEMPOTENCY_KEY, {
+      reason: "month_end_sweep",
+      month: "2026-07",
+    });
+
+    const [, body] = createOffSessionInvoiceForOrg.mock.calls[0]!;
+    expect(body.metadata).toEqual({ reason: "month_end_sweep", month: "2026-07" });
   });
 
   it("queries listPaymentMethods with customer id and type=card", async () => {
     listPaymentMethods.mockResolvedValue(buildPMList([buildPM("pm_card", "card")]));
 
-    await reloadViaPaymentIntent({ "x-org-id": "org_test" }, 2500, IDEMPOTENCY_KEY);
+    await reloadViaInvoice({ "x-org-id": ORG_ID }, 2500, IDEMPOTENCY_KEY);
 
     expect(getCustomerByOrg).toHaveBeenCalledTimes(1);
     expect(listPaymentMethods).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## What

Every automatic off-session **auto-topup reload** now produces a **finalized, paid Stripe invoice** (hosted invoice + PDF, visible in the customer's Stripe billing portal invoice list) instead of a bare uninvoiced PaymentIntent. Interactive Checkout top-ups already invoice (`checkout.ts` `invoice_creation`); this closes the gap for the automatic path flagged as "separate future work" in `checkout.ts`.

## How

Swaps the reload charge primitive from stripe-service `POST /v1/payment_intents` to the new user-less **`POST /internal/invoices/by-org/{orgId}`** (stripe-service#89), which drives Stripe draft-invoice → line-item → finalize → pay-off_session and returns the paid Invoice.

- `stripe-service-client.ts`: `createOffSessionInvoiceForOrg(orgId, {amount, currency, description, payment_method?, metadata?}, idempotencyKey)` + `StripeInvoice` type. X-API-Key only, orgId in path, `Idempotency-Key` header.
- `reload.ts`: `reloadViaPaymentIntent` → `reloadViaInvoice`, same `(identity, amountCents, idempotencyKey, metadata)` signature and same `ReloadOutcome {succeeded|failed, payment_intent_id?}` contract. Resolves an explicit card (then link fallback) PM as before and passes it; flattens the paid invoice → `ReloadOutcome`.
- All four off-session call sites unchanged in shape: authorize auto-reload, usage_apply auto-reload, month-end sweep, wallet_setup initial load.

## Accounting — unchanged

stripe-service snapshots the invoice's PaymentIntent into its mirror synchronously on pay, so billing's `sumSucceededTopups*` counts the invoiced reload as a paid topup **identically** to the former bare-PI reload. No double-count, no under-count of `credited_cents` / `balance`.

## Single-charge / idempotency — preserved

The in-memory coalescer still fires **one** charge per burst per org; the same per-reload `Idempotency-Key` (`reloadIdempotencyKey` / `sweepIdempotencyKey` / `initialLoadIdempotencyKey`) is forwarded to the invoice endpoint, which derives per-Stripe-step keys from it → a retry never double-charges or duplicates the invoice.

## AC

- [x] Auto-topup / off-session reload → finalized, paid Stripe invoice in the portal invoice list (not a bare charge).
- [x] `credited_cents` / balance accounting identical to the PaymentIntent path.
- [x] Single-charge / idempotency preserved (coalescer + forwarded idempotency key).

## Tests

- Rewrote `tests/unit/reload.test.ts` for the invoice path (PM pick order, link fallback, missing-x-org-id guard, paid→succeeded flatten, expanded `payment_intent` object, idempotency-key + metadata forwarding).
- Full suite green: **333 passed**, typecheck + build clean.

## Dependency / merge gate

Gated on **stripe-service#89** (`POST /internal/invoices/by-org/{orgId}`) being **live in staging**. Conforms to its deployed contract (read from the pushed branch source; will re-verify against api-registry once deployed). **Hold merge until stripe-service#89 is merged + deployed to staging.**

## Triage

feature → staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
