### PR TITLE
feat(billing): automate the $25 welcome-completion gift + $25 visible discount on the first checkout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,44 @@ The only persistent ledger billing-service owns. One row per (org, promo_code) �
 
 `amount_cents` is positive (these are credits). `numeric(16,10)` — Drizzle returns it as a JS string. Use Decimal.js (via `src/lib/cents.ts` helpers) for arithmetic; never cast to Number for math.
 
+## Welcome-completion gift — "$25 in free credits", automatic (`src/lib/welcome-completion.ts`)
+
+Onboarding promises every new customer **$25 of free credits**. Signup only grants the `welcome` row ($5 today), so for months the remainder was granted BY HAND (staff `admin_grant` rows described "Welcome credits (2/2)"). `welcome_completion` (migration 0029) automates the remainder.
+
+**The rule (product-locked):**
+
+- An org receives **$25 in free credits IN TOTAL**, welcome gift included → `FREE_CREDIT_ENTITLEMENT_CENTS`.
+- The completion amount is **DERIVED**: `entitlement − SUM(local_promos)`. **Never hardcode $20** — it stays correct if the welcome amount is re-priced (0018/0019/0028 all moved it) or the org never got a welcome row at all. A re-priced $10 welcome leaves a $15 completion; an org already gifted $25 gets nothing.
+- It is **EARNED when cumulative SUCCEEDED payments reach $25** (`FREE_CREDIT_PAID_TRIGGER_CENTS`), net of refunds + lost disputes. The trigger is **money actually received, NOT usage consumed** — the account model is threshold-postpaid, so an org can consume on credit before paying anything, and we must not gift credits to someone whose card may still fail.
+
+**Who drives it (never the browser).** Nothing pushes into billing when a Checkout payment lands (stripe-service only mirrors the PaymentIntent), so `settleWelcomeCompletion(orgId, paidTopupsCents)` is called from every path that ALREADY holds the org's paid-topups sum — `composeAccountFunds` (so the dashboard read right after a payment makes it land in seconds) and the checkout route — plus, unconditionally, the hourly `runWelcomeCompletionSweep` on the existing dunning scheduler. A request can only make an already-EARNED grant land sooner; the condition is derived entirely from Stripe's record of money received plus billing's own ledger, so nothing a caller asserts can conjure a grant. `computeBalance` deliberately does NOT settle — `GET /internal/campaigns/:id/affordability` is documented side-effect-free and authorize stays hot-path-thin.
+
+**Idempotency** is the existing partial unique index `idx_local_promos_org_promo … WHERE idempotency_key IS NULL` — no new state. Concurrent settles race the INSERT; losers read `already_granted`.
+
+**NO BACKFILL** (explicit product decision, 2026-07-30): the $25 gift is the CURRENT offer, not a retroactive entitlement. `billing_accounts.welcome_completion_eligible` defaults **true** (a brand-new org is eligible) and migration 0029 flipped all 88 accounts that existed at ship time to **false**. Verified on a prod fork: 88/88 ineligible, 106 grant rows untouched. The cutoff is a literal timestamp, not `now()`, so re-applying the migration can never demote a later signup. **`insertTestAccount` therefore defaults `welcomeCompletionEligible: false`** — a hand-inserted fixture stands in for a pre-existing org, which keeps paid-topup mocks in unrelated suites from tripping the grant and shifting their credited totals. Pass `true` to exercise the gift.
+
+**Fail loud:** a missing `welcome_completion` seed THROWS (→ 502 on the account read). Swallowing it would leave a buyer short of credit they were promised, which is the exact failure this exists to remove. This is not paranoia — prod HAS lost promo-code seeds (`invite_reward`/`invite_welcome` never applied per 0017; `first_load_match` was seeded by journaled 0023 yet is absent from prod today, apparently hand-renamed to a `brand_welcome` row).
+
+### $25 discount on the FIRST checkout (advance of the same gift)
+
+`POST /v1/checkout-sessions` payment mode advances the whole entitlement as a **visible Stripe discount** (`discounts: [{coupon}]`) instead of granting it later. Every condition must hold, and each is load-bearing:
+
+| Condition | Why |
+|---|---|
+| org has **never paid** (`paidTopups == 0`) | otherwise every later top-up silently gets $25 off forever |
+| checkout ≥ **$50** (`WELCOME_DISCOUNT_MIN_CHECKOUT_CENTS`) | a $25 discount must not push the payment below the $25 that EARNS the gift. At $50 the buyer pays exactly $25 → trigger satisfied → credit = payment + welcome + completion = the $50 configured. Also why the charge can never reach $0. **Do NOT add a branch discounting a smaller first checkout.** |
+| entitlement remaining > 0 | an org already gifted its full $25 is owed no advance |
+| org is eligible | an ineligible org will never get the completion, so a discount would short-change it |
+| `WELCOME_DISCOUNT_COUPON_ID` set **and** the `welcome_completion` seed exists | makes it structurally impossible for the discount to land without the matching grant being possible |
+
+Without the discount, the buyer pays full and gets the $25 on top ($32 paid → $57 credit). With it, they pay $25 and land at $50. Both honor "$25 free"; the discount just makes the first purchase cheaper.
+
+**`WELCOME_DISCOUNT_COUPON_ID`** is a Stripe coupon id (`amount_off: 2500`, `currency: usd`, `duration: once`). billing cannot create it — stripe-service owns the Stripe key and exposes no coupons route, and touching stripe-service was out of scope. Unset → no discount, and the notice below is shown instead (coherent, never short-changes anyone).
+
+**Checkout-page copy.** When no discount applies, `custom_text.submit.message` carries `WELCOME_COMPLETION_CHECKOUT_NOTICE` — product-approved **verbatim**, do not reword or interpolate: `You get $25 in free credits. $5 now, the rest once your payments reach $25.` It is deliberately withheld from an ineligible org and from one already gifted $25 (it would be a lie). Stripe caps `message` at 1200 chars.
+
+**`allow_promotion_codes` is gone and must not come back.** It was enabled for a single journalist comp (that is done) and Stripe makes user-entered promotion codes mutually exclusive with a pre-applied discount.
+
 ## Billing/runs ownership target
 
 - **Billing-service** owns: local promo grants (`local_promos`), topup config (`billing_accounts.topup_amount_cents`, `topup_threshold_cents`).
@@ -167,6 +205,8 @@ A slow spender whose balance never crosses the floor within a calendar month wou
   "id": "<uuid>",
   "org_id": "<uuid>",
   "credited_cents": "55200.0000000000",      // SUM(succeeded PI.(amount_received − amount_returned)) + SUM(local_promos.amount_cents). Refunds + lost disputes are netted out — see "Refunds and lost disputes"
+  "credited_paid_cents": "52700.0000000000", // the PAID half of credited_cents: succeeded Stripe payments NET of returns. Render as "Credit paid Stripe"
+  "credited_gifted_cents": "2500.0000000000",// the GIFTED half: SUM(local_promos) — welcome, welcome-completion, first-load match, invite + staff grants, redeemed promos. Render as "Welcome credits". INVARIANT: credited_cents === credited_paid_cents + credited_gifted_cents
   "usage_cents": "38289.2958000000",         // runs-service spent_cents (platform actual+provisioned). Already NET of any usage discount (frozen at cost-write in runs-service).
   "balance_cents": "16910.7042000000",       // credited_cents − usage_cents; USE THIS for depletion/budget gates
   "actual_balance_cents": "16920.7042000000", // credited_cents − actualized usage only; display this as the user's credit balance
@@ -195,6 +235,7 @@ Composition (`src/routes/accounts.ts:composeAccountFunds`):
 1. `getCustomerByOrg(identity)` → Stripe customer (for `id`)
 2. `sumSucceededTopupsForCustomer(identity, customer.id)` → paginates `GET /v1/payment_intents?customer=cus_X` and sums `amount_received − amount_returned` where `status='succeeded'` (refunds + lost disputes netted out — see "Refunds and lost disputes")
 3. `sumLocalPromoCreditsForOrg(orgId)` → SUM `local_promos.amount_cents`
+3b. `settleWelcomeCompletion(orgId, paidTopups)` → grants the welcome-completion gift if earned (paid topups are its trigger and we already hold them here), then the freshly-granted amount is folded into the promo sum rather than re-querying. See "Welcome-completion gift". Fails loud → 502.
 4. `fetchRunsOrgUsageTotal(orgId, identity)` → reads runs-service **`net_spent_cents`** (the frozen-NET usage total, `SUM(COALESCE(net, gross))`), NOT the gross `spent_cents`. Returned to callers as `spent_cents` (billing's "usage" = the discounted amount the org owes).
 5. `fetchRunsOrgActualUsageTotal(orgId, identity)` → reads runs-service **`net_total_expected_cents`** (the frozen-NET actualized total), NOT the gross `total_expected_cents`, from actualized platform costs only.
 
@@ -202,7 +243,7 @@ Composition (`src/routes/accounts.ts:composeAccountFunds`):
 6. `hasAttachedCardPm(identity, customer.id)` → `has_payment_method` (≥1 chargeable PM: card or link)
 7. `getOrgCardDisplay(identity, customer.id)` → `{country, brand, last4, expMonth, expYear}` (one Stripe read of the first card PM) → `card_country`/`card_brand`/`card_last4`/`card_exp_month`/`card_exp_year` (display-only, null when no card PM) → `auto_reload_supported = !isAutoReloadBlockedCountry(card_country)` (see "Off_session auto-reload" below)
 8. `getUsageDiscountPct(orgId)` → `usage_discount_pct` (dashboard banner only; see "Per-org usage discount"). Does NOT enter the balance math — runs-service already served net usage.
-9. `credited_cents = paid_topups + local_credits`; `balance_cents = credited_cents − usage`; `actual_balance_cents = credited_cents − actualized_usage`. runs-service usage is already NET of the discount, so billing subtracts it verbatim (no discount applied here).
+9. `credited_cents = paid_topups + local_credits`; `balance_cents = credited_cents − usage`; `actual_balance_cents = credited_cents − actualized_usage`. runs-service usage is already NET of the discount, so billing subtracts it verbatim (no discount applied here). The two halves are also exposed raw as `credited_paid_cents` / `credited_gifted_cents` so the dashboard never computes a money figure in the browser.
 
 ### `GET /public/stats/billing`
 
@@ -235,7 +276,7 @@ Growth rows expose `credited_cents` and `revenue_cents` only, both NET (they rea
 | `PATCH` | `/v1/accounts/auto_topup` | configure auto-topup; body must include both `topup_amount_cents` and `topup_threshold_cents` |
 | `POST` | `/v1/accounts/wallet_setup` | first-campaign wallet setup: requires `initial_load_amount_cents`, `topup_amount_cents`, `topup_threshold_cents`; charges the initial load, stores org auto-topup config, grants `first_load_match` up to $25 once |
 | `DELETE` | `/v1/accounts/auto_topup` | disable auto-topup |
-| `POST` | `/v1/checkout-sessions` | one-shot top-up or setup-mode PM capture via Stripe Checkout; does NOT configure auto-topup |
+| `POST` | `/v1/checkout-sessions` | one-shot top-up or setup-mode PM capture via Stripe Checkout; does NOT configure auto-topup. Payment mode carries the "$25 in free credits" offer: a visible $25 pre-applied discount on a first-ever checkout ≥ $50, else the gift-is-coming notice. No user promotion-code entry. See "Welcome-completion gift" |
 | `POST` | `/v1/portal-sessions` | Stripe Customer Portal session |
 | `POST` | `/v1/customer_balance/authorize` | check if `balance_cents >= amount` ; auto-reload via PI if configured |
 | `POST` | `/v1/customer_balance/usage_apply` | proactive topup hint after a run; no-op for the ledger |

--- a/drizzle/0029_welcome_completion.sql
+++ b/drizzle/0029_welcome_completion.sql
@@ -1,0 +1,31 @@
+-- Welcome-completion gift — the second half of the "$25 in free credits" promise.
+--
+-- Onboarding tells every new customer they get $25 of free credits. Signup only
+-- grants the `welcome` row ($5 today), so the remainder was being granted BY HAND
+-- (staff `admin_grant` rows described "Welcome credits (2/2)"). This ledger key
+-- makes the remainder automatic: it is granted exactly once per org, the moment
+-- the org's cumulative SUCCEEDED payments reach $25.
+--
+-- The promo-code row is a technical ledger key only (amount 0): the actual grant
+-- amount is dynamic (entitlement $25 MINUS whatever the org has already been
+-- gifted) and is stored per row on local_promos, exactly like `first_load_match`.
+INSERT INTO "local_promo_codes" ("code", "amount_cents", "max_redemptions", "expires_at")
+VALUES ('welcome_completion', 0, NULL, NULL)
+ON CONFLICT ("code") DO UPDATE SET "amount_cents" = EXCLUDED."amount_cents";
+
+-- NO BACKFILL (product decision, 2026-07-30): the $25 gift is the CURRENT offer,
+-- not a retroactive entitlement. Orgs that already existed when this shipped keep
+-- exactly the grants they have — several are on the old $2-era welcome amount and
+-- several have no welcome row at all, and re-pricing history is explicitly out of
+-- scope. So the column defaults to TRUE (a brand-new org is eligible) and this
+-- one-time UPDATE marks every pre-existing account ineligible.
+--
+-- The cutoff literal (not now()) keeps the migration idempotent: re-applying it
+-- can never demote an account created after the feature shipped.
+ALTER TABLE "billing_accounts"
+  ADD COLUMN IF NOT EXISTS "welcome_completion_eligible" boolean NOT NULL DEFAULT true;
+
+UPDATE "billing_accounts"
+   SET "welcome_completion_eligible" = false
+ WHERE "created_at" < '2026-07-30T00:00:00Z'
+   AND "welcome_completion_eligible" = true;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1790676000000,
       "tag": "0028_welcome_amount_500",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1790762400000,
+      "tag": "0029_welcome_completion",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -94,6 +94,14 @@
           "credited_cents": {
             "type": "string"
           },
+          "credited_paid_cents": {
+            "type": "string",
+            "description": "Money the org actually paid us: SUM of succeeded Stripe payments NET of refunds and lost disputes. Together with credited_gifted_cents this decomposes credited_cents (credited_cents === credited_paid_cents + credited_gifted_cents), so a client can show 'credit paid' vs 'credits gifted' without computing money."
+          },
+          "credited_gifted_cents": {
+            "type": "string",
+            "description": "Credits we gave the org: SUM(local_promos) — signup welcome gift, welcome-completion gift, first-load match, invite grants, staff grants and redeemed promo codes. The other half of credited_cents alongside credited_paid_cents."
+          },
           "usage_cents": {
             "type": "string",
             "description": "Platform usage from runs-service, including actualized costs and provisioned holds. Already NET of any per-org usage discount (applied once at cost-write in runs-service). Use with balance_cents for spend authorization."
@@ -146,6 +154,8 @@
           "id",
           "org_id",
           "credited_cents",
+          "credited_paid_cents",
+          "credited_gifted_cents",
           "usage_cents",
           "balance_cents",
           "actual_balance_cents",
@@ -1590,7 +1600,7 @@
     "/v1/checkout-sessions": {
       "post": {
         "summary": "Create Stripe Checkout session via stripe-service",
-        "description": "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. HOSTED (default, no ui_mode): requires success_url + cancel_url and returns a redirect `url`. mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written. EMBEDDED (ui_mode='embedded'): Stripe Embedded Checkout for an in-app modal — no success_url/cancel_url, returns a `client_secret` the front-end mounts in an iframe; always charges topup_amount_cents (payment-only). Credit + first-load match land via the existing checkout.session.completed webhook in all modes.",
+        "description": "Auto-creates the billing account with welcome promo if the org has no account yet, then proxies to stripe-service. HOSTED (default, no ui_mode): requires success_url + cancel_url and returns a redirect `url`. mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written. EMBEDDED (ui_mode='embedded'): Stripe Embedded Checkout for an in-app modal — no success_url/cancel_url, returns a `client_secret` the front-end mounts in an iframe; always charges topup_amount_cents (payment-only). Credit + first-load match land via the existing checkout.session.completed webhook in all modes. FREE CREDITS: payment-mode checkouts carry the '$25 in free credits' offer. On an org's FIRST-EVER payment of at least $50 the whole $25 is advanced as a visible pre-applied Stripe discount (buyer pays $50 minus $25, and the credit that lands is still the full $50). Otherwise the page shows a notice that the remainder arrives once cumulative payments reach $25. User-entered promotion codes are NOT offered (allow_promotion_codes is never set) — they are mutually exclusive with the pre-applied discount.",
         "parameters": [
           {
             "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -9,6 +9,7 @@ import {
   index,
   primaryKey,
   bigserial,
+  boolean,
 } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 
@@ -26,6 +27,14 @@ export const billingAccounts = pgTable(
     orgId: uuid("org_id").notNull(),
     topupAmountCents: integer("topup_amount_cents"),
     topupThresholdCents: integer("topup_threshold_cents").default(200),
+    // Whether this org can still earn the welcome-COMPLETION gift (the second
+    // half of the "$25 in free credits" promise — see lib/welcome-completion).
+    // TRUE by default: a brand-new org is eligible. Migration 0029 flipped every
+    // account that existed when the feature shipped to FALSE — the $25 offer is
+    // the current offer, not a retroactive entitlement (no backfill).
+    welcomeCompletionEligible: boolean("welcome_completion_eligible")
+      .notNull()
+      .default(true),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -124,6 +133,34 @@ export const INVITE_REWARD_CODE = "invite_reward";
 export const INVITE_WELCOME_CODE = "invite_welcome";
 export const FIRST_LOAD_MATCH_CODE = "first_load_match";
 export const FIRST_LOAD_MATCH_CAP_CENTS = 2500;
+
+// --- Welcome-completion gift (migration 0029) ---
+//
+// Onboarding promises "$25 in free credits". Signup grants only the `welcome`
+// row, so the REMAINDER is granted under this code, exactly once per org, once
+// the org's cumulative succeeded payments reach FREE_CREDIT_PAID_TRIGGER_CENTS.
+// The per-row amount is dynamic (entitlement MINUS what the org was already
+// gifted) and lives on local_promos — the promo-code row's amount_cents is a 0
+// placeholder, like first_load_match. See lib/welcome-completion.ts.
+export const WELCOME_COMPLETION_CODE = "welcome_completion";
+
+// Total free credits an org may ever receive, welcome gift INCLUDED. The
+// completion grant is deliberately DERIVED (entitlement − already-gifted), never
+// a hardcoded "$20", so it stays correct if the welcome amount changes or the org
+// never got a welcome row at all.
+export const FREE_CREDIT_ENTITLEMENT_CENTS = 2500;
+
+// Cumulative SUCCEEDED payments that earn the completion. The trigger is money
+// actually received — NOT usage consumed: the account model is threshold-postpaid,
+// so an org can consume on credit before paying anything, and we must not gift
+// credits to someone whose card may still fail.
+export const FREE_CREDIT_PAID_TRIGGER_CENTS = 2500;
+
+// Minimum FIRST checkout that may carry the gift as an up-front visible discount.
+// Not arbitrary: a $25 discount must not push the payment below the $25 that earns
+// the gift. At $50 the buyer pays exactly $25, which satisfies the trigger, and the
+// credit that lands is (payment) + (welcome) + (completion) = the $50 configured.
+export const WELCOME_DISCOUNT_MIN_CHECKOUT_CENTS = 5000;
 
 // Admin-issued arbitrary-amount grant (staff oversight ledger, migration 0025).
 // Per-row amount lives on local_promos (like first_load_match); the promo-code

--- a/src/lib/dunning-scheduler.ts
+++ b/src/lib/dunning-scheduler.ts
@@ -11,6 +11,7 @@
 
 import { runDunningTick } from "./dunning.js";
 import { runMonthEndSweep } from "./month-end-sweep.js";
+import { runWelcomeCompletionSweep } from "./welcome-completion-sweep.js";
 
 // Hourly heartbeat. The follow-up windows (+3d / +10d) are far coarser, so this
 // is plenty frequent for both follow-ups and recharge detection.
@@ -48,6 +49,21 @@ export function startDunningScheduler(): void {
         }
       } catch (err) {
         console.error("[billing-service] month-end sweep failed:", err);
+      }
+
+      // Welcome-completion sweep — the unconditional server-side driver for the
+      // "$25 in free credits" completion gift. Isolated so a failure here never
+      // blocks dunning or the month-end sweep, and vice-versa.
+      try {
+        const w = await runWelcomeCompletionSweep();
+        if (w.granted > 0 || w.failed > 0) {
+          console.log(
+            `[billing-service] welcome-completion sweep: candidates=${w.candidates} ` +
+              `granted=${w.granted} failed=${w.failed}`
+          );
+        }
+      } catch (err) {
+        console.error("[billing-service] welcome-completion sweep failed:", err);
       }
     } finally {
       timer = setTimeout(tick, TICK_INTERVAL_MS);

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -417,13 +417,22 @@ export interface CheckoutSessionBody {
    */
   invoice_creation?: { enabled: boolean };
   /**
-   * Hosted payment-mode only: when true, Stripe's hosted Checkout page shows the native
-   * "Add promotion code" field so the user can enter a valid Stripe promotion code and
-   * have the discount applied at pay time. Credit accounting is unchanged — credit still
-   * derives from the amount Stripe actually receives (a fully-discounted $0 checkout
-   * lands $0 credit). Deliberately NOT set for setup mode (no charge) or embedded checkout.
+   * Payment-mode only: pre-applied discounts, shown on the Checkout page as a
+   * discount line so the buyer sees what they are getting before paying. Stripe
+   * accepts at most one entry. Used to advance the welcome-completion gift as a
+   * visible $25 off the org's FIRST checkout (see lib/welcome-completion).
+   *
+   * Mutually exclusive with user-entered promotion codes — billing deliberately
+   * does NOT set `allow_promotion_codes` anywhere (removed with the journalist comp
+   * it was added for), so there is no conflict to resolve.
    */
-  allow_promotion_codes?: boolean;
+  discounts?: Array<{ coupon: string }>;
+  /**
+   * Payment-mode only: copy rendered on the Checkout page alongside the pay button
+   * (Stripe caps `message` at 1200 chars). Used to tell a buyer the free credits are
+   * coming when no up-front discount applies.
+   */
+  custom_text?: { submit: { message: string } };
 }
 
 export async function createCheckoutSession(

--- a/src/lib/welcome-completion-sweep.ts
+++ b/src/lib/welcome-completion-sweep.ts
@@ -1,0 +1,63 @@
+/**
+ * Hourly welcome-completion sweep — the authoritative server-side driver for the
+ * "$25 in free credits" completion gift.
+ *
+ * Billing learns about a Checkout payment lazily (stripe-service mirrors the
+ * PaymentIntent; nothing pushes into billing). Every request path that already
+ * holds the org's paid-topups sum settles the gift inline, which is what makes it
+ * land within seconds of a purchase in practice. This sweep is what makes the
+ * guarantee UNCONDITIONAL: an org that pays and never opens the app still gets its
+ * credit, and a settle that failed once is retried on the next tick. No browser is
+ * ever the trigger.
+ *
+ * Runs from the SAME hourly scheduler as dunning + the month-end sweep, isolated
+ * in its own try/catch so neither can block the other.
+ *
+ * Candidate set = eligible accounts with no completion row yet (an org drops out
+ * permanently once granted), so this costs one stripe-service paid-topups read per
+ * not-yet-earned new signup per hour — bounded by signups, not by fleet size.
+ *
+ * Fail-loud per org, isolated: a per-org error is logged and skipped so one
+ * unreachable org never blocks the rest (same shape as runDunningTick).
+ */
+
+import { sumSucceededTopupsForOrg } from "./stripe-service-client.js";
+import {
+  listWelcomeCompletionCandidates,
+  settleWelcomeCompletion,
+} from "./welcome-completion.js";
+
+export interface WelcomeCompletionSweepResult {
+  candidates: number;
+  granted: number;
+  failed: number;
+}
+
+export async function runWelcomeCompletionSweep(): Promise<WelcomeCompletionSweepResult> {
+  const candidates = await listWelcomeCompletionCandidates();
+  let granted = 0;
+  let failed = 0;
+
+  for (const orgId of candidates) {
+    try {
+      // User-less org-keyed read (X-API-Key + org only) — there is no end user on
+      // this path, so no identity is invented. Net of refunds + lost disputes.
+      const paidTopups = await sumSucceededTopupsForOrg(orgId);
+      const outcome = await settleWelcomeCompletion(orgId, paidTopups);
+      if (outcome.granted) {
+        granted += 1;
+        console.log(
+          `[billing-service] welcome completion granted org=${orgId} amount_cents=${outcome.amountCents}`
+        );
+      }
+    } catch (err) {
+      failed += 1;
+      console.error(
+        `[billing-service] welcome-completion sweep failed for org ${orgId}:`,
+        err
+      );
+    }
+  }
+
+  return { candidates: candidates.length, granted, failed };
+}

--- a/src/lib/welcome-completion.ts
+++ b/src/lib/welcome-completion.ts
@@ -1,0 +1,284 @@
+/**
+ * Welcome-completion gift — the second half of the "$25 in free credits" promise.
+ *
+ * ## The rule
+ *
+ * An org receives FREE_CREDIT_ENTITLEMENT_CENTS ($25) in free credits IN TOTAL,
+ * welcome gift included. Signup grants only the `welcome` row ($5 today), so the
+ * completion is worth the remainder. The remainder is DERIVED from what the org
+ * has actually been gifted (SUM(local_promos)), never from a hardcoded $20 — so it
+ * stays correct if the welcome amount is re-priced or the org never got one.
+ *
+ * The completion is EARNED once the org's cumulative SUCCEEDED payments reach
+ * FREE_CREDIT_PAID_TRIGGER_CENTS ($25). The trigger is money actually received,
+ * NOT usage consumed: the account model is threshold-postpaid (an org can consume
+ * on credit before paying anything), and we must not gift credits to someone whose
+ * card may still fail.
+ *
+ * ## Who drives it
+ *
+ * Server-side only. A browser returning from Stripe is never the authority: the
+ * grant condition is derived entirely from Stripe's own record of money received
+ * (read through stripe-service) plus billing's own ledger, so a request can only
+ * make an ALREADY-EARNED grant land sooner, never conjure one. `settleWelcomeCompletion`
+ * is called from every path that already has the org's paid-topups sum in hand
+ * (composeAccountFunds, the checkout route) and, unconditionally, from the hourly
+ * welcome-completion sweep — so it lands even for an org that never opens the app.
+ *
+ * ## Idempotency
+ *
+ * The PARTIAL unique index `idx_local_promos_org_promo (org_id, promo_code_id)
+ * WHERE idempotency_key IS NULL` is the hard exactly-once guard. Concurrent
+ * settles race on the INSERT; the loser reads `already_granted`. Replaying the
+ * same payment event grants once.
+ *
+ * ## Fail loud
+ *
+ * A missing `welcome_completion` promo-code seed THROWS. Swallowing it would leave
+ * a buyer short of the credit they were promised — the exact failure this feature
+ * exists to remove. Note prod HAS lost promo-code seeds before (see CLAUDE.md
+ * "Migrations are hand-journaled"), which is why the checkout discount is gated on
+ * this seed existing: the discount can never be granted without the credit.
+ */
+
+import { and, eq, notExists, sql as rawSql } from "drizzle-orm";
+import { db } from "../db/index.js";
+import {
+  billingAccounts,
+  localPromoCodes,
+  localPromos,
+  FREE_CREDIT_ENTITLEMENT_CENTS,
+  FREE_CREDIT_PAID_TRIGGER_CENTS,
+  WELCOME_COMPLETION_CODE,
+  WELCOME_DISCOUNT_MIN_CHECKOUT_CENTS,
+} from "../db/schema.js";
+import { cmpCents, gte, subCents } from "./cents.js";
+import { sumLocalPromoCreditsForOrg } from "./promos.js";
+import { Decimal } from "decimal.js";
+
+// System sentinel — the completion has no human user (it is platform-issued).
+// Same convention as promos.ts grantCredit / internal transfer-brand.
+const SYSTEM_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+const ZERO = "0.0000000000";
+
+/**
+ * Copy shown on the checkout page when NO up-front discount applies, so the buyer
+ * knows the gift is coming before deciding to pay. Approved verbatim by the product
+ * owner — do not reword, do not interpolate. (No em-dash: customer-facing copy.)
+ */
+export const WELCOME_COMPLETION_CHECKOUT_NOTICE =
+  "You get $25 in free credits. $5 now, the rest once your payments reach $25.";
+
+export class WelcomeCompletionPromoCodeMissingError extends Error {
+  constructor() {
+    super(
+      `welcome-completion promo code seed missing: ${WELCOME_COMPLETION_CODE} (run migration 0029)`
+    );
+  }
+}
+
+function toCents(amountCents: number): string {
+  return new Decimal(amountCents).toFixed(10);
+}
+
+async function findWelcomeCompletionCode() {
+  const [row] = await db
+    .select()
+    .from(localPromoCodes)
+    .where(eq(localPromoCodes.code, WELCOME_COMPLETION_CODE))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * True when the `welcome_completion` ledger key exists, i.e. when a completion
+ * grant is possible at all. The checkout discount gates on this so a discount can
+ * never land without the matching credit grant.
+ */
+export async function welcomeCompletionCodeExists(): Promise<boolean> {
+  return (await findWelcomeCompletionCode()) !== null;
+}
+
+export type SettleReason =
+  | "granted"
+  | "already_granted"
+  | "no_account"
+  | "not_eligible"
+  | "payments_below_trigger"
+  | "entitlement_already_full";
+
+export interface WelcomeCompletionOutcome {
+  granted: boolean;
+  /** Amount granted by THIS call (canonical cents string); "0.…" when nothing was granted. */
+  amountCents: string;
+  reason: SettleReason;
+}
+
+const NOT_GRANTED = (reason: SettleReason): WelcomeCompletionOutcome => ({
+  granted: false,
+  amountCents: ZERO,
+  reason,
+});
+
+/**
+ * Grant the welcome-completion gift if it is earned and not yet granted.
+ *
+ * `paidTopupsCents` is the org's cumulative succeeded payments NET of refunds and
+ * lost disputes — i.e. exactly the figure the callers already computed via
+ * sumSucceededTopupsFor{Customer,Org}. Money that was given back does not earn the
+ * gift.
+ *
+ * Idempotent and safe to call on every request. Fails loud.
+ */
+export async function settleWelcomeCompletion(
+  orgId: string,
+  paidTopupsCents: string
+): Promise<WelcomeCompletionOutcome> {
+  const [account] = await db
+    .select({ eligible: billingAccounts.welcomeCompletionEligible })
+    .from(billingAccounts)
+    .where(eq(billingAccounts.orgId, orgId))
+    .limit(1);
+
+  if (!account) return NOT_GRANTED("no_account");
+  if (!account.eligible) return NOT_GRANTED("not_eligible");
+  if (!gte(paidTopupsCents, toCents(FREE_CREDIT_PAID_TRIGGER_CENTS))) {
+    return NOT_GRANTED("payments_below_trigger");
+  }
+
+  const giftedCents = await sumLocalPromoCreditsForOrg(orgId);
+  const remainingCents = subCents(
+    toCents(FREE_CREDIT_ENTITLEMENT_CENTS),
+    giftedCents
+  );
+  if (cmpCents(remainingCents, ZERO) <= 0) {
+    return NOT_GRANTED("entitlement_already_full");
+  }
+
+  const code = await findWelcomeCompletionCode();
+  if (!code) throw new WelcomeCompletionPromoCodeMissingError();
+
+  const inserted = await db
+    .insert(localPromos)
+    .values({
+      orgId,
+      userId: SYSTEM_USER_ID,
+      amountCents: remainingCents,
+      promoCodeId: code.id,
+      description: `Welcome credits (2/2): $${new Decimal(remainingCents)
+        .dividedBy(100)
+        .toFixed(2)}`,
+    })
+    // (org, promo_code) uniqueness is PARTIAL (WHERE idempotency_key IS NULL,
+    // migration 0025) — the conflict target must carry the predicate.
+    .onConflictDoNothing({
+      target: [localPromos.orgId, localPromos.promoCodeId],
+      where: rawSql`idempotency_key IS NULL`,
+    })
+    .returning();
+
+  if (inserted.length > 0) {
+    return { granted: true, amountCents: remainingCents, reason: "granted" };
+  }
+  return NOT_GRANTED("already_granted");
+}
+
+export interface CheckoutWelcomeOffer {
+  /** Apply a visible up-front discount to THIS checkout. */
+  applyDiscount: boolean;
+  /** Stripe coupon id to attach (only set when applyDiscount). */
+  couponId: string | null;
+  /** Show the "gift is coming" notice on the checkout page. */
+  showNotice: boolean;
+}
+
+const NO_OFFER: CheckoutWelcomeOffer = {
+  applyDiscount: false,
+  couponId: null,
+  showNotice: false,
+};
+
+/**
+ * Decide what the checkout page should say / apply for this org's payment-mode
+ * checkout.
+ *
+ * Discount rules, all of which must hold:
+ *   - the org has NEVER paid before (`paidTopupsCents` is 0) — otherwise every
+ *     later top-up would silently get $25 off forever;
+ *   - the org still has free-credit entitlement left to advance;
+ *   - the checkout is for at least WELCOME_DISCOUNT_MIN_CHECKOUT_CENTS ($50), so
+ *     the post-discount charge still reaches the $25 that EARNS the gift (this is
+ *     what makes it impossible to discount without the matching grant, and what
+ *     keeps the charge away from $0);
+ *   - a completion grant is actually possible (ledger key seeded) and a coupon is
+ *     configured.
+ *
+ * When no discount applies, the notice is shown instead — but only to an org that
+ * genuinely still has free credit coming. Telling an org with its full $25 already
+ * gifted (or an org that is not eligible at all) that "the rest" is on its way
+ * would be a lie.
+ */
+export async function decideCheckoutWelcomeOffer(
+  orgId: string,
+  paidTopupsCents: string,
+  checkoutAmountCents: number
+): Promise<CheckoutWelcomeOffer> {
+  const [account] = await db
+    .select({ eligible: billingAccounts.welcomeCompletionEligible })
+    .from(billingAccounts)
+    .where(eq(billingAccounts.orgId, orgId))
+    .limit(1);
+  if (!account || !account.eligible) return NO_OFFER;
+
+  const giftedCents = await sumLocalPromoCreditsForOrg(orgId);
+  const remainingCents = subCents(
+    toCents(FREE_CREDIT_ENTITLEMENT_CENTS),
+    giftedCents
+  );
+  if (cmpCents(remainingCents, ZERO) <= 0) return NO_OFFER;
+
+  const neverPaid = cmpCents(paidTopupsCents, ZERO) <= 0;
+  const meetsFloor = checkoutAmountCents >= WELCOME_DISCOUNT_MIN_CHECKOUT_CENTS;
+  const couponId = process.env.WELCOME_DISCOUNT_COUPON_ID?.trim() || null;
+  const grantable = couponId !== null && (await welcomeCompletionCodeExists());
+
+  if (neverPaid && meetsFloor && grantable) {
+    return { applyDiscount: true, couponId, showNotice: false };
+  }
+  return { applyDiscount: false, couponId: null, showNotice: true };
+}
+
+/**
+ * Org ids that could still earn the completion — the sweep's candidate set:
+ * eligible accounts with no completion row yet. An org drops out permanently once
+ * granted, so the set is bounded by recent signups, not by fleet size.
+ *
+ * Fails loud when the ledger key is missing (the sweep must not silently no-op).
+ */
+export async function listWelcomeCompletionCandidates(): Promise<string[]> {
+  const code = await findWelcomeCompletionCode();
+  if (!code) throw new WelcomeCompletionPromoCodeMissingError();
+
+  const rows = await db
+    .select({ orgId: billingAccounts.orgId })
+    .from(billingAccounts)
+    .where(
+      and(
+        eq(billingAccounts.welcomeCompletionEligible, true),
+        notExists(
+          db
+            .select({ one: rawSql`1` })
+            .from(localPromos)
+            .where(
+              and(
+                eq(localPromos.orgId, billingAccounts.orgId),
+                eq(localPromos.promoCodeId, code.id)
+              )
+            )
+        )
+      )
+    );
+
+  return rows.map((r) => r.orgId);
+}

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -10,6 +10,7 @@ import { addCents, isDepleted, subCents } from "../lib/cents.js";
 import { tierFor } from "../lib/topup-tier.js";
 import { fetchRunsOrgActualUsageTotal, fetchRunsOrgUsageTotal } from "../lib/runs-client.js";
 import { grantFirstLoadMatch, sumLocalPromoCreditsForOrg } from "../lib/promos.js";
+import { settleWelcomeCompletion } from "../lib/welcome-completion.js";
 import { getUsageDiscountPct } from "../lib/usage-discount.js";
 import { reloadViaInvoice } from "../lib/reload.js";
 import {
@@ -50,6 +51,7 @@ async function composeAccountFunds(
   actualBalanceCents: string;
   discountPct: number | null;
   paidTopupsCents: string;
+  giftedCreditsCents: string;
   hasPaymentMethod: boolean;
   cardCountry: string | null;
   cardBrand: string | null;
@@ -59,7 +61,7 @@ async function composeAccountFunds(
   autoReloadSupported: boolean;
 }> {
   const customer = await getCustomerByOrg(identity);
-  const [paidTopups, localCredits, runsUsage, actualRunsUsage, hasCardPm, cardDisplay, discountPct] =
+  const [paidTopups, localCreditsBeforeSettle, runsUsage, actualRunsUsage, hasCardPm, cardDisplay, discountPct] =
     await Promise.all([
       sumSucceededTopupsForCustomer(identity, customer.id),
       sumLocalPromoCreditsForOrg(orgId),
@@ -69,6 +71,16 @@ async function composeAccountFunds(
       getOrgCardDisplay(identity, customer.id),
       getUsageDiscountPct(orgId),
     ]);
+  // Welcome-completion gift: paid topups are the trigger and we already hold them,
+  // so settle here — the dashboard reads this endpoint right after a payment, which
+  // is what makes the gift land in seconds rather than waiting for the hourly sweep.
+  // The grant condition is derived entirely from Stripe's record of money received,
+  // never from anything the caller asserts. Fails loud (→ 502 at the call site).
+  // Fold the freshly-granted amount in rather than re-querying the ledger.
+  const completion = await settleWelcomeCompletion(orgId, paidTopups);
+  const localCredits = completion.granted
+    ? addCents(localCreditsBeforeSettle, completion.amountCents)
+    : localCreditsBeforeSettle;
   const cardCountry = cardDisplay?.country ?? null;
   const creditedCents = addCents(paidTopups, localCredits);
   // runs-service usage is already NET of the org's usage discount (frozen at
@@ -84,6 +96,7 @@ async function composeAccountFunds(
     actualBalanceCents,
     discountPct,
     paidTopupsCents: paidTopups,
+    giftedCreditsCents: localCredits,
     hasPaymentMethod: hasCardPm,
     cardCountry,
     cardBrand: cardDisplay?.brand ?? null,
@@ -103,6 +116,7 @@ function buildAccountResponse(
     actualBalanceCents: string;
     discountPct: number | null;
     paidTopupsCents: string;
+    giftedCreditsCents: string;
     hasPaymentMethod: boolean;
     cardCountry: string | null;
     cardBrand: string | null;
@@ -124,6 +138,15 @@ function buildAccountResponse(
     id: account.id,
     org_id: account.orgId,
     credited_cents: funds.creditedCents,
+    // Decomposition of credited_cents into the two things it is made of, so the
+    // dashboard can render "money you paid" vs "credits we gave you" without doing
+    // any money arithmetic in the browser. Invariant:
+    //   credited_cents === credited_paid_cents + credited_gifted_cents
+    // paid = succeeded Stripe payments NET of refunds + lost disputes.
+    // gifted = SUM(local_promos): welcome, welcome-completion, first-load match,
+    // invite grants, staff grants, redeemed promo codes.
+    credited_paid_cents: funds.paidTopupsCents,
+    credited_gifted_cents: funds.giftedCreditsCents,
     usage_cents: funds.usageCents,
     balance_cents: funds.balanceCents,
     actual_balance_cents: funds.actualBalanceCents,

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -1,9 +1,18 @@
 import { Router } from "express";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { CreateCheckoutRequestSchema } from "../schemas.js";
-import { createCheckoutSession, getCustomerByOrg } from "../lib/stripe-service-client.js";
+import {
+  createCheckoutSession,
+  getCustomerByOrg,
+  sumSucceededTopupsForCustomer,
+} from "../lib/stripe-service-client.js";
 import type { CheckoutSessionBody } from "../lib/stripe-service-client.js";
 import { findOrCreateAccount } from "../lib/account.js";
+import {
+  decideCheckoutWelcomeOffer,
+  settleWelcomeCompletion,
+  WELCOME_COMPLETION_CHECKOUT_NOTICE,
+} from "../lib/welcome-completion.js";
 import { traceEvent } from "../lib/trace-event.js";
 
 const CHECKOUT_PRODUCT_NAME = "Distribute credit top-up";
@@ -65,6 +74,21 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
           metadata: { org_id: orgId },
         };
       } else {
+        // Free-credit offer for THIS checkout. Needs the org's cumulative paid
+        // topups: the $25 discount may only ever land on an org that has NEVER
+        // paid, otherwise every later top-up would silently get $25 off forever.
+        // Settling first also covers an org whose earlier payment already crossed
+        // the $25 trigger but was not yet settled, so the notice/discount decision
+        // reads a fresh ledger. Both fail loud (the catch below → 502): a buyer must
+        // never get a discount without the matching credit grant.
+        const paidTopupsCents = await sumSucceededTopupsForCustomer(identity, customer.id);
+        await settleWelcomeCompletion(orgId, paidTopupsCents);
+        const offer = await decideCheckoutWelcomeOffer(
+          orgId,
+          paidTopupsCents,
+          topup_amount_cents!
+        );
+
         // payment mode (hosted or embedded) — topup_amount_cents is guaranteed present
         // by the 400 guard above (non-setup + undefined already returned). The `!`
         // reflects that proven invariant; it is not a fallback.
@@ -92,6 +116,17 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
           // PaymentIntents and are NOT invoiced by this — separate future work.
           invoice_creation: { enabled: true },
         };
+        if (offer.applyDiscount) {
+          // Advance the whole $25 free-credit entitlement as a visible discount.
+          // Gated on a >= $50 checkout, so the buyer still pays >= $25 (which EARNS
+          // the completion) and the charge can never reach $0. The credit that lands
+          // is (payment) + (welcome) + (completion) = exactly the amount configured.
+          body.discounts = [{ coupon: offer.couponId! }];
+        } else if (offer.showNotice) {
+          // No discount on this checkout: tell the buyer the gift is still coming,
+          // so the promise is visible at the moment of payment.
+          body.custom_text = { submit: { message: WELCOME_COMPLETION_CHECKOUT_NOTICE } };
+        }
         if (isEmbedded) {
           // Embedded Checkout: mounted in an in-app modal iframe. No redirect URLs —
           // Stripe keeps the flow in-app (redirect_on_completion:"never") and returns a
@@ -102,12 +137,10 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
         } else {
           body.success_url = success_url;
           body.cancel_url = cancel_url;
-          // Hosted payment-mode top-up only: show Stripe's native "Add promotion code"
-          // field so a user can enter a valid Stripe promotion code (e.g. a 100%-off comp)
-          // and have the discount applied at pay time. Only valid codes do anything; credit
-          // still derives from the amount Stripe receives (a $0 checkout lands $0 credit).
-          // Deliberately NOT set for setup mode or embedded checkout (out of scope).
-          body.allow_promotion_codes = true;
+          // NOTE: `allow_promotion_codes` is deliberately NOT set. Stripe's native
+          // "Add promotion code" entry was enabled for a single journalist comp; that
+          // is done, and it is mutually exclusive with the pre-applied welcome
+          // discount above. Do not re-add it.
         }
       }
       session = await createCheckoutSession(identity, body);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -39,6 +39,19 @@ export const BillingAccountSchema = z
     org_id: z.string().uuid(),
     /** Lifetime credits added: stripe-service paid topups + sum(local_promos). */
     credited_cents: CentsStringSchema,
+    /**
+     * Money the org actually PAID: succeeded Stripe payments net of refunds and
+     * lost disputes. Ready to render, no browser-side arithmetic.
+     */
+    credited_paid_cents: CentsStringSchema.openapi({
+      description:
+        "Money the org actually paid us: SUM of succeeded Stripe payments NET of refunds and lost disputes. Together with credited_gifted_cents this decomposes credited_cents (credited_cents === credited_paid_cents + credited_gifted_cents), so a client can show 'credit paid' vs 'credits gifted' without computing money.",
+    }),
+    /** Credits GIFTED to the org: SUM(local_promos) — welcome, welcome-completion, matches, invite + staff grants, redeemed promos. */
+    credited_gifted_cents: CentsStringSchema.openapi({
+      description:
+        "Credits we gave the org: SUM(local_promos) — signup welcome gift, welcome-completion gift, first-load match, invite grants, staff grants and redeemed promo codes. The other half of credited_cents alongside credited_paid_cents.",
+    }),
     /** Lifetime platform usage from runs-service /internal/org-usage-total. */
     usage_cents: UsageCentsSchema,
     /** Spendable funds = credited_cents − usage_cents. Use this for depletion/budget gates. */
@@ -694,7 +707,9 @@ registry.registerPath({
     "mode='payment' (default) charges topup_amount_cents as a one-shot top-up and does not configure auto-topup. " +
     "mode='setup' creates a no-charge Checkout that saves a reusable off-session card (for enabling auto-topup); topup_amount_cents is omitted and no topup amount is written. " +
     "EMBEDDED (ui_mode='embedded'): Stripe Embedded Checkout for an in-app modal — no success_url/cancel_url, returns a `client_secret` the front-end mounts in an iframe; always charges topup_amount_cents (payment-only). " +
-    "Credit + first-load match land via the existing checkout.session.completed webhook in all modes.",
+    "Credit + first-load match land via the existing checkout.session.completed webhook in all modes. " +
+    "FREE CREDITS: payment-mode checkouts carry the '$25 in free credits' offer. On an org's FIRST-EVER payment of at least $50 the whole $25 is advanced as a visible pre-applied Stripe discount (buyer pays $50 minus $25, and the credit that lands is still the full $50). Otherwise the page shows a notice that the remainder arrives once cumulative payments reach $25. " +
+    "User-entered promotion codes are NOT offered (allow_promotion_codes is never set) — they are mutually exclusive with the pre-applied discount.",
   request: {
     headers: protectedHeaders,
     body: {

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -14,6 +14,7 @@ import {
   INVITE_WELCOME_CODE,
   FIRST_LOAD_MATCH_CODE,
   ADMIN_GRANT_CODE,
+  WELCOME_COMPLETION_CODE,
   type CreditDepletionEpisode,
   type CampaignAuthorizeCost,
 } from "../../src/db/schema.js";
@@ -24,6 +25,7 @@ const SEEDED_PROMO_CODES = [
   INVITE_WELCOME_CODE,
   FIRST_LOAD_MATCH_CODE,
   ADMIN_GRANT_CODE,
+  WELCOME_COMPLETION_CODE,
 ];
 
 export async function cleanTestData() {
@@ -41,16 +43,31 @@ export async function cleanTestData() {
     .where(notInArray(localPromoCodes.code, SEEDED_PROMO_CODES));
   await db
     .insert(localPromoCodes)
-    .values({
-      code: FIRST_LOAD_MATCH_CODE,
-      amountCents: 0,
-      maxRedemptions: null,
-      expiresAt: null,
-    })
+    .values([
+      {
+        code: FIRST_LOAD_MATCH_CODE,
+        amountCents: 0,
+        maxRedemptions: null,
+        expiresAt: null,
+      },
+      {
+        code: WELCOME_COMPLETION_CODE,
+        amountCents: 0,
+        maxRedemptions: null,
+        expiresAt: null,
+      },
+    ])
     .onConflictDoUpdate({
       target: localPromoCodes.code,
       set: { amountCents: 0 },
     });
+}
+
+/** Delete the welcome-completion ledger key — exercises the fail-loud / no-discount path. */
+export async function removeWelcomeCompletionCode() {
+  await db
+    .delete(localPromoCodes)
+    .where(eq(localPromoCodes.code, WELCOME_COMPLETION_CODE));
 }
 
 /** Insert a depletion episode directly (lets tests back-date started_at). */
@@ -96,10 +113,20 @@ export async function listEpisodes(orgId: string): Promise<CreditDepletionEpisod
     .where(eq(creditDepletionEpisodes.orgId, orgId));
 }
 
+/**
+ * Insert a billing account fixture.
+ *
+ * `welcomeCompletionEligible` defaults to FALSE: a hand-inserted fixture stands in
+ * for an org that already existed (exactly like the prod accounts migration 0029
+ * marked ineligible), so paid-topup mocks in unrelated suites never trip the
+ * welcome-completion grant and shift their credited totals. Pass `true` to
+ * exercise the gift.
+ */
 export async function insertTestAccount(data: {
   orgId: string;
   topupAmountCents?: number;
   topupThresholdCents?: number;
+  welcomeCompletionEligible?: boolean;
 }) {
   const [account] = await db
     .insert(billingAccounts)
@@ -107,6 +134,7 @@ export async function insertTestAccount(data: {
       orgId: data.orgId,
       topupAmountCents: data.topupAmountCents ?? null,
       topupThresholdCents: data.topupThresholdCents ?? 200,
+      welcomeCompletionEligible: data.welcomeCompletionEligible ?? false,
     })
     .returning();
   return account;

--- a/tests/integration/accounts.test.ts
+++ b/tests/integration/accounts.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import request from "supertest";
 import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
-import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
+import {
+  cleanTestData,
+  insertTestAccount,
+  insertTestPromoGrant,
+  closeDb,
+} from "../helpers/test-db.js";
 import {
   setupStripeMocks,
   customerWithDefaultPM,
@@ -281,7 +286,17 @@ describe("Accounts endpoints", () => {
       //
       // Numbers mirror the prod repro org 5fefaf5a…: gross usage $65.40, NET usage
       // $53.16 (Overview "Total spent"); gross actualized $33.24, NET actualized $27.84.
-      // Auto-create grants the $5 welcome bonus; paid topups seed the rest of credited.
+      // The $5 welcome bonus is seeded explicitly (rather than via auto-create) on a
+      // welcome-completion-INELIGIBLE account, so this stays a pure NET-usage test:
+      // an ELIGIBLE org with $67 of payments would also earn the $20 completion gift,
+      // which is covered in welcome-completion.test.ts.
+      await insertTestAccount({ orgId });
+      await insertTestPromoGrant({
+        orgId,
+        userId,
+        amountCents: 500,
+        promoCode: "welcome",
+      });
       ssMocks.hasAttachedCardPm.mockResolvedValue(false);
       ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("6700.0000000000");
       fetchRunsOrgUsageTotalSpy.mockResolvedValue({

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -66,12 +66,19 @@ describe("POST /v1/checkout-sessions", () => {
           setup_future_usage: "off_session",
         },
         invoice_creation: { enabled: true },
-        allow_promotion_codes: true,
+        // Auto-created account is eligible and has only the $5 welcome, so the
+        // "rest is coming" notice rides along (below the $50 discount floor).
+        custom_text: {
+          submit: {
+            message:
+              "You get $25 in free credits. $5 now, the rest once your payments reach $25.",
+          },
+        },
       }
     );
   });
 
-  it("hosted payment-mode: offers Stripe promotion-code entry (allow_promotion_codes:true)", async () => {
+  it("hosted payment-mode: does NOT offer Stripe promotion-code entry", async () => {
     ssMocks.createCheckoutSession.mockResolvedValue({
       url: "https://checkout.stripe.com/pay/cs_abc",
       session_id: "cs_abc",
@@ -87,7 +94,7 @@ describe("POST /v1/checkout-sessions", () => {
       });
 
     const sentBody = ssMocks.createCheckoutSession.mock.calls[0][1];
-    expect(sentBody.allow_promotion_codes).toBe(true);
+    expect(sentBody).not.toHaveProperty("allow_promotion_codes");
   });
 
   it("resolves Stripe customer before creating checkout session", async () => {
@@ -216,8 +223,10 @@ describe("POST /v1/checkout-sessions", () => {
     expect(sentBody).not.toHaveProperty("line_items");
     expect(sentBody).not.toHaveProperty("payment_intent_data");
     expect(sentBody).not.toHaveProperty("invoice_creation");
-    // Promotion-code entry is hosted-payment-only; never on a no-charge setup session.
+    // No charge → no free-credit offer surface, and never promotion-code entry.
     expect(sentBody).not.toHaveProperty("allow_promotion_codes");
+    expect(sentBody).not.toHaveProperty("custom_text");
+    expect(sentBody).not.toHaveProperty("discounts");
   });
 
   it("setup-mode: does NOT write a topup amount to the account", async () => {
@@ -319,13 +328,21 @@ describe("POST /v1/checkout-sessions", () => {
           setup_future_usage: "off_session",
         },
         invoice_creation: { enabled: true },
+        // The free-credit offer is org-scoped, not surface-scoped, so embedded
+        // checkout carries the same notice/discount as hosted.
+        custom_text: {
+          submit: {
+            message:
+              "You get $25 in free credits. $5 now, the rest once your payments reach $25.",
+          },
+        },
       }
     );
     // No redirect URLs on an embedded session.
     const sentBody = ssMocks.createCheckoutSession.mock.calls[0][1];
     expect(sentBody).not.toHaveProperty("success_url");
     expect(sentBody).not.toHaveProperty("cancel_url");
-    // Promotion-code entry is hosted-only; embedded checkout is out of scope.
+    // User-entered promotion codes are never offered on any surface.
     expect(sentBody).not.toHaveProperty("allow_promotion_codes");
   });
 

--- a/tests/integration/welcome-completion.test.ts
+++ b/tests/integration/welcome-completion.test.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import {
+  cleanTestData,
+  closeDb,
+  insertTestAccount,
+  insertTestPromoGrant,
+  removeWelcomeCompletionCode,
+} from "../helpers/test-db.js";
+import { setupStripeMocks } from "../helpers/mock-stripe.js";
+import * as runsClient from "../../src/lib/runs-client.js";
+import { db } from "../../src/db/index.js";
+import { localPromoCodes, localPromos, WELCOME_COMPLETION_CODE } from "../../src/db/schema.js";
+import {
+  settleWelcomeCompletion,
+  WelcomeCompletionPromoCodeMissingError,
+  WELCOME_COMPLETION_CHECKOUT_NOTICE,
+} from "../../src/lib/welcome-completion.js";
+import { runWelcomeCompletionSweep } from "../../src/lib/welcome-completion-sweep.js";
+
+const COUPON_ID = "coupon_welcome25";
+const orgId = "00000000-0000-0000-0000-0000000000c1";
+const userId = "00000000-0000-0000-0000-0000000000c2";
+
+/** Every completion row for the org, so tests can assert exactly-once. */
+async function completionRows(org: string) {
+  return db
+    .select({ amountCents: localPromos.amountCents, description: localPromos.description })
+    .from(localPromos)
+    .innerJoin(localPromoCodes, eq(localPromos.promoCodeId, localPromoCodes.id))
+    .where(eq(localPromoCodes.code, WELCOME_COMPLETION_CODE));
+}
+
+/** An eligible org that already carries the $5 signup welcome gift. */
+async function newPayingOrg(paidTopupsCents: string, ssMocks: ReturnType<typeof setupStripeMocks>) {
+  await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+  await insertTestPromoGrant({ orgId, userId, amountCents: 500, promoCode: "welcome" });
+  ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue(paidTopupsCents);
+  ssMocks.sumSucceededTopupsForOrg.mockResolvedValue(paidTopupsCents);
+}
+
+describe("welcome-completion gift ($25 total free credits)", () => {
+  const app = createTestApp();
+  let ssMocks: ReturnType<typeof setupStripeMocks>;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    ssMocks = setupStripeMocks();
+    await cleanTestData();
+    process.env.WELCOME_DISCOUNT_COUPON_ID = COUPON_ID;
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockResolvedValue({
+      spent_cents: "0.0000000000",
+    } as never);
+    vi.spyOn(runsClient, "fetchRunsOrgActualUsageTotal").mockResolvedValue({
+      spent_cents: "0.0000000000",
+    } as never);
+  });
+
+  afterAll(async () => {
+    delete process.env.WELCOME_DISCOUNT_COUPON_ID;
+    await cleanTestData();
+    await closeDb();
+  });
+
+  // --- AC1 / AC2: the gift lands, derived from what the org was actually gifted ---
+
+  it("AC1: $50 first checkout is discounted $25, the buyer pays $25, credit lands at $50", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    await insertTestPromoGrant({ orgId, userId, amountCents: 500, promoCode: "welcome" });
+    // Never paid yet at checkout-create time.
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/pay/cs_x",
+      session_id: "cs_x",
+    });
+
+    await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        success_url: "https://example.com/s",
+        cancel_url: "https://example.com/c",
+        topup_amount_cents: 5000,
+      });
+
+    const body = ssMocks.createCheckoutSession.mock.calls[0][1];
+    // Visible $25 off, and no notice (Stripe renders the discount line itself).
+    expect(body.discounts).toEqual([{ coupon: COUPON_ID }]);
+    expect(body).not.toHaveProperty("custom_text");
+    // Full $50 is still the line item — Stripe applies the discount at pay time.
+    expect(body.line_items[0].price_data.unit_amount).toBe(5000);
+
+    // Buyer pays the discounted $25 → the completion is earned.
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("2500.0000000000");
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+
+    expect(res.status).toBe(200);
+    expect(res.body.credited_paid_cents).toBe("2500.0000000000");
+    expect(res.body.credited_gifted_cents).toBe("2500.0000000000");
+    expect(res.body.credited_cents).toBe("5000.0000000000");
+    expect(res.body.balance_cents).toBe("5000.0000000000");
+  });
+
+  it("AC2: $32 first checkout gets no discount and $57 of credit (gift on top)", async () => {
+    await newPayingOrg("3200.0000000000", ssMocks);
+
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+
+    expect(res.body.credited_paid_cents).toBe("3200.0000000000");
+    // $5 welcome + $20 completion = the full $25 entitlement.
+    expect(res.body.credited_gifted_cents).toBe("2500.0000000000");
+    expect(res.body.credited_cents).toBe("5700.0000000000");
+  });
+
+  it("completion amount is DERIVED from grants, not a hardcoded $20 (no welcome row → full $25)", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("2500.0000000000");
+
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+
+    expect(res.body.credited_gifted_cents).toBe("2500.0000000000");
+    expect((await completionRows(orgId))[0].amountCents).toBe("2500.0000000000");
+  });
+
+  it("a re-priced welcome ($10) leaves a $15 completion — entitlement stays $25", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    await insertTestPromoGrant({ orgId, userId, amountCents: 1000, promoCode: "welcome" });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("2500.0000000000");
+
+    await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+
+    expect((await completionRows(orgId))[0].amountCents).toBe("1500.0000000000");
+  });
+
+  it("an org already gifted its full $25 receives no completion", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    await insertTestPromoGrant({ orgId, userId, amountCents: 2500, promoCode: "invite_welcome" });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("9000.0000000000");
+
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+
+    expect(await completionRows(orgId)).toHaveLength(0);
+    expect(res.body.credited_gifted_cents).toBe("2500.0000000000");
+  });
+
+  // --- AC3: below the trigger, nothing lands; it lands later, automatically ---
+
+  it("AC3: $8 first checkout gets no discount, no gift; the gift lands once payments reach $25", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    await insertTestPromoGrant({ orgId, userId, amountCents: 500, promoCode: "welcome" });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/pay/cs_x",
+      session_id: "cs_x",
+    });
+
+    await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        success_url: "https://example.com/s",
+        cancel_url: "https://example.com/c",
+        topup_amount_cents: 800,
+      });
+
+    const body = ssMocks.createCheckoutSession.mock.calls[0][1];
+    // Below the $50 floor → no discount, but the promise is shown.
+    expect(body).not.toHaveProperty("discounts");
+    expect(body.custom_text).toEqual({
+      submit: { message: WELCOME_COMPLETION_CHECKOUT_NOTICE },
+    });
+
+    // $8 paid: $13 of credit, no gift yet.
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("800.0000000000");
+    let res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+    expect(res.body.credited_cents).toBe("1300.0000000000");
+    expect(await completionRows(orgId)).toHaveLength(0);
+
+    // Cumulative payments reach $25 → the completion lands on its own.
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("2500.0000000000");
+    res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+    expect(res.body.credited_gifted_cents).toBe("2500.0000000000");
+    expect(await completionRows(orgId)).toHaveLength(1);
+  });
+
+  it("$24.99 of payments does not earn it; $25.00 exactly does", async () => {
+    await newPayingOrg("2499.0000000000", ssMocks);
+    await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+    expect(await completionRows(orgId)).toHaveLength(0);
+
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("2500.0000000000");
+    await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+    expect(await completionRows(orgId)).toHaveLength(1);
+  });
+
+  // --- AC4: only the FIRST checkout can be discounted ---
+
+  it("AC4: a second / third / tenth top-up by an already-paying org is never discounted", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/pay/cs_x",
+      session_id: "cs_x",
+    });
+
+    for (const paid of ["100.0000000000", "5000.0000000000", "100000.0000000000"]) {
+      ssMocks.createCheckoutSession.mockClear();
+      ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue(paid);
+      await request(app)
+        .post("/v1/checkout-sessions")
+        .set(getAuthHeaders(orgId))
+        .send({
+          success_url: "https://example.com/s",
+          cancel_url: "https://example.com/c",
+          topup_amount_cents: 20000,
+        });
+      const body = ssMocks.createCheckoutSession.mock.calls[0][1];
+      expect(body).not.toHaveProperty("discounts");
+    }
+  });
+
+  it("a $49.99 first checkout is not discounted (floor would push the charge under $25)", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/pay/cs_x",
+      session_id: "cs_x",
+    });
+
+    await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        success_url: "https://example.com/s",
+        cancel_url: "https://example.com/c",
+        topup_amount_cents: 4999,
+      });
+
+    const body = ssMocks.createCheckoutSession.mock.calls[0][1];
+    expect(body).not.toHaveProperty("discounts");
+    expect(body.custom_text).toEqual({
+      submit: { message: WELCOME_COMPLETION_CHECKOUT_NOTICE },
+    });
+  });
+
+  it("the discount is withheld when the completion could not be granted (missing ledger key)", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/pay/cs_x",
+      session_id: "cs_x",
+    });
+    await removeWelcomeCompletionCode();
+
+    await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        success_url: "https://example.com/s",
+        cancel_url: "https://example.com/c",
+        topup_amount_cents: 5000,
+      });
+
+    const body = ssMocks.createCheckoutSession.mock.calls[0][1];
+    expect(body).not.toHaveProperty("discounts");
+  });
+
+  it("the discount is withheld when no coupon is configured", async () => {
+    delete process.env.WELCOME_DISCOUNT_COUPON_ID;
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/pay/cs_x",
+      session_id: "cs_x",
+    });
+
+    await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        success_url: "https://example.com/s",
+        cancel_url: "https://example.com/c",
+        topup_amount_cents: 5000,
+      });
+
+    const body = ssMocks.createCheckoutSession.mock.calls[0][1];
+    expect(body).not.toHaveProperty("discounts");
+    expect(body.custom_text).toEqual({
+      submit: { message: WELCOME_COMPLETION_CHECKOUT_NOTICE },
+    });
+  });
+
+  it("an ineligible org sees neither a discount nor the notice (the gift is not coming)", async () => {
+    await insertTestAccount({ orgId }); // welcomeCompletionEligible defaults false
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("0.0000000000");
+    ssMocks.createCheckoutSession.mockResolvedValue({
+      url: "https://checkout.stripe.com/pay/cs_x",
+      session_id: "cs_x",
+    });
+
+    await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        success_url: "https://example.com/s",
+        cancel_url: "https://example.com/c",
+        topup_amount_cents: 5000,
+      });
+
+    const body = ssMocks.createCheckoutSession.mock.calls[0][1];
+    expect(body).not.toHaveProperty("discounts");
+    expect(body).not.toHaveProperty("custom_text");
+  });
+
+  // --- AC5: exactly once, under replay + concurrency ---
+
+  it("AC5: replaying the same payment grants the completion exactly once", async () => {
+    await newPayingOrg("2500.0000000000", ssMocks);
+
+    await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+    await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+
+    expect(await completionRows(orgId)).toHaveLength(1);
+    expect(res.body.credited_gifted_cents).toBe("2500.0000000000");
+  });
+
+  it("concurrent settles grant the completion exactly once", async () => {
+    await newPayingOrg("2500.0000000000", ssMocks);
+
+    const outcomes = await Promise.all([
+      settleWelcomeCompletion(orgId, "2500.0000000000"),
+      settleWelcomeCompletion(orgId, "2500.0000000000"),
+      settleWelcomeCompletion(orgId, "2500.0000000000"),
+    ]);
+
+    expect(outcomes.filter((o) => o.granted)).toHaveLength(1);
+    expect(await completionRows(orgId)).toHaveLength(1);
+  });
+
+  // --- AC8: no backfill ---
+
+  it("AC8: an ineligible (pre-existing) org never receives a completion grant", async () => {
+    await insertTestAccount({ orgId }); // ineligible, like every prod org at ship time
+    await insertTestPromoGrant({ orgId, userId, amountCents: 200, promoCode: "welcome" });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("100000.0000000000");
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("100000.0000000000");
+
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+    const sweep = await runWelcomeCompletionSweep();
+
+    expect(await completionRows(orgId)).toHaveLength(0);
+    expect(sweep.granted).toBe(0);
+    // Untouched: still the old $2-era welcome row only.
+    expect(res.body.credited_gifted_cents).toBe("200.0000000000");
+  });
+
+  // --- The server-side driver ---
+
+  it("the hourly sweep grants the completion with no request traffic at all", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    await insertTestPromoGrant({ orgId, userId, amountCents: 500, promoCode: "welcome" });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("2500.0000000000");
+
+    const first = await runWelcomeCompletionSweep();
+    expect(first.candidates).toBe(1);
+    expect(first.granted).toBe(1);
+    expect((await completionRows(orgId))[0].amountCents).toBe("2000.0000000000");
+
+    // Granted orgs drop out of the candidate set permanently.
+    const second = await runWelcomeCompletionSweep();
+    expect(second.candidates).toBe(0);
+    expect(second.granted).toBe(0);
+  });
+
+  it("the sweep isolates a per-org failure and keeps going", async () => {
+    const otherOrg = "00000000-0000-0000-0000-0000000000c9";
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    await insertTestAccount({ orgId: otherOrg, welcomeCompletionEligible: true });
+    ssMocks.sumSucceededTopupsForOrg.mockImplementation(async (org: string) => {
+      if (org === orgId) throw new Error("stripe-service down");
+      return "2500.0000000000";
+    });
+
+    const result = await runWelcomeCompletionSweep();
+
+    expect(result.failed).toBe(1);
+    expect(result.granted).toBe(1);
+  });
+
+  it("fails loud when the ledger key is missing — never silently skips the grant", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    await removeWelcomeCompletionCode();
+
+    await expect(settleWelcomeCompletion(orgId, "2500.0000000000")).rejects.toThrow(
+      WelcomeCompletionPromoCodeMissingError
+    );
+  });
+
+  it("propagates the missing-ledger-key failure to the account read as a 502", async () => {
+    await insertTestAccount({ orgId, welcomeCompletionEligible: true });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("2500.0000000000");
+    await removeWelcomeCompletionCode();
+
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+
+    expect(res.status).toBe(502);
+  });
+
+  // --- AC7: the paid / gifted split is served, never computed client-side ---
+
+  it("AC7: credited_cents decomposes exactly into credited_paid_cents + credited_gifted_cents", async () => {
+    await insertTestAccount({ orgId });
+    await insertTestPromoGrant({ orgId, userId, amountCents: 2500, promoCode: "welcome" });
+    ssMocks.sumSucceededTopupsForCustomer.mockResolvedValue("700.0000000000");
+
+    const res = await request(app).get("/v1/accounts").set(getAuthHeaders(orgId));
+
+    // Kevin's requested view: "Credit paid Stripe $7 / Welcome credits $25".
+    expect(res.body.credited_paid_cents).toBe("700.0000000000");
+    expect(res.body.credited_gifted_cents).toBe("2500.0000000000");
+    expect(res.body.credited_cents).toBe("3200.0000000000");
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -31,6 +31,9 @@ beforeAll(async () => {
     )
   `;
   await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_billing_accounts_org_id" ON "billing_accounts" ("org_id")`;
+  // Welcome-completion eligibility (migration 0029). DEFAULT true = a brand-new org
+  // is eligible; 0029 flipped pre-existing prod accounts to false (no backfill).
+  await sql`ALTER TABLE "billing_accounts" ADD COLUMN IF NOT EXISTS "welcome_completion_eligible" boolean NOT NULL DEFAULT true`;
 
   // Drop legacy columns if a stale local DB still has them.
   await sql`ALTER TABLE "billing_accounts" DROP COLUMN IF EXISTS "balance_cents"`;
@@ -174,7 +177,8 @@ beforeAll(async () => {
     VALUES ('invite_reward', 2500, NULL, NULL),
            ('invite_welcome', 2500, NULL, NULL),
            ('first_load_match', 0, NULL, NULL),
-           ('admin_grant', 0, NULL, NULL)
+           ('admin_grant', 0, NULL, NULL),
+           ('welcome_completion', 0, NULL, NULL)
     ON CONFLICT ("code") DO UPDATE SET "amount_cents" = EXCLUDED."amount_cents"
   `;
 


### PR DESCRIPTION
## What

Automates the **$25 of free credits** onboarding promises, and makes the promise visible at the moment of payment.

Prod today: across 88 billing accounts there are **zero** automatic grants of the completion gift, and the ledger key does not exist in the prod DB at all. Kevin has been granting the missing $20 by hand, four times so far ("Welcome credits (2/2)").

## The rule

An org receives **$25 in free credits IN TOTAL**, welcome gift included.

- The completion amount is **DERIVED** — `entitlement − SUM(local_promos)` — never a hardcoded $20. A re-priced $10 welcome leaves a $15 completion; an org with no welcome row gets the full $25; an org already gifted $25 gets nothing. (The welcome amount has moved three times: 0018 → 0019 → 0028.)
- It is **EARNED when cumulative SUCCEEDED payments reach $25**, net of refunds and lost disputes. The trigger is money actually received, **not usage consumed**: the account model is threshold-postpaid, so an org can consume on credit before paying anything, and we must not gift credits to someone whose card may still fail.

| First checkout | Charged | Gift | Credit available |
|---|---|---|---|
| $50 | $25 | now | $50 |
| $60 | $35 | now | $60 |
| $32 | $32 | now (payment already ≥ $25) | $57 |
| $8 | $8 | later, at $25 cumulative | $13, then +$20 |

All four are covered by tests.

## Who drives the grant (never the browser)

Nothing pushes into billing when a Checkout payment lands — stripe-service only mirrors the PaymentIntent. So `settleWelcomeCompletion` runs from every path that **already holds** the org's paid-topups sum (`composeAccountFunds`, the checkout route) plus, unconditionally, a new **hourly sweep** on the existing dunning scheduler.

A request can only make an already-**earned** grant land sooner; the condition derives entirely from Stripe's record of money received plus billing's own ledger, so nothing a caller asserts can conjure a grant. The sweep is what makes the guarantee unconditional (an org that pays and never opens the app still gets its credit, and a failed settle retries next tick).

`computeBalance` deliberately does **not** settle — `GET /internal/campaigns/:id/affordability` stays documented-side-effect-free and `authorize` stays thin.

**Exactly-once** rides the existing partial unique index `idx_local_promos_org_promo … WHERE idempotency_key IS NULL`. No new idempotency state.

## The $25 discount on the first checkout

`discounts: [{ coupon }]` on payment-mode sessions. Every gate is load-bearing:

| Gate | Why |
|---|---|
| org has **never paid** | otherwise every later top-up silently gets $25 off forever |
| checkout ≥ **$50** | a $25 discount must not push the payment below the $25 that **earns** the gift. At $50 the buyer pays exactly $25 → trigger satisfied → credit = payment + welcome + completion = the $50 configured. Also why the charge can never reach $0. |
| entitlement remaining > 0, org eligible | no advance owed / would short-change |
| coupon configured **and** ledger key seeded | makes it structurally impossible for the discount to land without the grant being possible |

Without the discount the buyer pays full and gets $25 on top; with it they pay $25 and land at $50. Both honor "$25 free".

## No backfill

Explicit product decision. `billing_accounts.welcome_completion_eligible` defaults **true** (a brand-new org is eligible); migration 0029 flipped every account that existed at ship time to **false**. **Verified on a fork of production:** 88/88 marked ineligible, **106 grant rows untouched**, and an idempotent re-apply does not demote a later signup (cutoff is a literal timestamp, not `now()`).

## Checkout page copy

Shown via `custom_text.submit.message` when no discount applies, verbatim as approved (no em-dash):

> You get $25 in free credits. $5 now, the rest once your payments reach $25.

Withheld from an ineligible org and from one already gifted $25 — it would be a lie.

`allow_promotion_codes` is **removed**. It was enabled for one journalist comp (done), and Stripe makes user-entered promotion codes mutually exclusive with a pre-applied discount.

---

## Dashboard contract (need 5) — the deployed shape

`GET /v1/accounts` now serves both halves of `credited_cents` as ready values. **No money arithmetic in the browser.**

```jsonc
{
  "credited_cents":        "3200.0000000000",  // unchanged
  "credited_paid_cents":   "700.0000000000",   // → "Credit paid Stripe  $7"
  "credited_gifted_cents": "2500.0000000000"   // → "Welcome credits    $25"
}
```

Invariant: `credited_cents === credited_paid_cents + credited_gifted_cents`.

- `credited_paid_cents` — succeeded Stripe payments **net of refunds and lost disputes**.
- `credited_gifted_cents` — `SUM(local_promos)`: signup welcome, welcome-completion, first-load match, invite grants, staff grants, redeemed promo codes.

Both are `numeric(16,10)` strings, same convention as every other cents field on this endpoint. Also documented in `openapi.json`.

## Ops

- **Stripe coupon created (live):** `Ez1ybmbf` — "Welcome credits ($25 off)", `amount_off: 2500`, `usd`, `duration: once`.
- **`WELCOME_DISCOUNT_COUPON_ID` set on production billing-service** as `${{shared.WELCOME_DISCOUNT_COUPON_ID}}`, shared bucket → `Ez1ybmbf`. Verified raw + rendered.
- **Not set on staging on purpose:** stripe-service has **no staging runtime** and billing-service staging carries no `STRIPE_SERVICE_URL`, so the checkout path cannot run there; the coupon is live-mode and pointing staging at it would be wrong. Staging is a code waypoint; the discount is verified after the prod promote.

## Tests

`31 files / 370 tests green.` New `tests/integration/welcome-completion.test.ts` (20 tests) covers every acceptance criterion: the four worked examples, the $24.99/$25.00 boundary, derived amounts under a re-priced/absent welcome row, no discount on 2nd/3rd/10th top-up, the $49.99 floor, replay + concurrent exactly-once, ineligible orgs never granted, the sweep granting with zero request traffic, per-org failure isolation, and fail-loud on a missing ledger key.

## Noticed, not fixed (out of scope)

`first_load_match` is seeded by **journaled** migration 0023 and was applied in prod, yet the code row is **absent** from the prod DB today — there is a `brand_welcome` row at 2500 (= `FIRST_LOAD_MATCH_CAP_CENTS`) that looks like a hand-rename. If so, `grantFirstLoadMatch` throws in prod and `POST /v1/accounts/wallet_setup` 500s. Worth a look; it is exactly why the discount here is gated on its ledger key existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
