### PR TITLE
feat: describe how a customer adds a card, instead of assuming a portal

### DIFF
--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -853,3 +853,24 @@ export async function chargeOrgOffSession(
     { "Idempotency-Key": idempotencyKey }
   );
 }
+
+/**
+ * How this org's customer adds a card, as stripe-service describes it.
+ *
+ * Not a URL, because the acquirers do not all do this the same way: one hosts a
+ * portal we redirect to, another has no portal at all and saves a card only
+ * through a browser widget the page mounts itself. stripe-service names the
+ * mechanism and hands over what it needs; this repo passes that through without
+ * interpreting it. Nothing here names an acquirer.
+ */
+export async function getCardSetup(
+  orgId: string,
+  returnUrl: string
+): Promise<Record<string, unknown>> {
+  return call<Record<string, unknown>>(
+    "POST",
+    `/internal/card_setup/by-org/${encodeURIComponent(orgId)}`,
+    {},
+    { return_url: returnUrl }
+  );
+}

--- a/src/routes/portal.ts
+++ b/src/routes/portal.ts
@@ -4,17 +4,24 @@ import { db } from "../db/index.js";
 import { billingAccounts } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { CreatePortalSessionRequestSchema } from "../schemas.js";
-import { createPortalSession, getCustomerByOrg } from "../lib/stripe-service-client.js";
+import { getCardSetup } from "../lib/stripe-service-client.js";
 
 const router = Router();
 
-// POST /v1/portal-sessions — Stripe Customer Portal session via stripe-service.
+// POST /v1/portal-sessions — how this org's customer adds a card.
+//
+// The name is historical: it no longer always produces a "portal session",
+// because not every acquirer has a portal. stripe-service resolves which
+// acquirer holds the org's card and describes the mechanism — a hosted redirect
+// for one, an embedded widget for another. This repo passes that through
+// without interpreting it and without naming a vendor.
+//
+// Backwards compatible on purpose: the hosted case still carries `url` exactly
+// where it always was, so a client that only reads `url` keeps working and can
+// adopt `mode` whenever it likes.
 router.post("/v1/portal-sessions", requireOrgHeaders, async (req, res) => {
   try {
     const orgId = req.headers["x-org-id"] as string;
-    const userId = req.headers["x-user-id"] as string;
-    const runId = req.headers["x-run-id"] as string;
-    const wfHeaders = forwardWorkflowHeaders(getWorkflowHeaders(req));
 
     const parsed = CreatePortalSessionRequestSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -34,29 +41,12 @@ router.post("/v1/portal-sessions", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    const identity = {
-      "x-org-id": orgId,
-      "x-user-id": userId,
-      "x-run-id": runId,
-      ...wfHeaders,
-    };
-
-    let session;
-    try {
-      // Stripe portal sessions cannot be created without a customer id. Resolve the
-      // org's Stripe customer (org-implicit, server-side from x-org-id) and forward it.
-      const customer = await getCustomerByOrg(identity);
-      session = await createPortalSession(identity, { customer: customer.id, return_url });
-    } catch (err) {
-      console.error("[billing-service] stripe-service createPortalSession failed:", err);
-      res.status(502).json({ error: "Failed to create portal session via stripe-service" });
-      return;
-    }
-
-    res.json({ url: session.url });
+    const setup = await getCardSetup(orgId, return_url);
+    res.json(setup);
   } catch (err) {
-    console.error("[billing-service] Error creating portal session:", err);
-    res.status(500).json({ error: "Internal server error" });
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[billing-service] card setup failed:", message);
+    res.status(502).json({ error: "Failed to start card setup" });
   }
 });
 

--- a/tests/helpers/mock-stripe.ts
+++ b/tests/helpers/mock-stripe.ts
@@ -28,6 +28,7 @@ export interface StripeServiceMocks {
   setCustomerMetadata: ReturnType<typeof vi.fn>;
   createCheckoutSession: ReturnType<typeof vi.fn>;
   createPortalSession: ReturnType<typeof vi.fn>;
+  getCardSetup: ReturnType<typeof vi.fn>;
   getStats: ReturnType<typeof vi.fn>;
   reloadOffSession: ReturnType<typeof vi.fn>;
 }
@@ -129,6 +130,11 @@ export function setupStripeMocks(): StripeServiceMocks {
     createPortalSession: vi.fn().mockResolvedValue({
       url: "https://billing.stripe.com/p/session/test_portal",
     }),
+    getCardSetup: vi.fn().mockResolvedValue({
+      object: "card_setup",
+      mode: "hosted_redirect",
+      url: "https://billing.stripe.com/p/session/abc",
+    }),
     listAllCustomersForOrg: vi.fn().mockResolvedValue([]),
     setCustomerMetadata: vi.fn().mockImplementation((id: string) =>
       Promise.resolve(buildMockCustomer({ id }))
@@ -169,6 +175,7 @@ export function setupStripeMocks(): StripeServiceMocks {
   vi.spyOn(ssClient, "hasChargeablePmForOrg").mockImplementation(mocks.hasChargeablePmForOrg);
   vi.spyOn(ssClient, "getOrgCardCountryByOrg").mockImplementation(mocks.getOrgCardCountryByOrg);
   vi.spyOn(ssClient, "createCheckoutSession").mockImplementation(mocks.createCheckoutSession);
+  vi.spyOn(ssClient, "getCardSetup").mockImplementation(mocks.getCardSetup as never);
   vi.spyOn(ssClient, "createPortalSession").mockImplementation(mocks.createPortalSession);
   vi.spyOn(ssClient, "listAllCustomersForOrg").mockImplementation(mocks.listAllCustomersForOrg);
   vi.spyOn(ssClient, "setCustomerMetadata").mockImplementation(mocks.setCustomerMetadata);

--- a/tests/integration/portal.test.ts
+++ b/tests/integration/portal.test.ts
@@ -20,10 +20,35 @@ describe("POST /v1/portal-sessions", () => {
     await closeDb();
   });
 
-  it("proxies to stripe-service", async () => {
+  it("passes stripe-service's card-setup description straight through", async () => {
     await insertTestAccount({ orgId });
-    ssMocks.createPortalSession.mockResolvedValue({
-      url: "https://billing.stripe.com/p/session/abc",
+
+    const res = await request(app)
+      .post("/v1/portal-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ return_url: "https://example.com/return" });
+
+    expect(res.status).toBe(200);
+    // `url` is still exactly where it always was for the hosted case, so a
+    // client that only reads `url` keeps working.
+    expect(res.body.url).toBe("https://billing.stripe.com/p/session/abc");
+    expect(res.body.mode).toBe("hosted_redirect");
+    expect(ssMocks.getCardSetup).toHaveBeenCalledWith(
+      orgId,
+      "https://example.com/return"
+    );
+  });
+
+  it("passes an embedded-widget description through without interpreting it", async () => {
+    // Not every acquirer has a portal. This repo must not flatten the two
+    // mechanisms into one, nor name the vendor behind either.
+    await insertTestAccount({ orgId });
+    ssMocks.getCardSetup.mockResolvedValue({
+      object: "card_setup",
+      mode: "embedded_widget",
+      public_key: "pk_test",
+      token: "tok_1",
+      save_payment_method_for: "merchant",
     });
 
     const res = await request(app)
@@ -32,11 +57,13 @@ describe("POST /v1/portal-sessions", () => {
       .send({ return_url: "https://example.com/return" });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ url: "https://billing.stripe.com/p/session/abc" });
-    expect(ssMocks.createPortalSession).toHaveBeenCalledWith(
-      expect.objectContaining({ "x-org-id": orgId }),
-      { customer: "cus_mock_123", return_url: "https://example.com/return" }
-    );
+    expect(res.body).toEqual({
+      object: "card_setup",
+      mode: "embedded_widget",
+      public_key: "pk_test",
+      token: "tok_1",
+      save_payment_method_for: "merchant",
+    });
   });
 
   it("returns 404 when billing account doesn't exist", async () => {
@@ -50,7 +77,7 @@ describe("POST /v1/portal-sessions", () => {
 
   it("returns 502 when stripe-service fails", async () => {
     await insertTestAccount({ orgId });
-    ssMocks.createPortalSession.mockRejectedValue(new Error("SS down"));
+    ssMocks.getCardSetup.mockRejectedValue(new Error("SS down"));
 
     const res = await request(app)
       .post("/v1/portal-sessions")


### PR DESCRIPTION
`/v1/portal-sessions` no longer always produces a portal session, because **not every acquirer has a portal**.

stripe-service resolves which acquirer holds the org's card and describes the mechanism:

| `mode` | what the client does |
|---|---|
| `hosted_redirect` | send the customer to `url` |
| `embedded_widget` | mount the acquirer's browser SDK with `public_key` + `token` |

This repo passes that through **without interpreting it and without naming a vendor**. Flattening the two into one shape would mean pretending one acquirer has a portal it does not, or pretending the other needs a widget it does not.

## Backwards compatible on purpose

The hosted case still carries `url` exactly where it always was, so a client that only reads `url` keeps working and can adopt `mode` whenever it likes. That is what lets the dashboard land after this rather than in lockstep with it.

The route keeps its historical name for the same reason — renaming it would break every caller for a cosmetic gain.

678 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)