### PR TITLE
hotfix: enable Stripe promotion-code entry on hosted onboarding top-up checkout

### DIFF
--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -360,6 +360,14 @@ export interface CheckoutSessionBody {
    * Omitted for setup mode (no charge).
    */
   invoice_creation?: { enabled: boolean };
+  /**
+   * Hosted payment-mode only: when true, Stripe's hosted Checkout page shows the native
+   * "Add promotion code" field so the user can enter a valid Stripe promotion code and
+   * have the discount applied at pay time. Credit accounting is unchanged — credit still
+   * derives from the amount Stripe actually receives (a fully-discounted $0 checkout
+   * lands $0 credit). Deliberately NOT set for setup mode (no charge) or embedded checkout.
+   */
+  allow_promotion_codes?: boolean;
 }
 
 export async function createCheckoutSession(

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -102,6 +102,12 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
         } else {
           body.success_url = success_url;
           body.cancel_url = cancel_url;
+          // Hosted payment-mode top-up only: show Stripe's native "Add promotion code"
+          // field so a user can enter a valid Stripe promotion code (e.g. a 100%-off comp)
+          // and have the discount applied at pay time. Only valid codes do anything; credit
+          // still derives from the amount Stripe receives (a $0 checkout lands $0 credit).
+          // Deliberately NOT set for setup mode or embedded checkout (out of scope).
+          body.allow_promotion_codes = true;
         }
       }
       session = await createCheckoutSession(identity, body);

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -66,8 +66,28 @@ describe("POST /v1/checkout-sessions", () => {
           setup_future_usage: "off_session",
         },
         invoice_creation: { enabled: true },
+        allow_promotion_codes: true,
       }
     );
+  });
+
+  it("hosted payment-mode: offers Stripe promotion-code entry (allow_promotion_codes:true)", async () => {
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/pay/cs_abc",
+      session_id: "cs_abc",
+    });
+
+    await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        success_url: "https://example.com/success",
+        cancel_url: "https://example.com/cancel",
+        topup_amount_cents: 2000,
+      });
+
+    const sentBody = ssMocks.createCheckoutSession.mock.calls[0][1];
+    expect(sentBody.allow_promotion_codes).toBe(true);
   });
 
   it("resolves Stripe customer before creating checkout session", async () => {
@@ -196,6 +216,8 @@ describe("POST /v1/checkout-sessions", () => {
     expect(sentBody).not.toHaveProperty("line_items");
     expect(sentBody).not.toHaveProperty("payment_intent_data");
     expect(sentBody).not.toHaveProperty("invoice_creation");
+    // Promotion-code entry is hosted-payment-only; never on a no-charge setup session.
+    expect(sentBody).not.toHaveProperty("allow_promotion_codes");
   });
 
   it("setup-mode: does NOT write a topup amount to the account", async () => {
@@ -303,6 +325,8 @@ describe("POST /v1/checkout-sessions", () => {
     const sentBody = ssMocks.createCheckoutSession.mock.calls[0][1];
     expect(sentBody).not.toHaveProperty("success_url");
     expect(sentBody).not.toHaveProperty("cancel_url");
+    // Promotion-code entry is hosted-only; embedded checkout is out of scope.
+    expect(sentBody).not.toHaveProperty("allow_promotion_codes");
   });
 
   it("embedded-mode: auto-creates the billing account on first checkout (same as hosted)", async () => {


### PR DESCRIPTION
Automated by release.sh