### PR TITLE
hotfix: Stop re-charging a card that just declined: per-org reload backoff

### DIFF
--- a/src/lib/reload-coalescer.ts
+++ b/src/lib/reload-coalescer.ts
@@ -1,22 +1,99 @@
 /**
- * In-memory per-org reload coalescer.
+ * In-memory per-org reload coalescer + post-failure backoff.
  *
- * Single-instance billing assumption: if N concurrent authorize calls for the
- * same org all need a topup, only ONE PaymentIntent fires. The rest join the
- * same promise and read the result.
+ * TWO guarantees, both per-org, both in memory:
  *
- * Multi-instance horizontal scaling: dedup must move into stripe-service
- * (mutex Redis per-org + Stripe idempotency key). Coalescer becomes a no-op
- * cache then.
+ * 1. COALESCING — N concurrent authorize calls for the same org fire ONE
+ *    PaymentIntent; the rest join the same promise and read the result.
+ *
+ * 2. BACKOFF — after a reload FAILS, the org is refused a new charge attempt
+ *    for a growing cooldown. Coalescing alone only dedupes calls that overlap
+ *    in TIME: the in-flight entry was dropped the moment the promise settled,
+ *    so a declined card left zero memory and the very next authorize charged
+ *    it again. Prod, 2026-08-29: one org accumulated 61 declined $500 charges
+ *    in six hours (one per minute in bursts), and the issuer escalated from
+ *    `insufficient_funds` to a flat `generic_decline` — repeated declines
+ *    degrade the card at its issuer and our decline rate at Stripe, so the
+ *    retries actively made recovery harder. Nothing was over-collected; the
+ *    damage is the hammering itself.
+ *
+ * A card that just declined declines again a minute later, so the cooldown is
+ * keyed on the ORG alone — never on the amount, or a different tier amount
+ * would walk straight past it.
+ *
+ * Single-instance billing assumption, same as the coalescing above. Multi-
+ * instance horizontal scaling: both must move into stripe-service (Redis
+ * mutex + failure marker per org); this module becomes a no-op cache then.
  */
 
 export interface ReloadOutcome {
   status: "succeeded" | "failed";
   payment_intent_id?: string;
   failure_reason?: string;
+  /**
+   * True ONLY on an outcome synthesised by the backoff — no charge was
+   * attempted and no new information was learned. Callers use it to stay quiet
+   * (the customer was already told when the real failure happened); every
+   * other reaction to a failed reload is unchanged. Absent on a real outcome.
+   */
+  backoffSkipped?: boolean;
+}
+
+/**
+ * Cooldown after the Nth consecutive failure. Grows so a persistently dead
+ * card stops costing attempts, and is CAPPED so an org that fixes its card
+ * resumes on its own within the hour rather than staying locked out. The first
+ * step is deliberately short: a failure can also be a transient stripe-service
+ * error, and 5 minutes is the right answer for that case too.
+ */
+const BACKOFF_STEPS_MS = [
+  5 * 60_000, // 1st failure  → 5 min
+  15 * 60_000, // 2nd          → 15 min
+  30 * 60_000, // 3rd          → 30 min
+  60 * 60_000, // 4th and beyond → 1 h (cap)
+] as const;
+
+interface FailureState {
+  consecutiveFailures: number;
+  blockedUntilMs: number;
 }
 
 const inFlight = new Map<string, Promise<ReloadOutcome>>();
+const failures = new Map<string, FailureState>();
+
+function cooldownFor(consecutiveFailures: number): number {
+  const i = Math.min(consecutiveFailures, BACKOFF_STEPS_MS.length) - 1;
+  return BACKOFF_STEPS_MS[Math.max(i, 0)];
+}
+
+function recordFailure(orgId: string, nowMs: number): void {
+  const consecutiveFailures = (failures.get(orgId)?.consecutiveFailures ?? 0) + 1;
+  failures.set(orgId, {
+    consecutiveFailures,
+    blockedUntilMs: nowMs + cooldownFor(consecutiveFailures),
+  });
+}
+
+/** A charge that went through clears the whole history — the card works. */
+function recordSuccess(orgId: string): void {
+  failures.delete(orgId);
+}
+
+/**
+ * Milliseconds until this org may be charged again, or 0 when it may be
+ * charged now. Exported so callers can log/trace WHY a reload was skipped.
+ */
+export function reloadBlockedForMs(orgId: string, nowMs: number = Date.now()): number {
+  const state = failures.get(orgId);
+  if (!state) return 0;
+  const remaining = state.blockedUntilMs - nowMs;
+  if (remaining <= 0) {
+    // Cooldown elapsed. Keep the failure COUNT so the next failure escalates
+    // rather than restarting at 5 minutes; only a success clears it.
+    return 0;
+  }
+  return remaining;
+}
 
 export async function coalesceReload(
   orgId: string,
@@ -25,14 +102,41 @@ export async function coalesceReload(
   const existing = inFlight.get(orgId);
   if (existing) return existing;
 
-  const promise = fn().finally(() => {
-    inFlight.delete(orgId);
-  });
+  const blockedForMs = reloadBlockedForMs(orgId);
+  if (blockedForMs > 0) {
+    const state = failures.get(orgId);
+    return {
+      status: "failed",
+      backoffSkipped: true,
+      failure_reason:
+        `reload_backoff: ${state?.consecutiveFailures ?? 0} consecutive failures, ` +
+        `retry in ${Math.ceil(blockedForMs / 1000)}s`,
+    };
+  }
+
+  // A DECLINED off_session charge reaches us as a THROW (stripe-service answers
+  // non-2xx), so the backoff has to arm on the rejection path — arming only on a
+  // settled {status:"failed"} would miss every real card decline. The error is
+  // re-thrown untouched, so every caller's existing try/catch behaves as before.
+  const promise = fn()
+    .then((outcome) => {
+      if (outcome.status === "succeeded") recordSuccess(orgId);
+      else recordFailure(orgId, Date.now());
+      return outcome;
+    })
+    .catch((err) => {
+      recordFailure(orgId, Date.now());
+      throw err;
+    })
+    .finally(() => {
+      inFlight.delete(orgId);
+    });
   inFlight.set(orgId, promise);
   return promise;
 }
 
-/** Test-only: clear all in-flight entries. */
+/** Test-only: clear all in-flight entries and backoff state. */
 export function _resetCoalescer(): void {
   inFlight.clear();
+  failures.clear();
 }

--- a/src/routes/customer_balance.ts
+++ b/src/routes/customer_balance.ts
@@ -243,7 +243,16 @@ router.post("/v1/customer_balance/authorize", requireOrgHeaders, async (req, res
 
     if (reloadResult.status !== "succeeded") {
       console.warn(`[billing-service] reload status=${reloadResult.status} for org ${orgId}: ${reloadResult.failure_reason ?? ""}`);
-      sendEmail({ eventType: "credits-reload-failed", orgId, userId, runId, workflowHeaders: wfHeaders });
+      // A backoff-skipped reload attempted no charge and learned nothing new: the
+      // customer was already mailed when the real failure happened, and the
+      // depletion episode opened then too. Re-sending on every subsequent
+      // authorize is the duplicate-email bug the episode state exists to prevent
+      // (prod 2026-08-29: 61 declines in six hours would have been 61 mails).
+      // Everything else below is unchanged — the episode call is idempotent and
+      // must still run, so an org whose FIRST failure predates this stays covered.
+      if (!reloadResult.backoffSkipped) {
+        sendEmail({ eventType: "credits-reload-failed", orgId, userId, runId, workflowHeaders: wfHeaders });
+      }
       await openDepletionEpisodeIfDepleted({
         orgId, userId, runId,
         balanceCents: snapshot.balanceCents,

--- a/tests/unit/reload-backoff.test.ts
+++ b/tests/unit/reload-backoff.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  coalesceReload,
+  reloadBlockedForMs,
+  _resetCoalescer,
+  type ReloadOutcome,
+} from "../../src/lib/reload-coalescer.js";
+
+const ORG = "11111111-1111-1111-1111-111111111111";
+const OTHER_ORG = "22222222-2222-2222-2222-222222222222";
+
+const succeeded: ReloadOutcome = { status: "succeeded", payment_intent_id: "pi_ok" };
+
+/** A declined off_session charge reaches billing as a THROW (stripe-service 4xx). */
+function declined(): Promise<ReloadOutcome> {
+  return Promise.reject(new Error("card_declined: insufficient_funds"));
+}
+
+describe("reload backoff", () => {
+  beforeEach(() => {
+    _resetCoalescer();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-29T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    _resetCoalescer();
+  });
+
+  it("refuses a second charge right after a declined one, without calling stripe", async () => {
+    const charge = vi.fn(declined);
+
+    await expect(coalesceReload(ORG, charge)).rejects.toThrow("card_declined");
+    expect(charge).toHaveBeenCalledTimes(1);
+
+    // This is the prod bug: before the backoff, the next authorize charged again.
+    const second = await coalesceReload(ORG, charge);
+    expect(second.status).toBe("failed");
+    expect(second.backoffSkipped).toBe(true);
+    expect(charge).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-throws the original error on the attempt that actually failed", async () => {
+    // Callers' existing try/catch must behave exactly as before on a real attempt.
+    await expect(coalesceReload(ORG, declined)).rejects.toThrow(
+      "card_declined: insufficient_funds"
+    );
+  });
+
+  it("charges again once the cooldown elapses", async () => {
+    const charge = vi.fn(declined);
+    await expect(coalesceReload(ORG, charge)).rejects.toThrow();
+
+    vi.advanceTimersByTime(5 * 60_000 - 1_000);
+    expect((await coalesceReload(ORG, charge)).backoffSkipped).toBe(true);
+    expect(charge).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(2_000);
+    await expect(coalesceReload(ORG, charge)).rejects.toThrow();
+    expect(charge).toHaveBeenCalledTimes(2);
+  });
+
+  it("escalates the cooldown on consecutive failures and caps it at an hour", async () => {
+    const charge = vi.fn(declined);
+    const steps = [5, 15, 30, 60, 60];
+
+    for (const minutes of steps) {
+      await expect(coalesceReload(ORG, charge)).rejects.toThrow();
+      const blockedMs = reloadBlockedForMs(ORG);
+      expect(Math.round(blockedMs / 60_000)).toBe(minutes);
+      vi.advanceTimersByTime(minutes * 60_000 + 1_000);
+    }
+  });
+
+  it("clears the backoff entirely once a charge succeeds", async () => {
+    await expect(coalesceReload(ORG, declined)).rejects.toThrow();
+    expect(reloadBlockedForMs(ORG)).toBeGreaterThan(0);
+
+    vi.advanceTimersByTime(5 * 60_000 + 1_000);
+    await coalesceReload(ORG, async () => succeeded);
+    expect(reloadBlockedForMs(ORG)).toBe(0);
+
+    // ...and the NEXT failure starts again at the first step, not the escalated one.
+    await expect(coalesceReload(ORG, declined)).rejects.toThrow();
+    expect(Math.round(reloadBlockedForMs(ORG) / 60_000)).toBe(5);
+  });
+
+  it("arms on a settled failed outcome too, not only on a throw", async () => {
+    const charge = vi.fn(
+      async (): Promise<ReloadOutcome> => ({ status: "failed", failure_reason: "invoice.status=open" })
+    );
+    expect((await coalesceReload(ORG, charge)).status).toBe("failed");
+    expect((await coalesceReload(ORG, charge)).backoffSkipped).toBe(true);
+    expect(charge).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys the cooldown on the org, so a different org is unaffected", async () => {
+    await expect(coalesceReload(ORG, declined)).rejects.toThrow();
+
+    const otherCharge = vi.fn(async (): Promise<ReloadOutcome> => succeeded);
+    expect((await coalesceReload(OTHER_ORG, otherCharge)).status).toBe("succeeded");
+    expect(otherCharge).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys the cooldown on the org alone, so a different amount cannot walk past it", async () => {
+    // A declining card declines any amount; the sweep charges a different figure
+    // than the tier reload, and must not get a free attempt because of it.
+    await expect(coalesceReload(ORG, declined)).rejects.toThrow();
+    const sweepCharge = vi.fn(declined);
+    expect((await coalesceReload(ORG, sweepCharge)).backoffSkipped).toBe(true);
+    expect(sweepCharge).not.toHaveBeenCalled();
+  });
+
+  it("still coalesces concurrent calls into one charge", async () => {
+    let resolveCharge: (o: ReloadOutcome) => void = () => {};
+    const charge = vi.fn(
+      () => new Promise<ReloadOutcome>((resolve) => { resolveCharge = resolve; })
+    );
+
+    const a = coalesceReload(ORG, charge);
+    const b = coalesceReload(ORG, charge);
+    resolveCharge(succeeded);
+
+    expect((await a).status).toBe("succeeded");
+    expect((await b).status).toBe("succeeded");
+    expect(charge).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a real outcome without the backoff flag, so callers still notify", async () => {
+    const outcome = await coalesceReload(ORG, async () => succeeded);
+    expect(outcome.backoffSkipped).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Automated by release.sh