### PR TITLE
fix(billing): net refunds and lost disputes out of credited

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,24 @@ Naming follows Stripe Topups + Refunds APIs. When in doubt, search Stripe docs f
 
 | Term | Definition | Source of truth |
 |---|---|---|
-| **credited** | Lifetime credits added to org (paid topups + promos). | `SUM(succeeded payment_intents.amount_received)` via stripe-service + `SUM(local_promos.amount_cents)` |
+| **credited** | Lifetime credits added to org (paid topups NET of money returned, + promos). | `SUM(succeeded payment_intents.(amount_received − amount_returned))` via stripe-service + `SUM(local_promos.amount_cents)` |
 | **usage** | Platform AI cost consumed by org. Lifetime, all-time. | runs-service `GET /internal/org-usage-total` |
 | **balance** | Funds usable right now for new work. `credited − usage`. **Use this for depletion/budget gates.** | computed at request time |
 | **topup** | Auto/manual Stripe payment that increases credited. | stripe-service `payment_intents` (status='succeeded') |
 | **gift / promo** | Non-payment credit (welcome bonus, promo redemption, manual adjustment). | `local_promos.amount_cents` |
-| **refund** | Funds returned to org. | stripe-service `refunds` (visibility only — does not auto-deduct from billing) |
+| **returned** | Money given back on a topup — a succeeded **refund** or a **LOST dispute**. Deducted from credited. | stripe-service `amount_returned` on each PaymentIntent read |
+
+### Refunds and lost disputes are netted out of `credited` (GH #290)
+
+**Stripe never mutates a payment when money goes back out.** A fully refunded charge keeps `status: "succeeded"` at its full `amount_received` forever; the return lives on a separate Refund (or Dispute) object. So summing `amount_received` alone credits an org for money it was already given back — a manual dashboard refund used to leave the customer holding the full credit, on every refund and every lost dispute in the account.
+
+stripe-service (#92, v0.27.0) mirrors Refunds + Disputes and exposes, on **every** PaymentIntent read surface, `amount_refunded` / `amount_disputed_lost` / `amount_returned`. `amount_returned` counts ONLY a `succeeded` refund and a `lost` dispute — a pending refund, a refund that later failed/was canceled, and an open or won dispute are all excluded, so partial refunds and reverted refunds are correct by construction.
+
+Billing nets it in ONE place: `netReceivedCents(pi)` in `src/lib/stripe-service-client.ts`, used by BOTH `sumSucceededTopupsForCustomer` (real-user `/v1/accounts` path) and `sumSucceededTopupsForOrg` (user-less `computeBalance` path). Same arithmetic on the same rows, so the two surfaces can never disagree about how much an org paid in. **Never re-add a bare `amount_received` sum** — and note the netting also (correctly) shrinks `paidTopupsCents`, which drives the postpaid tier ladder: a refunded payment must not keep growing the org's credit line.
+
+Fail-loud: a PaymentIntent arriving without `amount_returned` (stripe-service older than #92) **throws**. Defaulting it to 0 would silently resurrect the bug. Consequence: billing must not run against a stripe-service below v0.27.0.
+
+**Known remaining gross surface:** `GET /public/stats/billing` composes `total_paid_cents` / `total_credited_cents` from stripe-service `getStats()`, which still sums gross `amount_received` platform-wide. That makes the platform-wide credited total disagree with the sum of the per-org ones. Tracked as a follow-up on stripe-service (expose a platform-wide returned total); `total_revenue_cents` legitimately stays gross.
 
 ### Stripe `customer.balance` is NOT used
 
@@ -150,7 +162,7 @@ A slow spender whose balance never crosses the floor within a calendar month wou
 {
   "id": "<uuid>",
   "org_id": "<uuid>",
-  "credited_cents": "55200.0000000000",      // SUM(succeeded PI.amount_received) + SUM(local_promos.amount_cents)
+  "credited_cents": "55200.0000000000",      // SUM(succeeded PI.(amount_received − amount_returned)) + SUM(local_promos.amount_cents). Refunds + lost disputes are netted out — see "Refunds and lost disputes"
   "usage_cents": "38289.2958000000",         // runs-service spent_cents (platform actual+provisioned). Already NET of any usage discount (frozen at cost-write in runs-service).
   "balance_cents": "16910.7042000000",       // credited_cents − usage_cents; USE THIS for depletion/budget gates
   "actual_balance_cents": "16920.7042000000", // credited_cents − actualized usage only; display this as the user's credit balance
@@ -177,7 +189,7 @@ All three credited/usage/balance endpoints fail loud (502) when runs-service or 
 
 Composition (`src/routes/accounts.ts:composeAccountFunds`):
 1. `getCustomerByOrg(identity)` → Stripe customer (for `id`)
-2. `sumSucceededTopupsForCustomer(identity, customer.id)` → paginates `GET /v1/payment_intents?customer=cus_X` and sums `amount_received` where `status='succeeded'`
+2. `sumSucceededTopupsForCustomer(identity, customer.id)` → paginates `GET /v1/payment_intents?customer=cus_X` and sums `amount_received − amount_returned` where `status='succeeded'` (refunds + lost disputes netted out — see "Refunds and lost disputes")
 3. `sumLocalPromoCreditsForOrg(orgId)` → SUM `local_promos.amount_cents`
 4. `fetchRunsOrgUsageTotal(orgId, identity)` → reads runs-service **`net_spent_cents`** (the frozen-NET usage total, `SUM(COALESCE(net, gross))`), NOT the gross `spent_cents`. Returned to callers as `spent_cents` (billing's "usage" = the discounted amount the org owes).
 5. `fetchRunsOrgActualUsageTotal(orgId, identity)` → reads runs-service **`net_total_expected_cents`** (the frozen-NET actualized total), NOT the gross `total_expected_cents`, from actualized platform costs only.

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -53,6 +53,20 @@ export interface StripePaymentIntent {
   customer: string | null;
   status: StripePaymentIntentStatus;
   last_payment_error: { code?: string; message?: string } | null;
+  /**
+   * Money given back on this payment, in the payment's own minor unit. Added by
+   * stripe-service (#92) on every PaymentIntent read surface — Stripe itself has
+   * no refund field on a PaymentIntent (a refund is a separate object and leaves
+   * `amount_received` untouched forever), so without these a fully refunded
+   * top-up reads as a plain successful charge.
+   *
+   * `amount_returned` = succeeded Refunds + LOST Disputes. A pending refund, a
+   * refund that later failed/was canceled, and an open or won dispute are all
+   * excluded — the money is only "returned" once it has actually left.
+   */
+  amount_refunded: number;
+  amount_disputed_lost: number;
+  amount_returned: number;
 }
 
 export interface StripePaymentIntentList {
@@ -272,9 +286,35 @@ const TOPUP_PAGE_LIMIT = 100;
 const TOPUP_PAGE_CAP = 200;
 
 /**
- * Paginate every payment_intent for `customerId` and sum `amount_received`
- * across rows with `status === 'succeeded'`. The result is the total money
- * the org has actually paid into Stripe — the paid-topups component of
+ * Money a single succeeded top-up actually left with us: `amount_received`
+ * minus `amount_returned` (succeeded refunds + lost disputes). Non-succeeded
+ * PaymentIntents contribute nothing.
+ *
+ * Stripe never mutates a payment when money goes back out — a refunded charge
+ * keeps `status: "succeeded"` at its full `amount_received` forever, and the
+ * return lives on a separate object. Summing `amount_received` alone therefore
+ * credits an org for money it was already given back.
+ *
+ * Fail-loud: a PaymentIntent with no `amount_returned` means stripe-service is
+ * older than #92. Defaulting it to zero would silently resurrect exactly the
+ * bug this nets out, so it throws instead.
+ */
+function netReceivedCents(pi: StripePaymentIntent): Decimal {
+  if (pi.status !== "succeeded" || typeof pi.amount_received !== "number") {
+    return new Decimal(0);
+  }
+  if (typeof pi.amount_returned !== "number") {
+    throw new Error(
+      `stripe-service payment_intent ${pi.id} is missing amount_returned — refunds cannot be netted out of credited`
+    );
+  }
+  return new Decimal(pi.amount_received).minus(pi.amount_returned);
+}
+
+/**
+ * Paginate every payment_intent for `customerId` and sum each succeeded row's
+ * `amount_received` NET of what was given back. The result is the money the
+ * org has paid in and not been refunded — the paid-topups component of
  * billing-side `credited_cents`.
  *
  * Returns a numeric(16,10)-formatted string for arithmetic-compatibility
@@ -296,9 +336,7 @@ export async function sumSucceededTopupsForCustomer(
       starting_after: startingAfter,
     });
     for (const pi of page.data) {
-      if (pi.status === "succeeded" && typeof pi.amount_received === "number") {
-        total = total.plus(pi.amount_received);
-      }
+      total = total.plus(netReceivedCents(pi));
     }
     if (!page.has_more) {
       return total.toFixed(10);
@@ -565,10 +603,14 @@ export async function fetchOrgCustomer(orgId: string): Promise<StripeCustomer> {
 }
 
 /**
- * Sum `amount_received` across all the org's `status === 'succeeded'`
- * PaymentIntents — the paid-topups component of `credited_cents`. The
- * `/internal/payment_intents/by-org/{orgId}` route returns ALL PIs in one list
- * (no limit, no pagination), so there is no page loop.
+ * Sum each succeeded PaymentIntent's `amount_received` NET of what was given
+ * back, across all the org's PaymentIntents — the paid-topups component of
+ * `credited_cents`. The `/internal/payment_intents/by-org/{orgId}` route returns
+ * ALL PIs in one list (no limit, no pagination), so there is no page loop.
+ *
+ * Uses the SAME per-PaymentIntent netting as the real-user
+ * `sumSucceededTopupsForCustomer` above, so the two surfaces can never disagree
+ * about how much an org has paid in.
  *
  * Returns a numeric(16,10)-formatted string for arithmetic-compatibility with
  * the cents helpers.
@@ -581,9 +623,7 @@ export async function sumSucceededTopupsForOrg(orgId: string): Promise<string> {
   );
   let total = new Decimal(0);
   for (const pi of list.data) {
-    if (pi.status === "succeeded" && typeof pi.amount_received === "number") {
-      total = total.plus(pi.amount_received);
-    }
+    total = total.plus(netReceivedCents(pi));
   }
   return total.toFixed(10);
 }

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -71,6 +71,9 @@ export function setupStripeMocks(): StripeServiceMocks {
       customer: MOCK_CUSTOMER_ID,
       status: "succeeded",
       last_payment_error: null,
+      amount_refunded: 0,
+      amount_disputed_lost: 0,
+      amount_returned: 0,
     }),
     getPaymentIntent: vi.fn().mockResolvedValue({
       id: "pi_mock",
@@ -81,6 +84,9 @@ export function setupStripeMocks(): StripeServiceMocks {
       customer: MOCK_CUSTOMER_ID,
       status: "succeeded",
       last_payment_error: null,
+      amount_refunded: 0,
+      amount_disputed_lost: 0,
+      amount_returned: 0,
     }),
     listPaymentIntents: vi.fn().mockResolvedValue({
       object: "list",

--- a/tests/unit/stripe-service-client.test.ts
+++ b/tests/unit/stripe-service-client.test.ts
@@ -14,8 +14,11 @@ import {
 function pi(
   id: string,
   status: StripePaymentIntent["status"],
-  amount_received: number | null
+  amount_received: number | null,
+  returned: { refunded?: number; disputedLost?: number } = {}
 ): StripePaymentIntent {
+  const amount_refunded = returned.refunded ?? 0;
+  const amount_disputed_lost = returned.disputedLost ?? 0;
   return {
     id,
     object: "payment_intent",
@@ -25,6 +28,9 @@ function pi(
     customer: "cus_test",
     status,
     last_payment_error: null,
+    amount_refunded,
+    amount_disputed_lost,
+    amount_returned: amount_refunded + amount_disputed_lost,
   };
 }
 
@@ -153,6 +159,83 @@ describe("sumSucceededTopupsForCustomer", () => {
     const total = await sumSucceededTopupsForCustomer({}, "cus_test");
 
     expect(total).toBe("55200.0000000000");
+  });
+
+  // Stripe leaves a refunded payment `succeeded` at its full amount_received
+  // forever — the money returned lives on separate Refund/Dispute objects that
+  // stripe-service#92 surfaces as amount_returned. Summing amount_received alone
+  // credits the org for money it was already given back (GH billing #290).
+  it("nets a fully refunded top-up out of the total", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pageBody(
+          [
+            pi("pi_kept", "succeeded", 5000),
+            pi("pi_refunded", "succeeded", 1000, { refunded: 1000 }),
+          ],
+          false
+        )
+      )
+    );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("5000.0000000000");
+  });
+
+  it("nets a partial refund proportionally", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pageBody([pi("pi_1", "succeeded", 5000, { refunded: 1500 })], false)
+      )
+    );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("3500.0000000000");
+  });
+
+  // A lost dispute takes the money exactly like a refund does.
+  it("nets a lost dispute out of the total", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pageBody([pi("pi_1", "succeeded", 5000, { disputedLost: 5000 })], false)
+      )
+    );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("0.0000000000");
+  });
+
+  it("nets a refund and a lost dispute on the same payment", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pageBody(
+          [pi("pi_1", "succeeded", 10000, { refunded: 2500, disputedLost: 1000 })],
+          false
+        )
+      )
+    );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("6500.0000000000");
+  });
+
+  // Defaulting a missing amount_returned to zero would silently resurrect the
+  // very bug this nets out, so an older stripe-service must fail loud.
+  it("throws when stripe-service omits amount_returned (fail-loud)", async () => {
+    const legacy = pi("pi_legacy", "succeeded", 1000) as Partial<StripePaymentIntent>;
+    delete legacy.amount_returned;
+
+    fetchMock.mockResolvedValue(
+      jsonResponse(pageBody([legacy as StripePaymentIntent], false))
+    );
+
+    await expect(sumSucceededTopupsForCustomer({}, "cus_test")).rejects.toThrow(
+      /pi_legacy is missing amount_returned/
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

Stripe never mutates a payment when money goes back out. A fully refunded charge keeps `status: "succeeded"` at its full `amount_received` **forever**; the return lives on a separate Refund (or Dispute) object.

billing summed `amount_received` alone, so a refund gave the money back **and left the wallet funded**. Verified in prod: org `a81327ee-…` (`hello@emailtoolshub.com`) was refunded $10.00 by hand on 2026-07-29 and still held the $10 of spendable credit.

Not org-specific. Every fully refunded top-up in the account was still spendable:

| org | refund | still credited |
|---|---|---|
| `17d240d8-…` maggie.madeleine.2017@gmail.com | $50.00 | yes |
| `b645207b-…` kevin.lourd@gmail.com | $15.00 | yes |
| `a81327ee-…` hello@emailtoolshub.com | $10.00 | yes |

…and every future refund or lost dispute would have done the same.

## Fix

stripe-service [#92](https://github.com/shamanic-technologies/stripe-service/pull/92) (v0.27.0, already in prod) mirrors Refunds + Disputes and exposes `amount_refunded` / `amount_disputed_lost` / `amount_returned` on every PaymentIntent read surface. `amount_returned` counts **only** a `succeeded` refund and a `lost` dispute, so partial refunds, refunds that later fail or are canceled, and open/won disputes are all correct by construction.

Billing nets it in **one** place — `netReceivedCents()` — used by BOTH sums:

- `sumSucceededTopupsForCustomer` (real-user path, `/v1/accounts`)
- `sumSucceededTopupsForOrg` (user-less path, `computeBalance`)

Same arithmetic on the same rows, so the two surfaces can never disagree about how much an org paid in.

The netting also (deliberately) shrinks `paidTopupsCents`, which drives the postpaid tier ladder — a refunded payment must not keep growing an org's credit line.

**Fail-loud:** a PaymentIntent arriving without `amount_returned` throws. Defaulting it to `0` would silently resurrect the exact bug this nets out. Consequence: billing requires stripe-service >= v0.27.0 (live in prod since this morning).

## Not deleted, not hidden

The payment record is untouched — Stripe's ledger is append-only and so is ours. The refund is netted out of `credited`; the payment itself stays in the history (a dashboard "Refunded" badge is the follow-up).

## Tests

348 passing. New coverage on the sum: full refund, partial refund, lost dispute, refund + lost dispute on one payment, and the fail-loud missing-field guard.

## Known remaining gross surface

`GET /public/stats/billing` composes `total_paid_cents` / `total_credited_cents` from stripe-service `getStats()`, which still sums gross `amount_received` platform-wide — so the platform-wide credited total disagrees with the sum of the per-org ones. Documented in CLAUDE.md, tracked as a stripe-service follow-up. `total_revenue_cents` legitimately stays gross.

## ⚠️ Operational consequence to decide before 31 July

Netting flips org `17d240d8-…` (maggie.madeleine.2017@gmail.com) from **+$8.02** to **−$41.98**. She has a live saved card that auto-topup charges off-session, and the month-end sweep charges any auto-topup-enabled org with a negative balance on the last day of the month — so on **31 July** she would be charged $50.00, ten days after we refunded her $50.00.

Arithmetically that is defensible (she paid $149, consumed $145.48, was refunded $50 → she owes $46.48 of consumed service). Whether a manual refund also **forgives the consumed usage** is a business call, not a code one, so it is deliberately NOT bundled here. If the answer is "the refund forgives it", disable her auto-topup before 31 July.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
