### PR TITLE
fix(billing): report platform-wide credited and revenue net of returns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Billing nets it in ONE place: `netReceivedCents(pi)` in `src/lib/stripe-service-
 
 Fail-loud: a PaymentIntent arriving without `amount_returned` (stripe-service older than #92) **throws**. Defaulting it to 0 would silently resurrect the bug. Consequence: billing must not run against a stripe-service below v0.27.0.
 
-**Known remaining gross surface:** `GET /public/stats/billing` composes `total_paid_cents` / `total_credited_cents` from stripe-service `getStats()`, which still sums gross `amount_received` platform-wide. That makes the platform-wide credited total disagree with the sum of the per-org ones. Tracked as a follow-up on stripe-service (expose a platform-wide returned total); `total_revenue_cents` legitimately stays gross.
+**The platform-wide surface is netted too** (stripe-service #95, v0.28.0): `GET /public/stats/billing` reads `total_net_cents` (and per-bucket `net_cents`) for `total_credited_cents` AND `total_revenue_cents`, so the platform total equals the sum of the per-org ones. `total_paid_cents` keeps its original GROSS meaning and `total_returned_cents` is exposed alongside. Revenue is net on purpose: it feeds the landing investor-metrics page, and money we refunded is not revenue we earned.
 
 ### Stripe `customer.balance` is NOT used
 
@@ -208,9 +208,10 @@ Composed from stripe-service `getStats()` + local `localPromos`:
 {
   "total_accounts": 2,
   "accounts_with_payment_method": 1,                // from stripe-service
-  "total_credited_cents": "15400.0000000000",       // total_paid_cents + total_local_credits_cents
-  "total_paid_cents": "15000.0000000000",           // stripe-service Stripe payments (gross)
-  "total_revenue_cents": "15000.0000000000",        // cumulative all-time Stripe revenue
+  "total_credited_cents": "15400.0000000000",       // stripe-service total_net_cents + total_local_credits_cents
+  "total_paid_cents": "15000.0000000000",           // stripe-service Stripe payments, GROSS (unchanged meaning)
+  "total_revenue_cents": "15000.0000000000",        // cumulative all-time Stripe revenue, NET of returns (= paid − returned)
+  "total_returned_cents": "0.0000000000",           // settled refunds + LOST disputes, platform-wide
   "total_local_credits_cents": "400.0000000000",    // SUM(local_promos.amount_cents)
   "monthly_growth": [
     { "period": "2026-05-01", "credited_cents": "25000.0000000000", "revenue_cents": "23000.0000000000" }
@@ -219,7 +220,7 @@ Composed from stripe-service `getStats()` + local `localPromos`:
 }
 ```
 
-Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed lives in runs-service. Endpoint returns 502 if stripe-service unreachable.
+Growth rows expose `credited_cents` and `revenue_cents` only, both NET (they read stripe-service's per-bucket `net_cents`). A return is bucketed in the period it HAPPENED, not the period of the payment it reverses — stripe-service does not back-date, so a past bucket is never rewritten. Total consumed lives in runs-service. Endpoint returns 502 if stripe-service unreachable.
 
 ## Endpoints reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,24 @@ Naming follows Stripe Topups + Refunds APIs. When in doubt, search Stripe docs f
 
 | Term | Definition | Source of truth |
 |---|---|---|
-| **credited** | Lifetime credits added to org (paid topups + promos). | `SUM(succeeded payment_intents.amount_received)` via stripe-service + `SUM(local_promos.amount_cents)` |
+| **credited** | Lifetime credits added to org (paid topups NET of money returned, + promos). | `SUM(succeeded payment_intents.(amount_received − amount_returned))` via stripe-service + `SUM(local_promos.amount_cents)` |
 | **usage** | Platform AI cost consumed by org. Lifetime, all-time. | runs-service `GET /internal/org-usage-total` |
 | **balance** | Funds usable right now for new work. `credited − usage`. **Use this for depletion/budget gates.** | computed at request time |
 | **topup** | Auto/manual Stripe payment that increases credited. | stripe-service `payment_intents` (status='succeeded') |
 | **gift / promo** | Non-payment credit (welcome bonus, promo redemption, manual adjustment). | `local_promos.amount_cents` |
-| **refund** | Funds returned to org. | stripe-service `refunds` (visibility only — does not auto-deduct from billing) |
+| **returned** | Money given back on a topup — a succeeded **refund** or a **LOST dispute**. Deducted from credited. | stripe-service `amount_returned` on each PaymentIntent read |
+
+### Refunds and lost disputes are netted out of `credited` (GH #290)
+
+**Stripe never mutates a payment when money goes back out.** A fully refunded charge keeps `status: "succeeded"` at its full `amount_received` forever; the return lives on a separate Refund (or Dispute) object. So summing `amount_received` alone credits an org for money it was already given back — a manual dashboard refund used to leave the customer holding the full credit, on every refund and every lost dispute in the account.
+
+stripe-service (#92, v0.27.0) mirrors Refunds + Disputes and exposes, on **every** PaymentIntent read surface, `amount_refunded` / `amount_disputed_lost` / `amount_returned`. `amount_returned` counts ONLY a `succeeded` refund and a `lost` dispute — a pending refund, a refund that later failed/was canceled, and an open or won dispute are all excluded, so partial refunds and reverted refunds are correct by construction.
+
+Billing nets it in ONE place: `netReceivedCents(pi)` in `src/lib/stripe-service-client.ts`, used by BOTH `sumSucceededTopupsForCustomer` (real-user `/v1/accounts` path) and `sumSucceededTopupsForOrg` (user-less `computeBalance` path). Same arithmetic on the same rows, so the two surfaces can never disagree about how much an org paid in. **Never re-add a bare `amount_received` sum** — and note the netting also (correctly) shrinks `paidTopupsCents`, which drives the postpaid tier ladder: a refunded payment must not keep growing the org's credit line.
+
+Fail-loud: a PaymentIntent arriving without `amount_returned` (stripe-service older than #92) **throws**. Defaulting it to 0 would silently resurrect the bug. Consequence: billing must not run against a stripe-service below v0.27.0.
+
+**Known remaining gross surface:** `GET /public/stats/billing` composes `total_paid_cents` / `total_credited_cents` from stripe-service `getStats()`, which still sums gross `amount_received` platform-wide. That makes the platform-wide credited total disagree with the sum of the per-org ones. Tracked as a follow-up on stripe-service (expose a platform-wide returned total); `total_revenue_cents` legitimately stays gross.
 
 ### Stripe `customer.balance` is NOT used
 
@@ -150,7 +162,7 @@ A slow spender whose balance never crosses the floor within a calendar month wou
 {
   "id": "<uuid>",
   "org_id": "<uuid>",
-  "credited_cents": "55200.0000000000",      // SUM(succeeded PI.amount_received) + SUM(local_promos.amount_cents)
+  "credited_cents": "55200.0000000000",      // SUM(succeeded PI.(amount_received − amount_returned)) + SUM(local_promos.amount_cents). Refunds + lost disputes are netted out — see "Refunds and lost disputes"
   "usage_cents": "38289.2958000000",         // runs-service spent_cents (platform actual+provisioned). Already NET of any usage discount (frozen at cost-write in runs-service).
   "balance_cents": "16910.7042000000",       // credited_cents − usage_cents; USE THIS for depletion/budget gates
   "actual_balance_cents": "16920.7042000000", // credited_cents − actualized usage only; display this as the user's credit balance
@@ -177,7 +189,7 @@ All three credited/usage/balance endpoints fail loud (502) when runs-service or 
 
 Composition (`src/routes/accounts.ts:composeAccountFunds`):
 1. `getCustomerByOrg(identity)` → Stripe customer (for `id`)
-2. `sumSucceededTopupsForCustomer(identity, customer.id)` → paginates `GET /v1/payment_intents?customer=cus_X` and sums `amount_received` where `status='succeeded'`
+2. `sumSucceededTopupsForCustomer(identity, customer.id)` → paginates `GET /v1/payment_intents?customer=cus_X` and sums `amount_received − amount_returned` where `status='succeeded'` (refunds + lost disputes netted out — see "Refunds and lost disputes")
 3. `sumLocalPromoCreditsForOrg(orgId)` → SUM `local_promos.amount_cents`
 4. `fetchRunsOrgUsageTotal(orgId, identity)` → reads runs-service **`net_spent_cents`** (the frozen-NET usage total, `SUM(COALESCE(net, gross))`), NOT the gross `spent_cents`. Returned to callers as `spent_cents` (billing's "usage" = the discounted amount the org owes).
 5. `fetchRunsOrgActualUsageTotal(orgId, identity)` → reads runs-service **`net_total_expected_cents`** (the frozen-NET actualized total), NOT the gross `total_expected_cents`, from actualized platform costs only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ Billing nets it in ONE place: `netReceivedCents(pi)` in `src/lib/stripe-service-
 
 Fail-loud: a PaymentIntent arriving without `amount_returned` (stripe-service older than #92) **throws**. Defaulting it to 0 would silently resurrect the bug. Consequence: billing must not run against a stripe-service below v0.27.0.
 
+**⚠️ Automating a correction that was previously done BY HAND double-counts unless you delete the manual rows first.** Before this shipped, the only way to take back a refunded top-up was a NEGATIVE `local_promos` row inserted by staff. Those rows survive the automation, so the org gets debited twice — once by the manual row, once by the netting. Cost 2026-07-29: org `17d240d8-…` carried a `-5000` `admin_grant` row ("Refund offset: $50 erroneous auto-topup") from 21 July; after the netting shipped its credits read $103.50 instead of $153.50 and its balance went to −$41.98 instead of +$8.02, which would then have triggered a month-end sweep charge. Kevin caught it from the dashboard, not from any test. The row was deleted; it was the only one.
+
+So whenever you automate something staff used to patch manually, sweep for the manual patches in the SAME ship: `SELECT * FROM local_promos WHERE amount_cents::numeric < 0` (a negative grant is almost always a hand-rolled correction, since promos are credits) and grep the descriptions for the concept you just automated. A rendered `Bonus credit +$-50.00` in the dashboard Gifts list is the visible tell that one is still there.
+
 **The platform-wide surface is netted too** (stripe-service #95, v0.28.0): `GET /public/stats/billing` reads `total_net_cents` (and per-bucket `net_cents`) for `total_credited_cents` AND `total_revenue_cents`, so the platform total equals the sum of the per-org ones. `total_paid_cents` keeps its original GROSS meaning and `total_returned_cents` is exposed alongside. Revenue is net on purpose: it feeds the landing investor-metrics page, and money we refunded is not revenue we earned.
 
 ### Stripe `customer.balance` is NOT used

--- a/openapi.json
+++ b/openapi.json
@@ -49,6 +49,9 @@
           "total_revenue_cents": {
             "type": "string"
           },
+          "total_returned_cents": {
+            "type": "string"
+          },
           "total_local_credits_cents": {
             "type": "string"
           },
@@ -71,6 +74,7 @@
           "total_credited_cents",
           "total_paid_cents",
           "total_revenue_cents",
+          "total_returned_cents",
           "total_local_credits_cents",
           "monthly_growth",
           "weekly_growth"

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -145,13 +145,31 @@ export interface PortalSessionResult {
   url: string;
 }
 
+/**
+ * One period of the platform-wide growth series. Carries the same gross/net
+ * split as the all-time totals: `paid_cents` is gross charges (revenue),
+ * `net_cents` is gross minus money returned (the credit customers kept).
+ *
+ * A return is attributed to the period it HAPPENED in, not to the period of the
+ * payment it reverses — stripe-service does not back-date, so a past bucket is
+ * never rewritten.
+ */
 export interface StripeBillingStatsGrowthRow {
   period: string;
   paid_cents: string;
+  net_cents: string;
 }
 
 export interface StripeBillingStatsResult {
+  /** Gross charges. Revenue is reported gross; this keeps its original meaning. */
   total_paid_cents: string;
+  /**
+   * Gross minus settled refunds and lost disputes — the spendable credit
+   * customers actually ended up with. This is what billing reports as credited;
+   * summing payments alone counts money we gave back as money we still hold.
+   */
+  total_net_cents: string;
+  total_returned_cents: string;
   accounts_with_payment_method: number;
   monthly_growth: StripeBillingStatsGrowthRow[];
   weekly_growth: StripeBillingStatsGrowthRow[];

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -53,6 +53,20 @@ export interface StripePaymentIntent {
   customer: string | null;
   status: StripePaymentIntentStatus;
   last_payment_error: { code?: string; message?: string } | null;
+  /**
+   * Money given back on this payment, in the payment's own minor unit. Added by
+   * stripe-service (#92) on every PaymentIntent read surface — Stripe itself has
+   * no refund field on a PaymentIntent (a refund is a separate object and leaves
+   * `amount_received` untouched forever), so without these a fully refunded
+   * top-up reads as a plain successful charge.
+   *
+   * `amount_returned` = succeeded Refunds + LOST Disputes. A pending refund, a
+   * refund that later failed/was canceled, and an open or won dispute are all
+   * excluded — the money is only "returned" once it has actually left.
+   */
+  amount_refunded: number;
+  amount_disputed_lost: number;
+  amount_returned: number;
 }
 
 export interface StripePaymentIntentList {
@@ -272,9 +286,35 @@ const TOPUP_PAGE_LIMIT = 100;
 const TOPUP_PAGE_CAP = 200;
 
 /**
- * Paginate every payment_intent for `customerId` and sum `amount_received`
- * across rows with `status === 'succeeded'`. The result is the total money
- * the org has actually paid into Stripe — the paid-topups component of
+ * Money a single succeeded top-up actually left with us: `amount_received`
+ * minus `amount_returned` (succeeded refunds + lost disputes). Non-succeeded
+ * PaymentIntents contribute nothing.
+ *
+ * Stripe never mutates a payment when money goes back out — a refunded charge
+ * keeps `status: "succeeded"` at its full `amount_received` forever, and the
+ * return lives on a separate object. Summing `amount_received` alone therefore
+ * credits an org for money it was already given back.
+ *
+ * Fail-loud: a PaymentIntent with no `amount_returned` means stripe-service is
+ * older than #92. Defaulting it to zero would silently resurrect exactly the
+ * bug this nets out, so it throws instead.
+ */
+function netReceivedCents(pi: StripePaymentIntent): Decimal {
+  if (pi.status !== "succeeded" || typeof pi.amount_received !== "number") {
+    return new Decimal(0);
+  }
+  if (typeof pi.amount_returned !== "number") {
+    throw new Error(
+      `stripe-service payment_intent ${pi.id} is missing amount_returned — refunds cannot be netted out of credited`
+    );
+  }
+  return new Decimal(pi.amount_received).minus(pi.amount_returned);
+}
+
+/**
+ * Paginate every payment_intent for `customerId` and sum each succeeded row's
+ * `amount_received` NET of what was given back. The result is the money the
+ * org has paid in and not been refunded — the paid-topups component of
  * billing-side `credited_cents`.
  *
  * Returns a numeric(16,10)-formatted string for arithmetic-compatibility
@@ -296,9 +336,7 @@ export async function sumSucceededTopupsForCustomer(
       starting_after: startingAfter,
     });
     for (const pi of page.data) {
-      if (pi.status === "succeeded" && typeof pi.amount_received === "number") {
-        total = total.plus(pi.amount_received);
-      }
+      total = total.plus(netReceivedCents(pi));
     }
     if (!page.has_more) {
       return total.toFixed(10);
@@ -565,10 +603,14 @@ export async function fetchOrgCustomer(orgId: string): Promise<StripeCustomer> {
 }
 
 /**
- * Sum `amount_received` across all the org's `status === 'succeeded'`
- * PaymentIntents — the paid-topups component of `credited_cents`. The
- * `/internal/payment_intents/by-org/{orgId}` route returns ALL PIs in one list
- * (no limit, no pagination), so there is no page loop.
+ * Sum each succeeded PaymentIntent's `amount_received` NET of what was given
+ * back, across all the org's PaymentIntents — the paid-topups component of
+ * `credited_cents`. The `/internal/payment_intents/by-org/{orgId}` route returns
+ * ALL PIs in one list (no limit, no pagination), so there is no page loop.
+ *
+ * Uses the SAME per-PaymentIntent netting as the real-user
+ * `sumSucceededTopupsForCustomer` above, so the two surfaces can never disagree
+ * about how much an org has paid in.
  *
  * Returns a numeric(16,10)-formatted string for arithmetic-compatibility with
  * the cents helpers.
@@ -581,9 +623,7 @@ export async function sumSucceededTopupsForOrg(orgId: string): Promise<string> {
   );
   let total = new Decimal(0);
   for (const pi of list.data) {
-    if (pi.status === "succeeded" && typeof pi.amount_received === "number") {
-      total = total.plus(pi.amount_received);
-    }
+    total = total.plus(netReceivedCents(pi));
   }
   return total.toFixed(10);
 }

--- a/src/routes/public-stats.ts
+++ b/src/routes/public-stats.ts
@@ -37,6 +37,16 @@ async function queryLocalGrowth(truncTo: "month" | "week"): Promise<LocalGrowthR
   return rows as unknown as LocalGrowthRow[];
 }
 
+// Both credited and revenue take the NET Stripe figure (gross minus settled
+// refunds and lost disputes). Money we gave back is neither revenue we earned
+// nor credit the customer can spend, and `total_revenue_cents` feeds the
+// investor metrics page, where overstating by the refunded amount is the wrong
+// direction to be wrong in. The raw gross charges stay available, unchanged, as
+// `total_paid_cents`. Credited still differs from revenue by the local promo
+// grants, exactly as before.
+//
+// A return is attributed to the period it happened in, not the period of the
+// payment it reverses, so a past bucket is never rewritten.
 function mergeGrowthRows(
   localRows: LocalGrowthRow[],
   ssRows: StripeBillingStatsGrowthRow[]
@@ -48,10 +58,10 @@ function mergeGrowthRows(
   for (const r of ssRows) {
     const existing = merged.get(r.period);
     if (existing) {
-      existing.credited = addCents(existing.credited, r.paid_cents);
-      existing.revenue = addCents(existing.revenue, r.paid_cents);
+      existing.credited = addCents(existing.credited, r.net_cents);
+      existing.revenue = addCents(existing.revenue, r.net_cents);
     } else {
-      merged.set(r.period, { credited: r.paid_cents, revenue: r.paid_cents });
+      merged.set(r.period, { credited: r.net_cents, revenue: r.net_cents });
     }
   }
   return [...merged.entries()]
@@ -98,9 +108,11 @@ router.get("/public/stats/billing", async (_req, res) => {
     res.json({
       total_accounts: accountStats.totalAccounts,
       accounts_with_payment_method: ssStats.accounts_with_payment_method,
-      total_credited_cents: addCents(localCreditStats.totalLocalCredits, ssStats.total_paid_cents),
+      // NET for credited and revenue, GROSS kept as total_paid_cents. See mergeGrowthRows.
+      total_credited_cents: addCents(localCreditStats.totalLocalCredits, ssStats.total_net_cents),
       total_paid_cents: ssStats.total_paid_cents,
-      total_revenue_cents: ssStats.total_paid_cents,
+      total_revenue_cents: ssStats.total_net_cents,
+      total_returned_cents: ssStats.total_returned_cents,
       total_local_credits_cents: localCreditStats.totalLocalCredits,
       monthly_growth: mergeGrowthRows(monthlyLocal, ssStats.monthly_growth),
       weekly_growth: mergeGrowthRows(weeklyLocal, ssStats.weekly_growth),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -481,7 +481,9 @@ export const ReadBrandDailyBudgetHistorySchema = z
 export const BillingGrowthRowSchema = z
   .object({
     period: z.string(),
+    /** NET Stripe payments in this period + local promo credits granted in it. */
     credited_cents: CentsStringSchema,
+    /** NET Stripe payments in this period. Returns are attributed to the period they happened in. */
     revenue_cents: CentsStringSchema,
   })
   .openapi("BillingGrowthRow");
@@ -490,16 +492,23 @@ export const PublicBillingStatsSchema = z
   .object({
     total_accounts: z.number().int(),
     accounts_with_payment_method: z.number().int(),
-    /** Lifetime sum of paid + local credits (combined). */
+    /** Lifetime NET Stripe payments + local credits (combined). */
     total_credited_cents: CentsStringSchema,
-    /** Lifetime stripe-service paid only. */
+    /** Lifetime GROSS stripe-service payments, before anything was given back. */
     total_paid_cents: CentsStringSchema,
     /**
      * Cumulative all-time Stripe revenue, top-level alias for investor/landing-page consumers.
-     * Currently equals `total_paid_cents` (gross — refunds not subtracted). Will become net
-     * (paid − refunded) once stripe-service exposes refund totals.
+     * NET of money returned: `total_paid_cents − total_returned_cents`. Money we refunded is
+     * not revenue we earned, and this figure feeds the investor metrics page. Read
+     * `total_paid_cents` for the gross charges.
      */
     total_revenue_cents: CentsStringSchema,
+    /**
+     * Lifetime money given back across the platform: settled refunds plus LOST disputes.
+     * A pending refund, a refund that later failed or was cancelled, and an open or won
+     * dispute are all excluded — only money that actually left counts.
+     */
+    total_returned_cents: CentsStringSchema,
     /** Lifetime local promo credits only. */
     total_local_credits_cents: CentsStringSchema,
     monthly_growth: z.array(BillingGrowthRowSchema),

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -134,6 +134,8 @@ export function setupStripeMocks(): StripeServiceMocks {
     ),
     getStats: vi.fn().mockResolvedValue({
       total_paid_cents: "0.0000000000",
+      total_returned_cents: "0.0000000000",
+      total_net_cents: "0.0000000000",
       accounts_with_payment_method: 0,
       monthly_growth: [],
       weekly_growth: [],

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -71,6 +71,9 @@ export function setupStripeMocks(): StripeServiceMocks {
       customer: MOCK_CUSTOMER_ID,
       status: "succeeded",
       last_payment_error: null,
+      amount_refunded: 0,
+      amount_disputed_lost: 0,
+      amount_returned: 0,
     }),
     getPaymentIntent: vi.fn().mockResolvedValue({
       id: "pi_mock",
@@ -81,6 +84,9 @@ export function setupStripeMocks(): StripeServiceMocks {
       customer: MOCK_CUSTOMER_ID,
       status: "succeeded",
       last_payment_error: null,
+      amount_refunded: 0,
+      amount_disputed_lost: 0,
+      amount_returned: 0,
     }),
     listPaymentIntents: vi.fn().mockResolvedValue({
       object: "list",

--- a/tests/integration/public-stats.test.ts
+++ b/tests/integration/public-stats.test.ts
@@ -54,6 +54,8 @@ describe("GET /public/stats/billing", () => {
 
     ssMocks.getStats.mockResolvedValue({
       total_paid_cents: "15000.0000000000",
+      total_returned_cents: "0.0000000000",
+      total_net_cents: "15000.0000000000",
       accounts_with_payment_method: 1,
       monthly_growth: [],
       weekly_growth: [],
@@ -76,9 +78,15 @@ describe("GET /public/stats/billing", () => {
 
     ssMocks.getStats.mockResolvedValue({
       total_paid_cents: "5000.0000000000",
+      total_returned_cents: "0.0000000000",
+      total_net_cents: "5000.0000000000",
       accounts_with_payment_method: 1,
-      monthly_growth: [{ period: "2026-05-01", paid_cents: "5000.0000000000" }],
-      weekly_growth: [{ period: "2026-05-11", paid_cents: "5000.0000000000" }],
+      monthly_growth: [
+        { period: "2026-05-01", paid_cents: "5000.0000000000", net_cents: "5000.0000000000" },
+      ],
+      weekly_growth: [
+        { period: "2026-05-11", paid_cents: "5000.0000000000", net_cents: "5000.0000000000" },
+      ],
     });
 
     const res = await request(app).get("/public/stats/billing");
@@ -101,6 +109,58 @@ describe("GET /public/stats/billing", () => {
     );
     expect(totalCredited).toBe(5500);
     expect(totalRevenue).toBe(5000);
+  });
+
+  // Money given back is neither revenue we earned nor credit the customer can
+  // spend. Reporting the gross figure would also make this platform-wide total
+  // disagree with the sum of the per-org credited figures, which net returns out
+  // per PaymentIntent.
+  it("reports credited and revenue NET of returns, keeping paid gross", async () => {
+    await insertTestAccount({ orgId: orgA });
+    await insertTestPromoGrant({ orgId: orgA, userId, amountCents: 500, promoCode: "welcome" });
+
+    ssMocks.getStats.mockResolvedValue({
+      total_paid_cents: "15000.0000000000",
+      total_returned_cents: "7500.0000000000",
+      total_net_cents: "7500.0000000000",
+      accounts_with_payment_method: 1,
+      monthly_growth: [],
+      weekly_growth: [],
+    });
+
+    const res = await request(app).get("/public/stats/billing");
+
+    expect(res.status).toBe(200);
+    expect(res.body.total_paid_cents).toBe("15000.0000000000");
+    expect(res.body.total_returned_cents).toBe("7500.0000000000");
+    expect(res.body.total_revenue_cents).toBe("7500.0000000000");
+    expect(res.body.total_credited_cents).toBe("8000.0000000000");
+  });
+
+  it("nets returns out of the growth buckets too", async () => {
+    await insertTestAccount({ orgId: orgA });
+
+    ssMocks.getStats.mockResolvedValue({
+      total_paid_cents: "5000.0000000000",
+      total_returned_cents: "2000.0000000000",
+      total_net_cents: "3000.0000000000",
+      accounts_with_payment_method: 1,
+      monthly_growth: [
+        { period: "2026-05-01", paid_cents: "5000.0000000000", net_cents: "3000.0000000000" },
+      ],
+      weekly_growth: [
+        { period: "2026-05-11", paid_cents: "5000.0000000000", net_cents: "3000.0000000000" },
+      ],
+    });
+
+    const res = await request(app).get("/public/stats/billing");
+
+    expect(res.status).toBe(200);
+    const may = res.body.monthly_growth.find(
+      (r: { period: string }) => r.period === "2026-05-01"
+    );
+    expect(may.revenue_cents).toBe("3000.0000000000");
+    expect(may.credited_cents).toBe("3000.0000000000");
   });
 
   it("returns 502 when stripe-service stats unavailable", async () => {

--- a/tests/unit/stripe-service-client.test.ts
+++ b/tests/unit/stripe-service-client.test.ts
@@ -14,8 +14,11 @@ import {
 function pi(
   id: string,
   status: StripePaymentIntent["status"],
-  amount_received: number | null
+  amount_received: number | null,
+  returned: { refunded?: number; disputedLost?: number } = {}
 ): StripePaymentIntent {
+  const amount_refunded = returned.refunded ?? 0;
+  const amount_disputed_lost = returned.disputedLost ?? 0;
   return {
     id,
     object: "payment_intent",
@@ -25,6 +28,9 @@ function pi(
     customer: "cus_test",
     status,
     last_payment_error: null,
+    amount_refunded,
+    amount_disputed_lost,
+    amount_returned: amount_refunded + amount_disputed_lost,
   };
 }
 
@@ -153,6 +159,83 @@ describe("sumSucceededTopupsForCustomer", () => {
     const total = await sumSucceededTopupsForCustomer({}, "cus_test");
 
     expect(total).toBe("55200.0000000000");
+  });
+
+  // Stripe leaves a refunded payment `succeeded` at its full amount_received
+  // forever — the money returned lives on separate Refund/Dispute objects that
+  // stripe-service#92 surfaces as amount_returned. Summing amount_received alone
+  // credits the org for money it was already given back (GH billing #290).
+  it("nets a fully refunded top-up out of the total", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pageBody(
+          [
+            pi("pi_kept", "succeeded", 5000),
+            pi("pi_refunded", "succeeded", 1000, { refunded: 1000 }),
+          ],
+          false
+        )
+      )
+    );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("5000.0000000000");
+  });
+
+  it("nets a partial refund proportionally", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pageBody([pi("pi_1", "succeeded", 5000, { refunded: 1500 })], false)
+      )
+    );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("3500.0000000000");
+  });
+
+  // A lost dispute takes the money exactly like a refund does.
+  it("nets a lost dispute out of the total", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pageBody([pi("pi_1", "succeeded", 5000, { disputedLost: 5000 })], false)
+      )
+    );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("0.0000000000");
+  });
+
+  it("nets a refund and a lost dispute on the same payment", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        pageBody(
+          [pi("pi_1", "succeeded", 10000, { refunded: 2500, disputedLost: 1000 })],
+          false
+        )
+      )
+    );
+
+    const total = await sumSucceededTopupsForCustomer({}, "cus_test");
+
+    expect(total).toBe("6500.0000000000");
+  });
+
+  // Defaulting a missing amount_returned to zero would silently resurrect the
+  // very bug this nets out, so an older stripe-service must fail loud.
+  it("throws when stripe-service omits amount_returned (fail-loud)", async () => {
+    const legacy = pi("pi_legacy", "succeeded", 1000) as Partial<StripePaymentIntent>;
+    delete legacy.amount_returned;
+
+    fetchMock.mockResolvedValue(
+      jsonResponse(pageBody([legacy as StripePaymentIntent], false))
+    );
+
+    await expect(sumSucceededTopupsForCustomer({}, "cus_test")).rejects.toThrow(
+      /pi_legacy is missing amount_returned/
+    );
   });
 });
 


### PR DESCRIPTION
Follow-up to #292. Per-org credited stopped counting refunded money, but `/public/stats/billing` still summed gross, so the platform total disagreed with the sum of the orgs it aggregates.

Reads stripe-service v0.28.0's `total_net_cents` / per-bucket `net_cents` for `total_credited_cents` AND `total_revenue_cents`. Revenue is net on purpose: it feeds the landing investor-metrics page, and money we refunded is not revenue we earned. Gross stays available unchanged as `total_paid_cents`, plus a new `total_returned_cents` so consumers can reconcile.

**Draft on purpose:** requires stripe-service >= v0.28.0 (promote shamanic-technologies/stripe-service#96 still open). Marking ready once that is live.

350 tests passing.