### PR TITLE
feat: carry the top-up amount into card setup, and say so when one is needed

### DIFF
--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -865,12 +865,14 @@ export async function chargeOrgOffSession(
  */
 export async function getCardSetup(
   orgId: string,
-  returnUrl: string
+  returnUrl: string,
+  amount?: number,
+  currency?: string
 ): Promise<Record<string, unknown>> {
   return call<Record<string, unknown>>(
     "POST",
     `/internal/card_setup/by-org/${encodeURIComponent(orgId)}`,
     {},
-    { return_url: returnUrl }
+    { return_url: returnUrl, ...(amount ? { amount, currency } : {}) }
   );
 }

--- a/src/routes/portal.ts
+++ b/src/routes/portal.ts
@@ -28,7 +28,7 @@ router.post("/v1/portal-sessions", requireOrgHeaders, async (req, res) => {
       res.status(400).json({ error: parsed.error.message });
       return;
     }
-    const { return_url } = parsed.data;
+    const { return_url, amount, currency } = parsed.data;
 
     const [account] = await db
       .select()
@@ -41,10 +41,21 @@ router.post("/v1/portal-sessions", requireOrgHeaders, async (req, res) => {
       return;
     }
 
-    const setup = await getCardSetup(orgId, return_url);
+    const setup = await getCardSetup(orgId, return_url, amount, currency);
     res.json(setup);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // Not every provider can store a card without taking a payment. That is a
+    // legible answer the client must act on — collect an amount and retry — so
+    // it is passed through rather than flattened into a generic failure.
+    if (/card_setup_requires_payment/.test(message)) {
+      res.status(409).json({
+        error:
+          "This account's payment provider saves a card only with a payment. Choose a top-up amount and the card is saved with it.",
+        code: "card_setup_requires_payment",
+      });
+      return;
+    }
     console.error("[billing-service] card setup failed:", message);
     res.status(502).json({ error: "Failed to start card setup" });
   }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -186,6 +186,8 @@ export const CheckoutResponseSchema = z
 export const CreatePortalSessionRequestSchema = z
   .object({
     return_url: z.string().url(),
+    amount: z.number().int().positive().optional(),
+    currency: z.string().min(3).optional(),
   })
   .openapi("CreatePortalSessionRequest");
 

--- a/tests/integration/portal.test.ts
+++ b/tests/integration/portal.test.ts
@@ -35,7 +35,9 @@ describe("POST /v1/portal-sessions", () => {
     expect(res.body.mode).toBe("hosted_redirect");
     expect(ssMocks.getCardSetup).toHaveBeenCalledWith(
       orgId,
-      "https://example.com/return"
+      "https://example.com/return",
+      undefined,
+      undefined
     );
   });
 
@@ -64,6 +66,41 @@ describe("POST /v1/portal-sessions", () => {
       token: "tok_1",
       save_payment_method_for: "merchant",
     });
+  });
+
+  it("passes a top-up amount through, for a provider that saves a card only with a payment", async () => {
+    await insertTestAccount({ orgId });
+
+    await request(app)
+      .post("/v1/portal-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        return_url: "https://example.com/return",
+        amount: 50000,
+        currency: "USD",
+      });
+
+    expect(ssMocks.getCardSetup).toHaveBeenCalledWith(
+      orgId,
+      "https://example.com/return",
+      50000,
+      "USD"
+    );
+  });
+
+  it("tells the client to collect an amount rather than failing opaquely", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.getCardSetup.mockRejectedValue(
+      new Error('stripe-service POST /internal/card_setup failed: 409 {"code":"card_setup_requires_payment"}')
+    );
+
+    const res = await request(app)
+      .post("/v1/portal-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ return_url: "https://example.com/return" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("card_setup_requires_payment");
   });
 
   it("returns 404 when billing account doesn't exist", async () => {


### PR DESCRIPTION
Follow-up to #396. The widget opened in production, the card went in, and "Next" failed with a bare `Transaction failed`.

**Not every payment provider can store a card without taking a payment.** One of ours cannot — a zero-amount order is accepted at create and then fails at pay with no attempt recorded, so there is nothing to read a reason from.

So the amount the customer is paying now rides along and the card is saved with it. Nothing here names a provider: the amount is forwarded, and a provider whose portal stores a card on its own ignores it.

When the amount is missing and the provider needs one, that comes back as a **409 with a message the client can act on** rather than a generic failure. *"Choose an amount and the card is saved with it"* is a thing a user can do; *"failed to start card setup"* is not.

680 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)