### PR TITLE
fix(billing): report platform-wide credited and revenue net of returns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Billing nets it in ONE place: `netReceivedCents(pi)` in `src/lib/stripe-service-
 
 Fail-loud: a PaymentIntent arriving without `amount_returned` (stripe-service older than #92) **throws**. Defaulting it to 0 would silently resurrect the bug. Consequence: billing must not run against a stripe-service below v0.27.0.
 
-**Known remaining gross surface:** `GET /public/stats/billing` composes `total_paid_cents` / `total_credited_cents` from stripe-service `getStats()`, which still sums gross `amount_received` platform-wide. That makes the platform-wide credited total disagree with the sum of the per-org ones. Tracked as a follow-up on stripe-service (expose a platform-wide returned total); `total_revenue_cents` legitimately stays gross.
+**The platform-wide surface is netted too** (stripe-service #95, v0.28.0): `GET /public/stats/billing` reads `total_net_cents` (and per-bucket `net_cents`) for `total_credited_cents` AND `total_revenue_cents`, so the platform total equals the sum of the per-org ones. `total_paid_cents` keeps its original GROSS meaning and `total_returned_cents` is exposed alongside. Revenue is net on purpose: it feeds the landing investor-metrics page, and money we refunded is not revenue we earned.
 
 ### Stripe `customer.balance` is NOT used
 
@@ -208,9 +208,10 @@ Composed from stripe-service `getStats()` + local `localPromos`:
 {
   "total_accounts": 2,
   "accounts_with_payment_method": 1,                // from stripe-service
-  "total_credited_cents": "15400.0000000000",       // total_paid_cents + total_local_credits_cents
-  "total_paid_cents": "15000.0000000000",           // stripe-service Stripe payments (gross)
-  "total_revenue_cents": "15000.0000000000",        // cumulative all-time Stripe revenue
+  "total_credited_cents": "15400.0000000000",       // stripe-service total_net_cents + total_local_credits_cents
+  "total_paid_cents": "15000.0000000000",           // stripe-service Stripe payments, GROSS (unchanged meaning)
+  "total_revenue_cents": "15000.0000000000",        // cumulative all-time Stripe revenue, NET of returns (= paid − returned)
+  "total_returned_cents": "0.0000000000",           // settled refunds + LOST disputes, platform-wide
   "total_local_credits_cents": "400.0000000000",    // SUM(local_promos.amount_cents)
   "monthly_growth": [
     { "period": "2026-05-01", "credited_cents": "25000.0000000000", "revenue_cents": "23000.0000000000" }
@@ -219,7 +220,7 @@ Composed from stripe-service `getStats()` + local `localPromos`:
 }
 ```
 
-Growth rows expose `credited_cents` and `revenue_cents` only. Total consumed lives in runs-service. Endpoint returns 502 if stripe-service unreachable.
+Growth rows expose `credited_cents` and `revenue_cents` only, both NET (they read stripe-service's per-bucket `net_cents`). A return is bucketed in the period it HAPPENED, not the period of the payment it reverses — stripe-service does not back-date, so a past bucket is never rewritten. Total consumed lives in runs-service. Endpoint returns 502 if stripe-service unreachable.
 
 ## Endpoints reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ Billing nets it in ONE place: `netReceivedCents(pi)` in `src/lib/stripe-service-
 
 Fail-loud: a PaymentIntent arriving without `amount_returned` (stripe-service older than #92) **throws**. Defaulting it to 0 would silently resurrect the bug. Consequence: billing must not run against a stripe-service below v0.27.0.
 
+**⚠️ Automating a correction that was previously done BY HAND double-counts unless you delete the manual rows first.** Before this shipped, the only way to take back a refunded top-up was a NEGATIVE `local_promos` row inserted by staff. Those rows survive the automation, so the org gets debited twice — once by the manual row, once by the netting. Cost 2026-07-29: org `17d240d8-…` carried a `-5000` `admin_grant` row ("Refund offset: $50 erroneous auto-topup") from 21 July; after the netting shipped its credits read $103.50 instead of $153.50 and its balance went to −$41.98 instead of +$8.02, which would then have triggered a month-end sweep charge. Kevin caught it from the dashboard, not from any test. The row was deleted; it was the only one.
+
+So whenever you automate something staff used to patch manually, sweep for the manual patches in the SAME ship: `SELECT * FROM local_promos WHERE amount_cents::numeric < 0` (a negative grant is almost always a hand-rolled correction, since promos are credits) and grep the descriptions for the concept you just automated. A rendered `Bonus credit +$-50.00` in the dashboard Gifts list is the visible tell that one is still there.
+
 **The platform-wide surface is netted too** (stripe-service #95, v0.28.0): `GET /public/stats/billing` reads `total_net_cents` (and per-bucket `net_cents`) for `total_credited_cents` AND `total_revenue_cents`, so the platform total equals the sum of the per-org ones. `total_paid_cents` keeps its original GROSS meaning and `total_returned_cents` is exposed alongside. Revenue is net on purpose: it feeds the landing investor-metrics page, and money we refunded is not revenue we earned.
 
 ### Stripe `customer.balance` is NOT used

--- a/openapi.json
+++ b/openapi.json
@@ -49,6 +49,9 @@
           "total_revenue_cents": {
             "type": "string"
           },
+          "total_returned_cents": {
+            "type": "string"
+          },
           "total_local_credits_cents": {
             "type": "string"
           },
@@ -71,6 +74,7 @@
           "total_credited_cents",
           "total_paid_cents",
           "total_revenue_cents",
+          "total_returned_cents",
           "total_local_credits_cents",
           "monthly_growth",
           "weekly_growth"

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -145,13 +145,31 @@ export interface PortalSessionResult {
   url: string;
 }
 
+/**
+ * One period of the platform-wide growth series. Carries the same gross/net
+ * split as the all-time totals: `paid_cents` is gross charges (revenue),
+ * `net_cents` is gross minus money returned (the credit customers kept).
+ *
+ * A return is attributed to the period it HAPPENED in, not to the period of the
+ * payment it reverses — stripe-service does not back-date, so a past bucket is
+ * never rewritten.
+ */
 export interface StripeBillingStatsGrowthRow {
   period: string;
   paid_cents: string;
+  net_cents: string;
 }
 
 export interface StripeBillingStatsResult {
+  /** Gross charges. Revenue is reported gross; this keeps its original meaning. */
   total_paid_cents: string;
+  /**
+   * Gross minus settled refunds and lost disputes — the spendable credit
+   * customers actually ended up with. This is what billing reports as credited;
+   * summing payments alone counts money we gave back as money we still hold.
+   */
+  total_net_cents: string;
+  total_returned_cents: string;
   accounts_with_payment_method: number;
   monthly_growth: StripeBillingStatsGrowthRow[];
   weekly_growth: StripeBillingStatsGrowthRow[];

--- a/src/routes/public-stats.ts
+++ b/src/routes/public-stats.ts
@@ -37,6 +37,16 @@ async function queryLocalGrowth(truncTo: "month" | "week"): Promise<LocalGrowthR
   return rows as unknown as LocalGrowthRow[];
 }
 
+// Both credited and revenue take the NET Stripe figure (gross minus settled
+// refunds and lost disputes). Money we gave back is neither revenue we earned
+// nor credit the customer can spend, and `total_revenue_cents` feeds the
+// investor metrics page, where overstating by the refunded amount is the wrong
+// direction to be wrong in. The raw gross charges stay available, unchanged, as
+// `total_paid_cents`. Credited still differs from revenue by the local promo
+// grants, exactly as before.
+//
+// A return is attributed to the period it happened in, not the period of the
+// payment it reverses, so a past bucket is never rewritten.
 function mergeGrowthRows(
   localRows: LocalGrowthRow[],
   ssRows: StripeBillingStatsGrowthRow[]
@@ -48,10 +58,10 @@ function mergeGrowthRows(
   for (const r of ssRows) {
     const existing = merged.get(r.period);
     if (existing) {
-      existing.credited = addCents(existing.credited, r.paid_cents);
-      existing.revenue = addCents(existing.revenue, r.paid_cents);
+      existing.credited = addCents(existing.credited, r.net_cents);
+      existing.revenue = addCents(existing.revenue, r.net_cents);
     } else {
-      merged.set(r.period, { credited: r.paid_cents, revenue: r.paid_cents });
+      merged.set(r.period, { credited: r.net_cents, revenue: r.net_cents });
     }
   }
   return [...merged.entries()]
@@ -98,9 +108,11 @@ router.get("/public/stats/billing", async (_req, res) => {
     res.json({
       total_accounts: accountStats.totalAccounts,
       accounts_with_payment_method: ssStats.accounts_with_payment_method,
-      total_credited_cents: addCents(localCreditStats.totalLocalCredits, ssStats.total_paid_cents),
+      // NET for credited and revenue, GROSS kept as total_paid_cents. See mergeGrowthRows.
+      total_credited_cents: addCents(localCreditStats.totalLocalCredits, ssStats.total_net_cents),
       total_paid_cents: ssStats.total_paid_cents,
-      total_revenue_cents: ssStats.total_paid_cents,
+      total_revenue_cents: ssStats.total_net_cents,
+      total_returned_cents: ssStats.total_returned_cents,
       total_local_credits_cents: localCreditStats.totalLocalCredits,
       monthly_growth: mergeGrowthRows(monthlyLocal, ssStats.monthly_growth),
       weekly_growth: mergeGrowthRows(weeklyLocal, ssStats.weekly_growth),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -481,7 +481,9 @@ export const ReadBrandDailyBudgetHistorySchema = z
 export const BillingGrowthRowSchema = z
   .object({
     period: z.string(),
+    /** NET Stripe payments in this period + local promo credits granted in it. */
     credited_cents: CentsStringSchema,
+    /** NET Stripe payments in this period. Returns are attributed to the period they happened in. */
     revenue_cents: CentsStringSchema,
   })
   .openapi("BillingGrowthRow");
@@ -490,16 +492,23 @@ export const PublicBillingStatsSchema = z
   .object({
     total_accounts: z.number().int(),
     accounts_with_payment_method: z.number().int(),
-    /** Lifetime sum of paid + local credits (combined). */
+    /** Lifetime NET Stripe payments + local credits (combined). */
     total_credited_cents: CentsStringSchema,
-    /** Lifetime stripe-service paid only. */
+    /** Lifetime GROSS stripe-service payments, before anything was given back. */
     total_paid_cents: CentsStringSchema,
     /**
      * Cumulative all-time Stripe revenue, top-level alias for investor/landing-page consumers.
-     * Currently equals `total_paid_cents` (gross — refunds not subtracted). Will become net
-     * (paid − refunded) once stripe-service exposes refund totals.
+     * NET of money returned: `total_paid_cents − total_returned_cents`. Money we refunded is
+     * not revenue we earned, and this figure feeds the investor metrics page. Read
+     * `total_paid_cents` for the gross charges.
      */
     total_revenue_cents: CentsStringSchema,
+    /**
+     * Lifetime money given back across the platform: settled refunds plus LOST disputes.
+     * A pending refund, a refund that later failed or was cancelled, and an open or won
+     * dispute are all excluded — only money that actually left counts.
+     */
+    total_returned_cents: CentsStringSchema,
     /** Lifetime local promo credits only. */
     total_local_credits_cents: CentsStringSchema,
     monthly_growth: z.array(BillingGrowthRowSchema),

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -134,6 +134,8 @@ export function setupStripeMocks(): StripeServiceMocks {
     ),
     getStats: vi.fn().mockResolvedValue({
       total_paid_cents: "0.0000000000",
+      total_returned_cents: "0.0000000000",
+      total_net_cents: "0.0000000000",
       accounts_with_payment_method: 0,
       monthly_growth: [],
       weekly_growth: [],

--- a/tests/integration/public-stats.test.ts
+++ b/tests/integration/public-stats.test.ts
@@ -54,6 +54,8 @@ describe("GET /public/stats/billing", () => {
 
     ssMocks.getStats.mockResolvedValue({
       total_paid_cents: "15000.0000000000",
+      total_returned_cents: "0.0000000000",
+      total_net_cents: "15000.0000000000",
       accounts_with_payment_method: 1,
       monthly_growth: [],
       weekly_growth: [],
@@ -76,9 +78,15 @@ describe("GET /public/stats/billing", () => {
 
     ssMocks.getStats.mockResolvedValue({
       total_paid_cents: "5000.0000000000",
+      total_returned_cents: "0.0000000000",
+      total_net_cents: "5000.0000000000",
       accounts_with_payment_method: 1,
-      monthly_growth: [{ period: "2026-05-01", paid_cents: "5000.0000000000" }],
-      weekly_growth: [{ period: "2026-05-11", paid_cents: "5000.0000000000" }],
+      monthly_growth: [
+        { period: "2026-05-01", paid_cents: "5000.0000000000", net_cents: "5000.0000000000" },
+      ],
+      weekly_growth: [
+        { period: "2026-05-11", paid_cents: "5000.0000000000", net_cents: "5000.0000000000" },
+      ],
     });
 
     const res = await request(app).get("/public/stats/billing");
@@ -101,6 +109,58 @@ describe("GET /public/stats/billing", () => {
     );
     expect(totalCredited).toBe(5500);
     expect(totalRevenue).toBe(5000);
+  });
+
+  // Money given back is neither revenue we earned nor credit the customer can
+  // spend. Reporting the gross figure would also make this platform-wide total
+  // disagree with the sum of the per-org credited figures, which net returns out
+  // per PaymentIntent.
+  it("reports credited and revenue NET of returns, keeping paid gross", async () => {
+    await insertTestAccount({ orgId: orgA });
+    await insertTestPromoGrant({ orgId: orgA, userId, amountCents: 500, promoCode: "welcome" });
+
+    ssMocks.getStats.mockResolvedValue({
+      total_paid_cents: "15000.0000000000",
+      total_returned_cents: "7500.0000000000",
+      total_net_cents: "7500.0000000000",
+      accounts_with_payment_method: 1,
+      monthly_growth: [],
+      weekly_growth: [],
+    });
+
+    const res = await request(app).get("/public/stats/billing");
+
+    expect(res.status).toBe(200);
+    expect(res.body.total_paid_cents).toBe("15000.0000000000");
+    expect(res.body.total_returned_cents).toBe("7500.0000000000");
+    expect(res.body.total_revenue_cents).toBe("7500.0000000000");
+    expect(res.body.total_credited_cents).toBe("8000.0000000000");
+  });
+
+  it("nets returns out of the growth buckets too", async () => {
+    await insertTestAccount({ orgId: orgA });
+
+    ssMocks.getStats.mockResolvedValue({
+      total_paid_cents: "5000.0000000000",
+      total_returned_cents: "2000.0000000000",
+      total_net_cents: "3000.0000000000",
+      accounts_with_payment_method: 1,
+      monthly_growth: [
+        { period: "2026-05-01", paid_cents: "5000.0000000000", net_cents: "3000.0000000000" },
+      ],
+      weekly_growth: [
+        { period: "2026-05-11", paid_cents: "5000.0000000000", net_cents: "3000.0000000000" },
+      ],
+    });
+
+    const res = await request(app).get("/public/stats/billing");
+
+    expect(res.status).toBe(200);
+    const may = res.body.monthly_growth.find(
+      (r: { period: string }) => r.period === "2026-05-01"
+    );
+    expect(may.revenue_cents).toBe("3000.0000000000");
+    expect(may.credited_cents).toBe("3000.0000000000");
   });
 
   it("returns 502 when stripe-service stats unavailable", async () => {


### PR DESCRIPTION
Follow-up to #292 (supersedes #295, which was cut before the squash-merge and went DIRTY).

Per-org credited stopped counting refunded money, but `/public/stats/billing` still summed gross, so the platform total disagreed with the sum of the orgs it aggregates.

Reads stripe-service v0.28.0's `total_net_cents` / per-bucket `net_cents` for `total_credited_cents` AND `total_revenue_cents`. Revenue is net on purpose: it feeds the landing investor-metrics page, and money we refunded is not revenue we earned. Gross stays available unchanged as `total_paid_cents`, plus a new `total_returned_cents` so consumers can reconcile.

stripe-service v0.28.0 is live in prod, verified:
```
total_paid_cents 960189 | total_returned_cents 7500 | total_net_cents 952689
```

Also pins the CLAUDE.md lesson from the double-deduction #292 caused (a hand-inserted refund-offset row that survived the automation).

350 tests passing.