### PR TITLE
fix: read "did the charge work" from both shapes stripe-service returns

### DIFF
--- a/src/lib/reload.ts
+++ b/src/lib/reload.ts
@@ -44,7 +44,19 @@ function flattenInvoiceStatus(invoice: StripeInvoice): ReloadOutcome {
     typeof invoice.payment_intent === "string"
       ? invoice.payment_intent
       : invoice.payment_intent?.id;
-  if (invoice.status === "paid" || invoice.paid === true) {
+  // stripe-service answers this route with an INVOICE where the org's acquirer
+  // produces one, and with a plain charge result where it does not — some
+  // acquirers have no invoice object at all. Both say the same thing about
+  // whether the money moved; only the vocabulary differs, and reading just the
+  // invoice one would report a successful charge as a failed reload.
+  //
+  // This is not vendor knowledge: nothing here names an acquirer, and nothing
+  // branches on which one was used. It reads "did it work" from both shapes.
+  const succeeded =
+    invoice.status === "paid" ||
+    invoice.paid === true ||
+    (invoice as { status?: string }).status === "succeeded";
+  if (succeeded) {
     return { status: "succeeded", payment_intent_id: paymentIntentId };
   }
   // stripe-service throws (non-2xx) on a declined off_session charge, so this


### PR DESCRIPTION
One org has been moved onto a second payment acquirer, live in production. This is the only change this repo needs, and it does **not** teach it that acquirers exist.

## The bug it prevents

stripe-service answers the off-session charge route with an **invoice** where the org's acquirer produces one, and with a plain **charge result** where it does not — some acquirers have no invoice object at all.

Both say the same thing about whether the money moved. Only the vocabulary differs (`paid` vs `succeeded`). Reading just the invoice one reports a **successful charge as a failed reload** — which leaves the org uncredited and re-charged on the next tick.

## Why this is not vendor knowledge

Nothing here names an acquirer. Nothing branches on which one was used. It reads *did it work* from both shapes, and would keep working if a third acquirer appeared.

678 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)