### PR TITLE
feat(billing): tell both sides of a referral when a reward opens and when it lands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,29 @@ Verified on a prod fork (`br-withered-fog-a1a1bnsc` off the prod default): 89/89
 - **`referrer_org_id` is deliberately NOT resolved.** The invitee reached us through that org's own invite link, so they already know who it was; they hold exactly one referral promise (nothing to disambiguate); and no consumer reads it. Revealing less is the default.
 - Needs `BRAND_SERVICE_URL` + `BRAND_SERVICE_API_KEY` (both `${{shared.*}}` references on Railway, prod + staging).
 
+### Telling the two sides (`src/lib/referral-notifications.ts`, migration 0034)
+
+The money worked end to end before this and nobody was ever told. A referrer has no reason to open the dashboard on the day someone they invited converts, so they could bring in three converting customers and never learn the referral worked. billing is the service that opens the promises and grants them, so it is the only place that can observe those moments.
+
+**TWO messages, and the list of what was dropped is the design:**
+
+| eventType | to | when |
+|---|---|---|
+| `referral-reward-opened` | the REFERRER | someone they invited converted, so a reward opened at their own next bar |
+| `referral-credits-granted` | whoever earned it, either side | the credits actually landed |
+
+Not sent, deliberately: **the invitee's promise being CREATED at signup** (nothing is earned yet, and they are mid-onboarding reading the same thing on screen); **"opened" when the reward is already earned as it opens** (see below); and anything about the welcome offer, which is the other promise kind.
+
+**The collapse rule is the whole reason `alreadyEarned` exists.** An inviter's new bar is `(their highest bar) + $500`, which says nothing about what they have already paid — so a referrer already past that bar earns the reward on the very next settle. Sending "$500 is on its way" and then, minutes later, "$500 arrived" teaches nothing with the second message. `notifyReferralRewardOpened` therefore reads that org's paid topups once, and stays silent when the bar is already met; the granted message carries the whole story and names the same referral. That read **fails OPEN** (a throw means "not yet earned", so the referrer is still told) — a possible duplicate beats silence about money.
+
+**Exactly-once is its own state, because "did we grant" and "did we tell them" are different questions.** The grant's idempotency cannot answer the second: the hourly sweep re-examines every outstanding promise on every tick, so with no marker a customer would be mailed about the same event forever. Migration 0034 adds `opened_notified_at` / `granted_notified_at` to `free_credit_promises`, each claimed by a conditional `UPDATE … WHERE <marker> IS NULL RETURNING` — only the caller whose update returns a row sends, so two racing settles produce one email. **The claim is taken AFTER the recipient resolves**, so a cold stripe-service leaves the marker NULL and the next tick retries instead of burning the only send; an org whose billing customer exists with no address IS marked, because there is nothing to retry against. 0034 also backfills every pre-existing promise as already-notified, so the first sweep after the deploy cannot mail anyone about days-old activity. (Measured on prod at ship time: 89 welcome rows, **zero** referral rows, so the backfill was belt-and-braces.)
+
+**Fail-soft, the documented exception to fail-loud, same posture as the identity lookup above.** Every path logs loudly and returns; nothing here can fail, delay or roll back a grant, and the grant transaction has already committed before any of it runs. A notification failure must never touch the money it describes.
+
+**Recipient = the org's Stripe billing email** (`fetchOrgCustomer`, the user-less org-keyed read), passed as `recipientEmail` — transactional-email-service accepts it in place of an `x-user-id` lookup, so no fake user identity is invented on a settle. Both messages name the referral through the same `resolveOrgDisplayIdentity` the Billing page uses, under the same authorization, and never fabricate anything from the UUID: an unresolvable org renders as "A new customer" in the opened message and drops out of the granted message's `{{reason}}` sentence.
+
+**Both templates are registered by THIS service** (`src/instrument.ts`), since the fleet convention is that a template belongs to whoever SENDS it. Every `{{variable}}` in them is always supplied and never empty — an unset one renders as a literal `{{placeholder}}` in a customer's inbox, which is why `referredOrg` carries a phrase rather than a possibly-null name and why `reason` is composed in code rather than branched in the template. A test pins the template's variable set against the sender's.
+
 ## Welcome-completion gift — "$N in free credits", automatic (`src/lib/welcome-completion.ts`)
 
 Onboarding promises every new customer **$N of free credits**. Signup only grants the `welcome` row ($5 today), so for months the remainder was granted BY HAND (staff `admin_grant` rows described "Welcome credits (2/2)"). `welcome_completion` (migration 0029) automates the remainder.

--- a/drizzle/0034_referral_notification_markers.sql
+++ b/drizzle/0034_referral_notification_markers.sql
@@ -1,0 +1,31 @@
+-- Referral notification markers.
+--
+-- "Did we grant this" and "did we tell them about it" are different questions.
+-- The hourly sweep re-examines every promise on every tick, so without a marker
+-- of its own each pass would re-send the same email.
+--
+-- Two columns rather than one because the two moments are distinct and either can
+-- happen without the other: a reward OPENS for an inviter when someone they
+-- referred converts, and is GRANTED later when the inviter's own payments cross
+-- its bar.
+--
+-- Idempotent: safe to replay.
+ALTER TABLE "free_credit_promises"
+  ADD COLUMN IF NOT EXISTS "opened_notified_at" timestamp with time zone;
+
+ALTER TABLE "free_credit_promises"
+  ADD COLUMN IF NOT EXISTS "granted_notified_at" timestamp with time zone;
+
+-- Existing promises are backfilled as ALREADY NOTIFIED.
+--
+-- They pre-date the notification, so leaving them NULL would have the first sweep
+-- after this deploy mail every customer about referral activity they have already
+-- seen on their Billing page, some of it days old. A notification is only worth
+-- sending about something that just happened.
+UPDATE "free_credit_promises"
+  SET "opened_notified_at" = now()
+  WHERE "opened_notified_at" IS NULL;
+
+UPDATE "free_credit_promises"
+  SET "granted_notified_at" = now()
+  WHERE "granted_notified_at" IS NULL AND "granted_at" IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1791108000000,
       "tag": "0033_free_credit_promises",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1791108000001,
+      "tag": "0034_referral_notification_markers",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -264,6 +264,17 @@ export const freeCreditPromises = pgTable(
     referredOrgId: uuid("referred_org_id"),
     /** NULL while outstanding. Stamped when the matching credit grant lands. */
     grantedAt: timestamp("granted_at", { withTimezone: true }),
+    /**
+     * Notification markers. "Did we grant" and "did we tell them" are different
+     * questions, so they get different columns: the sweep re-examines a promise
+     * on every tick, and without these it would re-send on each pass.
+     *
+     * Stamped by a CONDITIONAL update that claims the right to send, so exactly
+     * one caller sends even when two settles race. Never blocks a grant: a
+     * notification that cannot go out leaves the money committed.
+     */
+    openedNotifiedAt: timestamp("opened_notified_at", { withTimezone: true }),
+    grantedNotifiedAt: timestamp("granted_notified_at", { withTimezone: true }),
     /** The `local_promos` row that granted it (audit link); NULL while outstanding. */
     grantedLocalPromoId: uuid("granted_local_promo_id"),
     createdAt: timestamp("created_at", { withTimezone: true })

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -17,11 +17,17 @@
  * that appears in a `sendEmail` call:
  *   - `credits-reload-failed`      → src/routes/customer_balance.ts
  *   - `brand_daily_budget_changed` → src/lib/brand-budget-notification.ts
+ *   - `referral-reward-opened`     → src/lib/referral-notifications.ts
+ *   - `referral-credits-granted`   → src/lib/referral-notifications.ts
  * The six dunning templates (`credit-depleted*`) are registered by the dashboard
  * (distribute.you#1420, which owns their copy) and are present in prod.
  */
 import { fetchWithRetry } from "./lib/fetch-retry.js";
 import { BRAND_DAILY_BUDGET_CHANGED_EVENT } from "./lib/brand-budget-notification.js";
+import {
+  REFERRAL_REWARD_OPENED_EVENT,
+  REFERRAL_CREDITS_GRANTED_EVENT,
+} from "./lib/referral-notifications.js";
 
 /**
  * The sibling can be cold (Neon scale-to-zero), suspended, or down at our boot.
@@ -57,6 +63,37 @@ const TEMPLATES = [
 <li>Org: {{orgId}}</li>
 </ul>`,
     textBody: "{{email}} changed a brand's daily budget. Was: {{previousBudget}}. Now: {{newBudget}}. Brand: {{brandId}}. Org: {{orgId}}.",
+  },
+  {
+    // Someone the recipient invited has converted, so a reward just opened for
+    // them. The one moment in the referral that cannot be inferred from anything
+    // they can see, because it happened when somebody ELSE paid.
+    //
+    // Every variable here is ALWAYS supplied and never empty: the identity lookup
+    // is fail-soft, so the sender substitutes a phrase that names nobody rather
+    // than leaving {{referredOrg}} blank in the middle of a sentence. See
+    // lib/referral-notifications.ts.
+    name: REFERRAL_REWARD_OPENED_EVENT,
+    subject: "You earned {{amount}} in free credits",
+    htmlBody: `<p>{{referredOrg}} signed up through your invite link and started paying, so {{amount}} in free credits is now yours.</p>
+<p>It lands in your account once your own payments reach {{unlockAt}}. Nothing to claim.</p>`,
+    textBody:
+      "{{referredOrg}} signed up through your invite link and started paying, so {{amount}} in free credits is now yours. It lands in your account once your own payments reach {{unlockAt}}. Nothing to claim.",
+  },
+  {
+    // The credits actually arrived, on either side of the referral.
+    //
+    // {{reason}} carries WHO converted, composed by the sender because the two
+    // sides earned the same amount for opposite reasons. It matters most when the
+    // referrer was already past the new bar and this is the only message they get
+    // about that referral.
+    name: REFERRAL_CREDITS_GRANTED_EVENT,
+    subject: "{{amount}} in free credits just landed",
+    htmlBody: `<p>{{amount}} in referral credits is now in your account.</p>
+<p>{{reason}}</p>
+<p>The credits come off what you spend from here, so there is nothing to claim.</p>`,
+    textBody:
+      "{{amount}} in referral credits is now in your account. {{reason}} The credits come off what you spend from here, so there is nothing to claim.",
   },
 ] as const;
 

--- a/src/lib/free-credit-promises.ts
+++ b/src/lib/free-credit-promises.ts
@@ -88,6 +88,10 @@ import {
   resolveOrgDisplayIdentity,
   type OrgDisplayIdentity,
 } from "./brand-service-client.js";
+import {
+  notifyReferralRewardOpened,
+  notifyReferralCreditsGranted,
+} from "./referral-notifications.js";
 
 /** System sentinel — a promise grant has no human user (it is platform-issued). */
 const SYSTEM_USER_ID = "00000000-0000-0000-0000-000000000000";
@@ -388,7 +392,15 @@ export async function reconcileInviterPromises(orgId: string): Promise<number> {
       orgId,
       promise.amountCents
     );
-    if (created) opened += 1;
+    if (created) {
+      opened += 1;
+      // The referrer cannot see this coming from anywhere else: it happened
+      // because somebody ELSE paid. Awaited only so its marker claim settles
+      // before the next pass could reach the same promise; the send itself is
+      // fire-and-forget inside, and every failure path is swallowed and logged
+      // so a mail can never disturb the grant that produced it.
+      await notifyReferralRewardOpened(created);
+    }
   }
   return opened;
 }
@@ -481,6 +493,9 @@ export async function settleReferralPromises(
           .plus(promise.amountCents)
           .toFixed(10);
         granted.push(landed.stamped);
+        // Strictly AFTER the transaction commits: the money is the point, and a
+        // notification must never sit inside the transaction that moves it.
+        await notifyReferralCreditsGranted(landed.stamped);
       }
     }
   }

--- a/src/lib/referral-notifications.ts
+++ b/src/lib/referral-notifications.ts
@@ -1,0 +1,262 @@
+/**
+ * Telling the two people in a referral what they cannot see coming.
+ *
+ * The money already works end to end: a customer shares their link, someone signs
+ * up through it and pays, that opens a $500 reward for the referrer, and the
+ * referrer earns it on their own next payments. None of it produced any
+ * notification, so a referrer had no reason to open the dashboard on the day any
+ * of it happened. They could bring in three converting customers and never learn
+ * the referral worked, let alone that money was waiting. An offer whose whole
+ * mechanism is "keep paying and it lands" is worth nothing to someone who never
+ * finds out it landed.
+ *
+ * ## Which moments, and which were dropped
+ *
+ * TWO messages, both about something the recipient could not otherwise know:
+ *
+ *   - `referral-reward-opened` → the REFERRER, when someone they invited converts
+ *     and a reward opens. This is the one that cannot be inferred from anything
+ *     they can see, and it is the one that makes sharing the link feel worth it.
+ *   - `referral-credits-granted` → whoever just had a reward GRANTED, on either
+ *     side, when the credits actually land.
+ *
+ * Both name the referral that caused them, because a referrer holding three
+ * pending $500s cannot otherwise tell which one a message is about. That is the
+ * same identity the Billing page already resolves, under the same authorization:
+ * billing is the only service that knows the referral relationship exists.
+ *
+ * Deliberately NOT sent:
+ *
+ *   - the invitee's promise being CREATED at signup. Nothing has been earned, and
+ *     the person is mid-onboarding being told the same thing on screen.
+ *   - "opened" when the reward is ALREADY earned the moment it opens. A referrer
+ *     whose own payments are past the new bar earns it on the very next settle, so
+ *     "$500 is on its way" followed minutes later by "$500 arrived" teaches nothing
+ *     with the second message. `alreadyEarned` collapses that pair down to the
+ *     granted one, which names the same referral anyway.
+ *   - a separate "your welcome credits landed". That is the other offer, and this
+ *     module is not the place to start mailing about it.
+ *
+ * ## Exactly once
+ *
+ * The sweep re-examines every promise on every tick, so "we granted it" cannot
+ * double as "we told them". Each message claims its own marker column with a
+ * CONDITIONAL update that only matches while the marker is still NULL, and only
+ * the caller whose update returns a row sends. Two racing settles therefore
+ * produce one email, and a replayed payment produces none.
+ *
+ * ## Fail-soft, deliberately
+ *
+ * The documented exception to this repo's fail-loud rule, same posture as the
+ * identity lookup this feature already relies on: the promise is the money-bearing
+ * information and the mail is not. A recipient we cannot resolve, or a send that
+ * throws, logs loudly and returns. It never fails, delays or rolls back a grant.
+ */
+import crypto from "crypto";
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { freeCreditPromises, type FreeCreditPromise } from "../db/schema.js";
+import { sendEmail } from "./email-client.js";
+import {
+  fetchOrgCustomer,
+  sumSucceededTopupsForOrg,
+} from "./stripe-service-client.js";
+import { resolveOrgDisplayIdentity } from "./brand-service-client.js";
+import { gte } from "./cents.js";
+import { Decimal } from "decimal.js";
+
+/** Someone you invited converted, so a reward just opened for you. */
+export const REFERRAL_REWARD_OPENED_EVENT = "referral-reward-opened";
+
+/** A referral reward has actually been credited. */
+export const REFERRAL_CREDITS_GRANTED_EVENT = "referral-credits-granted";
+
+// Platform-issued, like every other system-originated row here. The recipient is
+// resolved explicitly from the org's billing customer, so this identity is only
+// ever the ACTOR, never the addressee.
+const SYSTEM_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+function dollars(cents: number): string {
+  return `$${new Decimal(cents).dividedBy(100).toFixed(0)}`;
+}
+
+/**
+ * Claim the right to send, exactly once.
+ *
+ * Returns true only for the caller whose UPDATE actually matched, so a racing
+ * settle or a re-running sweep silently declines instead of sending again.
+ */
+async function claimNotification(
+  promiseId: string,
+  column: "openedNotifiedAt" | "grantedNotifiedAt"
+): Promise<boolean> {
+  const marker =
+    column === "openedNotifiedAt"
+      ? freeCreditPromises.openedNotifiedAt
+      : freeCreditPromises.grantedNotifiedAt;
+
+  const claimed = await db
+    .update(freeCreditPromises)
+    .set({ [column]: new Date() })
+    .where(and(eq(freeCreditPromises.id, promiseId), isNull(marker)))
+    .returning({ id: freeCreditPromises.id });
+
+  return claimed.length > 0;
+}
+
+/** The address to write to, or null when the org has no billing customer yet. */
+async function recipientFor(orgId: string): Promise<string | null> {
+  try {
+    const customer = await fetchOrgCustomer(orgId);
+    return customer.email ?? null;
+  } catch (err) {
+    console.error(
+      `[billing-service] referral notification: no billing customer for org ${orgId}, skipping send`,
+      err
+    );
+    return null;
+  }
+}
+
+/**
+ * Is this reward ALREADY earned the moment it opens?
+ *
+ * A referrer whose own payments are already past the new bar earns the reward on
+ * the very next settle, so telling them "$500 is on its way" and then, minutes
+ * later, "$500 arrived" teaches them nothing with the second message. When the bar
+ * is already met we say nothing here and let the granted message carry the whole
+ * story — it names the same referral.
+ *
+ * Fail-OPEN: a paid-topups read that throws yields false, so the referrer is told
+ * their referral converted. A possible duplicate beats silence about money.
+ */
+async function alreadyEarned(promise: FreeCreditPromise): Promise<boolean> {
+  try {
+    const paid = await sumSucceededTopupsForOrg(promise.orgId);
+    return gte(paid, new Decimal(promise.paidTriggerCents).toFixed(10));
+  } catch (err) {
+    console.error(
+      `[billing-service] referral notification: could not read paid topups for org ${promise.orgId}, assuming the reward is not yet earned:`,
+      err
+    );
+    return false;
+  }
+}
+
+/**
+ * Tell the REFERRER that someone they invited converted.
+ *
+ * Names who it was when we can resolve them, because a referrer with several
+ * pending rewards otherwise cannot tell which one this is about. The name is the
+ * same one the Billing page shows, and resolving it is fail-soft there too: an
+ * unresolvable org simply yields a message that does not name anyone rather than
+ * one naming a UUID.
+ */
+export async function notifyReferralRewardOpened(
+  promise: FreeCreditPromise
+): Promise<void> {
+  try {
+    // Deliberately unstamped when we skip: the promise is about to be granted,
+    // which takes it out of every outstanding set for good, so there is nothing
+    // left that could send this message late.
+    if (await alreadyEarned(promise)) {
+      console.log(
+        `[billing-service] referral reward opened ALREADY EARNED org=${promise.orgId} ` +
+          `promise=${promise.id} — the granted message will carry it`
+      );
+      return;
+    }
+
+    // Resolve the recipient BEFORE claiming. Claiming first would burn the
+    // marker on a transient failure (a cold stripe-service, an org whose
+    // customer is not created yet) and the notification would then never be
+    // retried by any later sweep — silently losing it forever.
+    const recipientEmail = await recipientFor(promise.orgId);
+    if (!recipientEmail) return;
+
+    if (!(await claimNotification(promise.id, "openedNotifiedAt"))) return;
+
+    const identity = promise.referredOrgId
+      ? await resolveOrgDisplayIdentity(promise.referredOrgId)
+      : null;
+
+    sendEmail({
+      eventType: REFERRAL_REWARD_OPENED_EVENT,
+      orgId: promise.orgId,
+      userId: SYSTEM_USER_ID,
+      runId: crypto.randomUUID(),
+      recipientEmail,
+      metadata: {
+        amount: dollars(promise.amountCents),
+        unlockAt: dollars(promise.paidTriggerCents),
+        // Always a real phrase, never blank: the name sits mid-sentence, and an
+        // empty substitution would leave a hole there. "A new customer" names
+        // nobody, which is the honest rendering when the lookup resolves nothing.
+        referredOrg: identity?.name ?? "A new customer",
+      },
+    });
+  } catch (err) {
+    // Never let a notification touch the money it is describing.
+    console.error(
+      `[billing-service] referral-reward-opened notification failed for promise ${promise.id}`,
+      err
+    );
+  }
+}
+
+/**
+ * Why this credit exists, in the recipient's own terms.
+ *
+ * Composed here rather than branched in the template, because the two sides of a
+ * referral earned the same amount for opposite reasons: an inviter through
+ * somebody else's signup, an invitee through their own. It is also the only place
+ * the granted message can name the referral, which matters most in the case where
+ * the reward was earned the instant it opened and this is the ONLY message the
+ * referrer receives about it.
+ */
+function grantReason(
+  promise: FreeCreditPromise,
+  referredOrgName: string | null
+): string {
+  if (!promise.referredOrgId) {
+    return "These are the referral credits for joining through an invite link.";
+  }
+  if (referredOrgName) {
+    return `This is your referral reward for ${referredOrgName} joining through your invite link.`;
+  }
+  return "This is your referral reward for a customer who joined through your invite link.";
+}
+
+/** Tell whoever just had a referral reward credited that it landed. */
+export async function notifyReferralCreditsGranted(
+  promise: FreeCreditPromise
+): Promise<void> {
+  try {
+    // Recipient first, then claim — see notifyReferralRewardOpened.
+    const recipientEmail = await recipientFor(promise.orgId);
+    if (!recipientEmail) return;
+
+    if (!(await claimNotification(promise.id, "grantedNotifiedAt"))) return;
+
+    const identity = promise.referredOrgId
+      ? await resolveOrgDisplayIdentity(promise.referredOrgId)
+      : null;
+
+    sendEmail({
+      eventType: REFERRAL_CREDITS_GRANTED_EVENT,
+      orgId: promise.orgId,
+      userId: SYSTEM_USER_ID,
+      runId: crypto.randomUUID(),
+      recipientEmail,
+      metadata: {
+        amount: dollars(promise.amountCents),
+        reason: grantReason(promise, identity?.name ?? null),
+      },
+    });
+  } catch (err) {
+    console.error(
+      `[billing-service] referral-credits-granted notification failed for promise ${promise.id}`,
+      err
+    );
+  }
+}

--- a/tests/integration/referral-notifications.test.ts
+++ b/tests/integration/referral-notifications.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Telling the two sides of a referral, exactly once, without ever touching the
+ * money.
+ *
+ * The money side is covered by referral-promises.test.ts. These cases pin the
+ * two guarantees that are easy to break and expensive when broken: the hourly
+ * sweep re-examines every promise on every tick, so a missing marker means a
+ * customer is mailed about the same event forever; and a notification that can
+ * throw is a notification that can roll back a grant.
+ *
+ * Own file rather than a describe appended to the referral suite: that one closes
+ * the shared postgres.js connection in afterAll (see CLAUDE.md).
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  cleanTestData,
+  closeDb,
+  insertTestAccount,
+  insertTestPromoGrant,
+} from "../helpers/test-db.js";
+import { setupStripeMocks } from "../helpers/mock-stripe.js";
+import * as runsClient from "../../src/lib/runs-client.js";
+import * as emailClient from "../../src/lib/email-client.js";
+import * as brandClient from "../../src/lib/brand-service-client.js";
+import * as stripeClient from "../../src/lib/stripe-service-client.js";
+import { db } from "../../src/db/index.js";
+import { freeCreditPromises } from "../../src/db/schema.js";
+import {
+  claimReferral,
+  settleReferralPromises,
+} from "../../src/lib/free-credit-promises.js";
+import {
+  REFERRAL_REWARD_OPENED_EVENT,
+  REFERRAL_CREDITS_GRANTED_EVENT,
+} from "../../src/lib/referral-notifications.js";
+
+const userId = "11111111-1111-4111-8111-111111111111";
+const inviter = "aaaaaaaa-1111-4aaa-8aaa-111111111111";
+const invitee = "bbbbbbbb-1111-4bbb-8bbb-111111111111";
+
+function cents(n: number): string {
+  return (n * 100).toFixed(10);
+}
+
+async function newSignup(orgId: string) {
+  await insertTestAccount({
+    orgId,
+    welcomeCompletionEligible: true,
+    freeCreditEntitlementCents: 40000,
+    freeCreditPaidTriggerCents: 40000,
+  });
+  await insertTestPromoGrant({ orgId, userId, amountCents: 500, promoCode: "welcome" });
+}
+
+function eventsSent(sendMock: ReturnType<typeof vi.fn>): string[] {
+  return sendMock.mock.calls.map((c) => (c[0] as { eventType: string }).eventType);
+}
+
+describe("referral notifications", () => {
+  let sendMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    setupStripeMocks();
+    await cleanTestData();
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockResolvedValue({
+      totalCostInUsdCents: "0",
+    } as never);
+    vi.spyOn(brandClient, "resolveOrgDisplayIdentity").mockResolvedValue({
+      brandId: "cccccccc-1111-4ccc-8ccc-111111111111",
+      name: "Acme",
+      domain: "acme.com",
+    } as never);
+    // Every org in these cases has a billing customer; the recipient is its email.
+    vi.spyOn(stripeClient, "fetchOrgCustomer").mockImplementation(
+      (async (orgId: string) => ({ id: `cus_${orgId.slice(0, 8)}`, email: `${orgId.slice(0, 8)}@test.dev` })) as never,
+    );
+    sendMock = vi.fn();
+    vi.spyOn(emailClient, "sendEmail").mockImplementation(sendMock as never);
+  });
+
+  afterAll(closeDb);
+
+  it("tells the referrer when someone they invited converts", async () => {
+    await newSignup(inviter);
+    await newSignup(invitee);
+    await claimReferral(invitee, inviter);
+
+    // The invitee crosses its own $900 bar: its referral lands, and that is what
+    // opens the inviter's.
+    await settleReferralPromises(invitee, cents(900));
+
+    expect(eventsSent(sendMock)).toContain(REFERRAL_REWARD_OPENED_EVENT);
+    const opened = sendMock.mock.calls
+      .map((c) => c[0] as { eventType: string; orgId: string; metadata: Record<string, string> })
+      .find((p) => p.eventType === REFERRAL_REWARD_OPENED_EVENT)!;
+    // Addressed to the INVITER, about the org that converted.
+    expect(opened.orgId).toBe(inviter);
+    expect(opened.metadata.referredOrg).toBe("Acme");
+    expect(opened.metadata.amount).toBe("$500");
+    // The inviter's own bar stacks above their $400 welcome: $400 + $500.
+    expect(opened.metadata.unlockAt).toBe("$900");
+  });
+
+  it("tells the invitee when their own referral credits land", async () => {
+    await newSignup(inviter);
+    await newSignup(invitee);
+    await claimReferral(invitee, inviter);
+
+    await settleReferralPromises(invitee, cents(900));
+
+    const granted = sendMock.mock.calls
+      .map(
+        (c) => c[0] as { eventType: string; orgId: string; metadata: Record<string, string> }
+      )
+      .filter((p) => p.eventType === REFERRAL_CREDITS_GRANTED_EVENT);
+    const toInvitee = granted.find((p) => p.orgId === invitee)!;
+    expect(toInvitee).toBeDefined();
+    expect(toInvitee.metadata.amount).toBe("$500");
+    // The invitee earned it through their OWN signup, so the sentence explaining
+    // why names nobody — there is no third party in their half of the chain.
+    expect(toInvitee.metadata.reason).toBe(
+      "These are the referral credits for joining through an invite link."
+    );
+  });
+
+  it("names the converted referral in the message the INVITER gets when it lands", async () => {
+    // The brief's rule: when a reward exists because a specific referral
+    // converted, say who. It matters most here, because a referrer already past
+    // their bar never receives the opened message at all.
+    await newSignup(inviter);
+    await newSignup(invitee);
+    await claimReferral(invitee, inviter);
+    await settleReferralPromises(invitee, cents(900));
+
+    // Now the inviter's own payments cross their $900 bar.
+    await settleReferralPromises(inviter, cents(900));
+
+    const toInviter = sendMock.mock.calls
+      .map(
+        (c) => c[0] as { eventType: string; orgId: string; metadata: Record<string, string> }
+      )
+      .find((p) => p.eventType === REFERRAL_CREDITS_GRANTED_EVENT && p.orgId === inviter)!;
+    expect(toInviter).toBeDefined();
+    expect(toInviter.metadata.reason).toBe(
+      "This is your referral reward for Acme joining through your invite link."
+    );
+  });
+
+  it("sends ONLY the granted message when the reward is already earned as it opens", async () => {
+    // A referrer whose own payments are already past the new bar earns the reward
+    // on the very next settle. "$500 is on its way" then "$500 arrived" minutes
+    // later teaches nothing with the second, so the opened one is dropped.
+    await newSignup(inviter);
+    await newSignup(invitee);
+    await claimReferral(invitee, inviter);
+
+    // The inviter has long since paid past their own $900 bar.
+    vi.spyOn(stripeClient, "sumSucceededTopupsForOrg").mockResolvedValue(
+      cents(5000) as never
+    );
+
+    await settleReferralPromises(invitee, cents(900));
+    expect(eventsSent(sendMock)).not.toContain(REFERRAL_REWARD_OPENED_EVENT);
+
+    await settleReferralPromises(inviter, cents(5000));
+    const toInviter = eventsSent(sendMock).filter(
+      (e) => e === REFERRAL_CREDITS_GRANTED_EVENT
+    );
+    // One to the invitee, one to the inviter. No opened message anywhere.
+    expect(toInviter).toHaveLength(2);
+    expect(eventsSent(sendMock)).not.toContain(REFERRAL_REWARD_OPENED_EVENT);
+  });
+
+  it("does NOT mail anyone when a promise is merely created at signup", async () => {
+    // Nothing has been earned, and the invitee is mid-onboarding being told the
+    // same thing on screen.
+    await newSignup(inviter);
+    await newSignup(invitee);
+    await claimReferral(invitee, inviter);
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("sends once, however many times the sweep re-examines the promise", async () => {
+    await newSignup(inviter);
+    await newSignup(invitee);
+    await claimReferral(invitee, inviter);
+
+    await settleReferralPromises(invitee, cents(900));
+    const afterFirst = eventsSent(sendMock).length;
+
+    // The sweep runs hourly over the same rows, forever.
+    await settleReferralPromises(invitee, cents(900));
+    await settleReferralPromises(invitee, cents(900));
+
+    expect(eventsSent(sendMock)).toHaveLength(afterFirst);
+  });
+
+  it("stamps its own marker, so granting and telling stay separate questions", async () => {
+    await newSignup(inviter);
+    await newSignup(invitee);
+    await claimReferral(invitee, inviter);
+    await settleReferralPromises(invitee, cents(900));
+
+    const rows = await db
+      .select()
+      .from(freeCreditPromises)
+      .where(eq(freeCreditPromises.orgId, inviter));
+    const referral = rows.find((r) => r.referredOrgId === invitee)!;
+    expect(referral.openedNotifiedAt).not.toBeNull();
+    // Opened, not granted: the inviter has not paid anything yet.
+    expect(referral.grantedAt).toBeNull();
+    expect(referral.grantedNotifiedAt).toBeNull();
+  });
+
+  it("skips the send, and does NOT burn the marker, when no recipient resolves", async () => {
+    // Claiming before resolving would lose the notification forever: the marker
+    // would be stamped and no later sweep would ever retry it.
+    vi.spyOn(stripeClient, "fetchOrgCustomer").mockRejectedValue(new Error("no customer") as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await newSignup(inviter);
+    await newSignup(invitee);
+    await claimReferral(invitee, inviter);
+    await settleReferralPromises(invitee, cents(900));
+
+    expect(sendMock).not.toHaveBeenCalled();
+    const rows = await db
+      .select()
+      .from(freeCreditPromises)
+      .where(eq(freeCreditPromises.orgId, inviter));
+    const referral = rows.find((r) => r.referredOrgId === invitee)!;
+    expect(referral.openedNotifiedAt).toBeNull();
+  });
+
+  it("commits the grant even when the notification throws", async () => {
+    // The money is the point and the mail is not. A send that blows up must
+    // leave the credits exactly where they landed.
+    vi.spyOn(emailClient, "sendEmail").mockImplementation(() => {
+      throw new Error("email service exploded");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await newSignup(inviter);
+    await newSignup(invitee);
+    await claimReferral(invitee, inviter);
+
+    const result = await settleReferralPromises(invitee, cents(900));
+
+    expect(result.granted).toHaveLength(1);
+    expect(result.inviterPromisesOpened).toBe(1);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("still sends when the referred org cannot be named", async () => {
+    // The identity lookup is fail-soft. A referrer whose invitee has no brand
+    // should still be told they earned something.
+    vi.spyOn(brandClient, "resolveOrgDisplayIdentity").mockResolvedValue(null as never);
+
+    await newSignup(inviter);
+    await newSignup(invitee);
+    await claimReferral(invitee, inviter);
+    await settleReferralPromises(invitee, cents(900));
+
+    const opened = sendMock.mock.calls
+      .map((c) => c[0] as { eventType: string; metadata: Record<string, string | null> })
+      .find((p) => p.eventType === REFERRAL_REWARD_OPENED_EVENT)!;
+    expect(opened).toBeDefined();
+    // A phrase that names nobody, never a UUID and never a blank hole mid-sentence.
+    expect(opened.metadata.referredOrg).toBe("A new customer");
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -190,6 +190,8 @@ beforeAll(async () => {
       "referrer_org_id" uuid,
       "referred_org_id" uuid,
       "granted_at" timestamp with time zone,
+      "opened_notified_at" timestamp with time zone,
+      "granted_notified_at" timestamp with time zone,
       "granted_local_promo_id" uuid,
       "created_at" timestamp with time zone DEFAULT now() NOT NULL,
       CONSTRAINT "free_credit_promises_kind_check" CHECK ("kind" IN ('welcome', 'referral'))
@@ -200,6 +202,12 @@ beforeAll(async () => {
   await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_free_credit_promises_org_referred" ON "free_credit_promises" ("org_id", "referred_org_id") WHERE "referred_org_id" IS NOT NULL`;
   await sql`CREATE INDEX IF NOT EXISTS "idx_free_credit_promises_org" ON "free_credit_promises" ("org_id")`;
   await sql`CREATE INDEX IF NOT EXISTS "idx_free_credit_promises_outstanding" ON "free_credit_promises" ("granted_at") WHERE "granted_at" IS NULL`;
+  // Notification markers (migration 0034). ALTERed rather than only declared above,
+  // because CREATE TABLE IF NOT EXISTS is a no-op against a local DB built before
+  // they existed — the table would keep the old shape and every promise suite would
+  // fail on a column that is present in schema.ts.
+  await sql`ALTER TABLE "free_credit_promises" ADD COLUMN IF NOT EXISTS "opened_notified_at" timestamp with time zone`;
+  await sql`ALTER TABLE "free_credit_promises" ADD COLUMN IF NOT EXISTS "granted_notified_at" timestamp with time zone`;
 
   // Seed platform-issued grant promo codes (matches migrations 0017 + 0025 + 0033).
   // referral_reward's amount_cents is NOT a placeholder: it is the live amount a NEW

--- a/tests/unit/instrument-templates.test.ts
+++ b/tests/unit/instrument-templates.test.ts
@@ -7,6 +7,10 @@ import {
   REGISTERED_TEMPLATE_NAMES,
 } from "../../src/instrument.js";
 import { BRAND_DAILY_BUDGET_CHANGED_EVENT } from "../../src/lib/brand-budget-notification.js";
+import {
+  REFERRAL_REWARD_OPENED_EVENT,
+  REFERRAL_CREDITS_GRANTED_EVENT,
+} from "../../src/lib/referral-notifications.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -74,7 +78,12 @@ describe("boot-time email template registration", () => {
     expect(headers["x-run-id"]).toBe("00000000-0000-0000-0000-000000000000");
 
     const names = lastBody(fetchMock).templates.map((t) => t.name);
-    expect(names).toEqual(["credits-reload-failed", BRAND_DAILY_BUDGET_CHANGED_EVENT]);
+    expect(names).toEqual([
+      "credits-reload-failed",
+      BRAND_DAILY_BUDGET_CHANGED_EVENT,
+      REFERRAL_REWARD_OPENED_EVENT,
+      REFERRAL_CREDITS_GRANTED_EVENT,
+    ]);
     expect(names).toEqual(REGISTERED_TEMPLATE_NAMES);
   });
 
@@ -160,5 +169,54 @@ describe("boot-time email template registration", () => {
     );
     expect(balance).toContain('eventType: "credits-reload-failed"');
     expect(REGISTERED_TEMPLATE_NAMES).toContain(BRAND_DAILY_BUDGET_CHANGED_EVENT);
+    // The referral senders import their names from the same constants the
+    // templates are keyed on, so the row and the eventType cannot drift.
+    expect(REGISTERED_TEMPLATE_NAMES).toContain(REFERRAL_REWARD_OPENED_EVENT);
+    expect(REGISTERED_TEMPLATE_NAMES).toContain(REFERRAL_CREDITS_GRANTED_EVENT);
+  });
+
+  it("interpolates only variables the senders actually supply", async () => {
+    // A template variable the sender never sets renders as a literal
+    // `{{placeholder}}` in a customer's inbox. The referral senders build every
+    // one of these, including the two that stand in for a failed identity
+    // lookup, so the set here and the set they emit must match exactly.
+    await deployEmailTemplates();
+    const templates = lastBody(fetchMock).templates;
+    const varsOf = (name: string) => {
+      const t = templates.find((x) => x.name === name)!;
+      return new Set(
+        [...`${t.subject} ${t.htmlBody} ${t.textBody}`.matchAll(/\{\{(\w+)\}\}/g)].map(
+          (m) => m[1],
+        ),
+      );
+    };
+
+    expect(varsOf(REFERRAL_REWARD_OPENED_EVENT)).toEqual(
+      new Set(["amount", "unlockAt", "referredOrg"]),
+    );
+    // The landed message carries WHO converted inside {{reason}}, which the
+    // sender composes: the two sides of a referral earned the same amount for
+    // opposite reasons, and only one of them has a third party to name.
+    expect(varsOf(REFERRAL_CREDITS_GRANTED_EVENT)).toEqual(
+      new Set(["amount", "reason"]),
+    );
+
+    const sender = readFileSync(
+      resolve(HERE, "../../src/lib/referral-notifications.ts"),
+      "utf-8",
+    );
+    for (const v of ["amount", "unlockAt", "referredOrg", "reason"]) {
+      expect(sender).toContain(`${v}:`);
+    }
+  });
+
+  it("uses no em-dash in customer-facing referral copy", async () => {
+    await deployEmailTemplates();
+    for (const t of lastBody(fetchMock).templates) {
+      if (!t.name.startsWith("referral")) continue;
+      expect(t.subject).not.toContain("—");
+      expect(t.textBody).not.toContain("—");
+      expect(t.htmlBody).not.toContain("—");
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #328 and #332. The referral money works end to end in prod (v0.60.0) and nobody is ever told.

A customer shares their invite link. Someone signs up through it, pays, and unlocks their own $500. That opens a $500 reward for the referrer, who then unlocks it on their own next payments. Not one of those moments produced a notification, so the referrer has no reason to open the dashboard on the day any of it happens. They can bring in three converting customers and never learn the referral worked, let alone that money is waiting for them.

## The moments I kept, and the ones I dropped

| eventType | to | when |
|---|---|---|
| `referral-reward-opened` | the REFERRER | someone they invited converted, so a reward opened at their own next bar |
| `referral-credits-granted` | whoever earned it, either side | the credits actually landed |

**Dropped: the invitee's promise being CREATED at signup.** Nothing has been earned yet and the person is mid-onboarding being told the same thing on screen.

**Dropped: "opened" when the reward is already earned as it opens.** This is the pair the brief warns about, and it is a real case rather than a theoretical one. An inviter's new bar is `(their highest bar) + $500`, which says nothing about what they have *already* paid, so a referrer who is past that bar earns the reward on the very next settle. They would get "$500 is on its way" and then, minutes later, "$500 arrived" — the second teaches them nothing. `alreadyEarned()` reads that org's paid topups once at open time and stays silent when the bar is already met; the granted message then carries the whole story, and it names the same referral. That read **fails open** (a throw means "not yet earned"), because a possible duplicate beats silence about money.

**Kept both for the referrer in the normal case**, where the two are days or weeks apart and carry genuinely different information: "you earned it" and "you can spend it".

Each message states the amount, and both name the referral that caused them — a referrer holding three pending $500s cannot otherwise tell which one a message is about. That is the same `resolveOrgDisplayIdentity` the Billing page already uses, under the same authorization: billing is the only service that knows the referral relationship exists, and that relationship is what makes naming the other org legitimate. Nothing beyond the name is exposed, and nothing is ever fabricated from the UUID.

## Exactly once

"Did we grant it" and "did we tell them" are different questions, so the grant's own idempotency cannot answer the second: the hourly sweep re-examines every outstanding promise on every tick, forever. Migration **0034** adds `opened_notified_at` / `granted_notified_at` to `free_credit_promises`, each claimed by a conditional `UPDATE … WHERE <marker> IS NULL RETURNING` — only the caller whose update returns a row sends, so two racing settles produce one email and a replayed payment produces none.

The claim is taken **after** the recipient resolves. Claiming first would burn the marker on a cold stripe-service and lose that notification forever; this way the next tick retries. An org whose billing customer exists with no address on it *is* marked, because there is nothing to retry against.

0034 also backfills every pre-existing promise as already-notified, so the first sweep after deploy cannot mail anyone about activity that is days old.

## A notification can never touch the money

Fail-soft throughout, the documented exception to this repo's fail-loud rule and the same posture as the identity lookup in #332. Every failure path logs loudly and returns; the grant transaction has already committed before any of it runs. A test asserts the grant and the inviter promise both survive a `sendEmail` that throws.

## Templates

Both are registered by this service (`src/instrument.ts`), per the fleet convention that a template belongs to whoever SENDS it. I checked the destination store rather than the registration code: `transactional-email` prod held 39 templates and no referral ones, so the names are free. Every `{{variable}}` is always supplied and never empty — an unset one renders as a literal `{{placeholder}}` in a customer's inbox, which is why `referredOrg` carries a phrase rather than a possibly-null name, and why `reason` is composed in the sender rather than branched in the template. A test pins the template's variable set against the sender's.

## Verification

- Full suite green: **476 tests / 38 files**, including the existing referral-promises suite. 10 new cases in `tests/integration/referral-notifications.test.ts` cover both messages, the collapse rule, exactly-once across three sweep passes, the unresolvable-recipient retry, the unnameable org, and a grant surviving a throwing send.
- `tsc --noEmit` clean, build clean.
- Migration 0034 replayed against a **fork of the prod default branch** (`br-soft-fog-a1un0038`): 89/89 promises marked notified, 0 marked granted (none are granted yet), the 112 promo rows and $1,093 gifted total untouched, and re-applying moves **0** rows. Prod currently holds 89 welcome promises and **zero** referral promises, so the backfill is belt-and-braces and no customer can be mailed retroactively.
- After promote I will query the `transactional-email` store for both template rows rather than trusting the registration code, and send one message to a staff address. No charge, refund, or money movement against any customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
