### PR TITLE
fix: stop asking for an amount to change a card

### DIFF
--- a/src/routes/portal.ts
+++ b/src/routes/portal.ts
@@ -45,17 +45,6 @@ router.post("/v1/portal-sessions", requireOrgHeaders, async (req, res) => {
     res.json(setup);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    // Not every provider can store a card without taking a payment. That is a
-    // legible answer the client must act on — collect an amount and retry — so
-    // it is passed through rather than flattened into a generic failure.
-    if (/card_setup_requires_payment/.test(message)) {
-      res.status(409).json({
-        error:
-          "This account's payment provider saves a card only with a payment. Choose a top-up amount and the card is saved with it.",
-        code: "card_setup_requires_payment",
-      });
-      return;
-    }
     console.error("[billing-service] card setup failed:", message);
     res.status(502).json({ error: "Failed to start card setup" });
   }

--- a/tests/integration/portal.test.ts
+++ b/tests/integration/portal.test.ts
@@ -88,21 +88,6 @@ describe("POST /v1/portal-sessions", () => {
     );
   });
 
-  it("tells the client to collect an amount rather than failing opaquely", async () => {
-    await insertTestAccount({ orgId });
-    ssMocks.getCardSetup.mockRejectedValue(
-      new Error('stripe-service POST /internal/card_setup failed: 409 {"code":"card_setup_requires_payment"}')
-    );
-
-    const res = await request(app)
-      .post("/v1/portal-sessions")
-      .set(getAuthHeaders(orgId))
-      .send({ return_url: "https://example.com/return" });
-
-    expect(res.status).toBe(409);
-    expect(res.body.code).toBe("card_setup_requires_payment");
-  });
-
   it("returns 404 when billing account doesn't exist", async () => {
     const res = await request(app)
       .post("/v1/portal-sessions")


### PR DESCRIPTION
**Updating a card is not a purchase.** The branch that told the client to go and collect a top-up amount was answering a constraint that no longer exists.

stripe-service (v0.43.0, already in production) verifies a card by **authorising a small sum and immediately voiding it** — `capture_mode: "manual"`, hold released as soon as the method is saved. Nothing is charged and nothing has to be chosen, so there is no condition left for this to report.

679 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)