### PR TITLE
feat(welcome): a flat $30 of free credit, granted in full at signup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ When reconciling or computing real cost: `WHERE rc.status='actual' AND rc.cost_s
 
 ## Local promos (`local_promos` table)
 
-The only persistent ledger billing-service owns. One row per (org, promo_code) — `UNIQUE (org_id, promo_code_id)`. Welcome trial = `code='welcome'` ($5 grant; seeded @$2 by migration 0016, bumped to $25 by 0018, reverted to $2 by 0019, set to $5 by 0028). Welcome-completion gift = `code='welcome_completion'` (technical code seeded at 0; dynamic per-row amount — see "Welcome-completion gift"). Other codes are admin-managed.
+The only persistent ledger billing-service owns. One row per (org, promo_code) — `UNIQUE (org_id, promo_code_id)`. Welcome trial = `code='welcome'` (seeded @$2 by migration 0016, bumped to $25 by 0018, reverted to $2 by 0019, set to $5 by 0028; re-priced at RUNTIME to $30 for the flat offer — the seed default is only what a fresh database starts at). Welcome-completion gift = `code='welcome_completion'` (technical code seeded at 0; dynamic per-row amount — see "Welcome-completion gift"). Other codes are admin-managed.
 
 **Removed — do NOT reintroduce `first_load_match` (migration 0031).** It backed `POST /v1/accounts/wallet_setup` (dollar-for-dollar match on the first paid load, capped $25). The whole path was dead: onboarding migrated off it (the dashboard's own `onboarding-flow.test.ts` asserts the flow does not contain `wallet_setup`, and its leftover `walletSetup()` helper had zero call sites) and prod never completed one — **0 of 1255** `payment_intents` carried `metadata.billing_reason='initial_load'`. Worse, it capped at $25 **on its own** with no reference to the free-credit entitlement, so `welcome` + `first_load_match` granted **$30** of free credit against a $25 entitlement — it contradicts the rule 0029 established. Its promise ("$25 free once you put money in") is now served by `welcome_completion`, on the checkout path onboarding actually uses. A removal guard in `tests/integration/accounts.test.ts` ("removed surfaces") asserts the route 404s and no `first_load_match` code row exists.
 
@@ -122,10 +122,15 @@ Until 0033 an org had exactly ONE outstanding promise, expressed as the two `bil
 
   | situation | ladder |
   |---|---|
-  | brand-new $400 account | $400 @ $400 (unchanged from today) |
-  | ...then referred | + $500 @ $900 |
-  | ...a third promise | + $500 @ $1,400, and so on, no ceiling |
+  | brand-new $30 account | $30 @ $30 |
+  | ...then referred | + $500 @ $530 |
+  | ...a third promise | + $500 @ $1,030, and so on, no ceiling |
+  | $400 account, referred | $400 @ $400, then $500 @ $900 |
   | grandfathered $25 account, referred | $25 @ $25, then $500 @ $525 |
+
+  The flat-$30 re-price (0040) needed NO change here and no special case: the welcome
+  bar is read off the account's own frozen trigger, so it simply became $30 and every
+  referral stacks $500 above whatever that org carries.
 
 - **An outstanding promise is a promise, not money.** No `local_promos` row exists until it is granted, so it is absent from `credited` / `balance` / `actual_balance` / spendable everywhere. Do NOT "helpfully" surface it in a balance figure.
 - **The referral offer has NO up-front portion** — the whole amount lands when the bar is crossed. The $5 up-front gift belongs to the welcome offer only, and is unchanged for every cohort.
@@ -203,7 +208,9 @@ The same trap bit the **dunning follow-ups**, which used `ep.runId ?? crypto.ran
 
 ## Welcome-completion gift — "$N in free credits", automatic (`src/lib/welcome-completion.ts`)
 
-Onboarding promises every new customer **$N of free credits**. Signup only grants the `welcome` row ($5 today), so for months the remainder was granted BY HAND (staff `admin_grant` rows described "Welcome credits (2/2)"). `welcome_completion` (migration 0029) automates the remainder.
+Onboarding promises every new customer **$N of free credits**. Under a MATCH offer signup granted only the `welcome` row ($5) and the remainder was earned by paying, so for months it was granted BY HAND (staff `admin_grant` rows described "Welcome credits (2/2)"); `welcome_completion` (migration 0029) automates it.
+
+**⚠️ For the CURRENT cohort this whole file is a no-op, and that is by design (migration 0040).** The offer is now a flat **$30 granted in full at signup** — the `welcome` promo row is priced at 3000 (the dashboard pushes that at boot via `PATCH /v1/promo-codes/welcome`), so the derived remainder is already zero and `settleWelcomeCompletion` returns `entitlement_already_full` without inserting anything, at any payment amount. Nothing was special-cased to achieve that: the remainder has always been `entitlement − what was already gifted`, and the two sides are now equal. The machinery is still here for the two MATCH cohorts ($25 and $400), which still earn their own remainder at their own trigger.
 
 **The rule (product-locked):**
 
@@ -215,11 +222,12 @@ Onboarding promises every new customer **$N of free credits**. Signup only grant
 
 Both figures used to be module-level constants, so re-pricing the offer re-priced it for **every existing customer at once**. They now live on `billing_accounts` — `free_credit_entitlement_cents` + `free_credit_paid_trigger_cents`, `integer NOT NULL` — written ONCE from the **column DEFAULT** at INSERT (`findOrCreateAccount` inserts `org_id` only) and never updated afterwards.
 
-- **Two cohorts today.** Accounts predating 0032 carry **$25 / $25** (`GRANDFATHERED_FREE_CREDIT_*`); accounts created after it carry **$400 / $400** (`CURRENT_FREE_CREDIT_*`). Verified on a prod fork: **93/93** existing accounts landed at 2500/2500 and a fresh `INSERT … (org_id)` came back 40000/40000.
+- **THREE cohorts today.** Accounts predating 0032 carry **$25 / $25** (`GRANDFATHERED_FREE_CREDIT_*`); accounts created between 0032 and 0040 carry **$400 / $400**; accounts created after 0040 carry **$30 / $30** (`CURRENT_FREE_CREDIT_*`). Measured in prod at 0040's ship time: **93** accounts at 2500/2500 and **10** at 40000/40000, none of which 0040 touches. Verified on a prod fork at 0032's ship time: 93/93 existing accounts landed at 2500/2500 and a fresh `INSERT … (org_id)` came back 40000/40000.
 - **Read the ROW, never a constant.** There is deliberately no bare `FREE_CREDIT_ENTITLEMENT_CENTS` export any more — a global entitlement is the exact bug this shape removes. `CURRENT_*` is the DB default, `GRANDFATHERED_*` is documentation for the cohort that must keep reading $25 forever. Do not re-price `GRANDFATHERED_*`.
 - **A future re-price is one line**: move the column DEFAULT. Existing rows already hold their value, so every customer grandfathers automatically — **no cutoff date, no backfill, no new rule to stack**. (Contrast `WELCOME_COMPLETION_LAUNCH_AT_ISO`, which needs a date because it is a claim about payment HISTORY. This is a claim about the account itself, so the row carries it.)
 - **Migration 0032's statement ORDER is the whole trick**, and it is why re-applying is safe: `ADD COLUMN … DEFAULT 2500` backfills existing rows with the offer they signed up under, *then* `ALTER COLUMN … SET DEFAULT 40000` aims future signups at the new one. On a re-apply, `ADD COLUMN IF NOT EXISTS` is a no-op, so a $400 account can never be re-stamped to $25. A test in `tests/integration/free-credit-offer-cohorts.test.ts` replays those exact statements and asserts it.
-- **The $5 up-front `welcome` gift is unchanged for BOTH cohorts.** Only the total and the trigger differ.
+- **Migration 0040 is that one-line re-price, and it is the shape to copy.** TWO `ALTER COLUMN … SET DEFAULT 3000` statements, no `ADD COLUMN` half and no row written — repeating 0032's backfill is the only way a re-price could reach an existing account, so it is absent. Idempotent by nature; the reverse SQL is in the migration header. A test replays it and asserts both older cohorts keep their exact figures.
+- **The `welcome` gift amount differs per cohort and is NOT a migration.** $5 for the two MATCH cohorts, $30 for the flat one — set at runtime on the `welcome` `local_promo_codes` row (`PATCH /v1/promo-codes/welcome`), so nothing in this repo hardcodes it. `WELCOME_PROMO_AMOUNT_CENTS` is only the seed default for a fresh database.
 - **`insertTestAccount` defaults to the GRANDFATHERED $25/$25**, so every suite written before the re-price keeps exercising the offer it was written against (same rationale as the `welcomeCompletionEligible: false` default). Pass `freeCreditEntitlementCents`/`freeCreditPaidTriggerCents` for the new cohort; to exercise what a REAL signup gets, insert with no offer columns at all so the DB DEFAULT applies.
 
 **Who drives it (never the browser).** Nothing pushes into billing when a Checkout payment lands (stripe-service only mirrors the PaymentIntent), so `settleWelcomeCompletion(orgId, paidTopupsCents, fetchPaidTopupsBeforeLaunchCents)` is called from every path that ALREADY holds the org's paid-topups sum — `composeAccountFunds` (so the dashboard read right after a payment makes it land in seconds) and the checkout route — plus, unconditionally, the hourly `runWelcomeCompletionSweep` on the existing dunning scheduler. A request can only make an already-EARNED grant land sooner; the condition is derived entirely from Stripe's record of money received plus billing's own ledger, so nothing a caller asserts can conjure a grant. `computeBalance` deliberately does NOT settle — `GET /internal/campaigns/:id/affordability` is documented side-effect-free and authorize stays hot-path-thin.
@@ -242,27 +250,38 @@ Verified on a prod fork: 88/88 eligible after 0030 (was 0/88), grant rows + gift
 
 **Fail loud:** a missing `welcome_completion` seed THROWS (→ 502 on the account read). Swallowing it would leave a buyer short of credit they were promised, which is the exact failure this exists to remove. This is not paranoia — prod HAS lost promo-code seeds (`invite_reward`/`invite_welcome` never applied per 0017; `first_load_match` was seeded by journaled 0023 yet is absent from prod today, apparently hand-renamed to a `brand_welcome` row).
 
-### Onboarding charges ONE DAY of the chosen budget, so a $400/day customer crosses the $400 trigger on their FIRST payment
+### Onboarding charges ONE DAY of the chosen budget, MINUS the $30 gift
 
-The daily budget the customer picks in onboarding IS the checkout amount — the flow charges roughly one day of it. That figure and the current cohort's `free_credit_paid_trigger_cents` are both **$400**, so a customer who sets $400/day pays $400 once and immediately earns the whole `welcome_completion` remainder. Observed in prod 2026-08-30, over 14 seconds on one org: paid $400 at 19:31:38, granted $395 at 19:31:51, budget row written at 19:31:52. Credited $800 against $400 collected.
+The daily budget the customer picks in onboarding IS the checkout amount — the flow charges roughly one day of it. Under the flat offer the gift comes off that charge, so the two sides of one $30 are:
 
-That is the offer working as designed, not a bug — but it is the shape to expect when a payment looks larger than a "trial", and it is why the number is the same on both sides of the sentence. It also means **the runway is one day**: at $400/day the $800 is gone in two days and the org lands in depletion dunning. Nothing in this service paces that; the daily budget is the only lever.
+    credit granted = $30, always, at signup
+    cash charged   = max($0, daily_budget − $30)
+
+A $30/day signup pays nothing (the dashboard sends a $0 setup-mode checkout instead) and starts with $30 of balance; a $50/day signup pays $20 and starts with $50. Both received exactly $30. **It is never $60 and never $0** — that invariant is the point of the design and is pinned by tests.
+
+Under the OLD $400 MATCH offer the same "one day of budget" property had a different consequence worth remembering: the checkout amount and the trigger were both $400, so a $400/day customer earned the whole $395 remainder on their FIRST payment. Observed in prod 2026-08-30, over 14 seconds on one org: paid $400 at 19:31:38, granted $395 at 19:31:51, budget row written at 19:31:52. Credited $800 against $400 collected — the offer working as designed, and the shape to expect on any account still carrying that cohort's figures. Its runway is one day: at $400/day the $800 is gone in two days and the org lands in depletion dunning. Nothing in this service paces that; the daily budget is the only lever.
 
 **Stopping a customer from being charged again = TWO independent levers, and only one of them is about money.** `DELETE /v1/accounts/auto_topup` removes the credit line (floor drops to `"0"`, strictly prepaid), stops every auto-reload, AND drops the org from the month-end sweep's candidate set, which selects auto-topup-ENABLED accounts only — so it closes all three charge paths at once. Setting the brand's daily budget to **0** pauses the work instead; it charges nothing by itself, because since campaign-service #343 it is the FUNDING of a sales funnel that makes its campaigns run (the pause flag is gone), so a funnel at 0 has campaigns that exist and do not spend. Reach for the budget when the customer wants to stop and come back, and for auto-topup when they meant to send money once. Doing only the budget leaves the sweep armed on any negative balance; doing only auto-topup leaves the spend running until the credit is gone.
 
-### Checkout-page copy — the gift is announced, never advanced
+### Checkout page — the gift comes OFF the price, or is announced as still coming
 
-`POST /v1/checkout-sessions` payment mode carries `custom_text.submit.message` = `welcomeCompletionCheckoutNotice(offer)`, telling the buyer the free credits are still coming. The SENTENCE is product-approved — do not reword it — but the two figures are substituted from the org's OWN offer, because they differ per cohort and quoting the wrong one would promise money we will not grant. `$25/$25` renders byte-identically to the string this service shipped before ("You get $25 in free credits. $5 now, the rest once your payments reach $25.") and there is a test pinning that; `$400/$400` renders the $400 wording. The `$5` is a literal on purpose (the welcome gift is $5 for every cohort). The notice is deliberately withheld from an ineligible org and from one already fully gifted (it would be a lie). Stripe caps `message` at 1200 chars.
+`decideCheckoutWelcomeOffer(orgId, paidTopupsCents)` returns `{couponId, noticeMessage}` and **exactly one is ever set, by construction**: the discount requires the entitlement to be fully gifted already, the notice requires some of it to still be coming. `POST /v1/checkout-sessions` payment mode then attaches `discounts: [{coupon}]` or `custom_text.submit.message`.
 
-`decideCheckoutWelcomeNotice(orgId)` returns that string or null. It takes ONLY the org: it no longer needs the paid-topups sum or the checkout amount, because nothing about the charge depends on it any more.
+**The notice** ("You get $25 in free credits. $5 now, the rest once your payments reach $25.") is product-approved — do not reword it — with both figures substituted from the org's OWN offer, because quoting the wrong cohort's would promise money we will not grant. The `$5` is a literal on purpose: the notice is only ever shown to an org that still has a remainder coming, i.e. one of the two MATCH cohorts, whose welcome gift is $5. The flat $30 cohort grants everything at signup, has no remainder, and never reaches the sentence. Withheld from an ineligible org and from one already fully gifted (it would be a lie). Stripe caps `message` at 1200 chars.
 
-**REMOVED — do NOT reintroduce the up-front checkout discount.** The route used to advance the whole entitlement as a pre-applied Stripe coupon (`discounts: [{coupon}]`, gated on `WELCOME_DISCOUNT_COUPON_ID`), so a first-ever checkout of at least `entitlement + trigger` was charged less and the credit landed immediately. Deleted along with `minDiscountedCheckoutCents`, `welcomeCompletionCodeExists`, the `applyDiscount`/`couponId` fields, and the `discounts` field on the checkout-session body.
+**The discount was REMOVED under the match offer and REINSTATED under the flat one (this is not a revert — the hazard is gone).** The old comment forbidding it said a discount "is the one place a buyer can be handed credit before the payment that earns it has cleared", and it required a floor of `entitlement + trigger` so the post-discount charge still reached the trigger. Both statements were about the MATCH: the credit had not been granted yet and paying is what earned it. With the flat offer the whole $30 is granted at signup and **no payment earns anything**, so nothing is advanced and the hazard has no way to occur. The discount is the CASH side of a gift the ledger has already recorded — and the buyer must SEE the $30 come off, not merely be charged less.
 
-The floor was the whole safety property: the post-discount charge still had to reach the trigger that EARNS the gift, or the discount handed over credit nobody paid for. At the $400 offer that floor is $800 — far above any real first checkout (onboarding charges roughly one day of budget) — so the branch had been **unreachable for every new signup** long before it was removed, and the grandfathered $25 cohort is the only one that could ever have hit it. The promise is served by `settleWelcomeCompletion`, on the path onboarding actually uses.
+The gate is stricter than the old floor rather than looser. All must hold:
 
-Two removal guards pin it: a first checkout at each cohort's old floor ($50 grandfathered, $800 new) must carry no `discounts` and must carry the notice instead. If you are tempted to bring the discount back, the thing to weigh is that it is the one place a buyer can be handed credit before the payment that earns it has cleared.
+- the org has already been gifted its **FULL** entitlement (remaining ≤ 0), so the discount can only ever mirror credit already in `local_promos`;
+- the org has **NEVER paid**, so it lands on the onboarding checkout once and can never repeat on a later top-up;
+- a coupon is configured whose **declared amount EQUALS this org's own frozen entitlement**.
 
-**`allow_promotion_codes` is gone and must not come back either.** It was enabled for a single journalist comp (that is done). Nothing in this service discounts a charge any more.
+**Two env vars, declared together so they cannot drift:** `WELCOME_DISCOUNT_COUPON_ID` and `WELCOME_DISCOUNT_COUPON_AMOUNT_CENTS`. The amount is declared rather than read back from Stripe because billing has no coupon read (stripe-service exposes none) — and it must be known, because a coupon worth the wrong amount is money. Declaring it makes a re-price **FAIL SAFE**: move the offer without minting a matching coupon and the discount simply stops applying (the buyer is charged in full and still receives the credit), instead of taking the old figure off the new price. It is also what stops a grandfathered $25 org or a $400 org ever being handed a $30 coupon. Absent, unparseable, or mismatched → no discount anywhere, which is a coherent state and not a degraded one.
+
+Note the consequence for the coupon object itself: **a re-price needs a NEW Stripe coupon plus both env vars moved**, in that order. Nothing in this repo can mint one.
+
+**`allow_promotion_codes` is still gone and must not come back.** It was enabled for a single journalist comp (that is done), and it is mutually exclusive with the pre-applied discount above. The welcome discount is the ONLY thing that discounts a charge in this service.
 
 ## Billing/runs ownership target
 
@@ -475,7 +494,7 @@ Growth rows expose `credited_cents` and `revenue_cents` only, both NET (they rea
 | `GET` | `/v1/accounts/balance` | shortcut: `{ balance_cents, depleted }` |
 | `PATCH` | `/v1/accounts/auto_topup` | configure auto-topup; body must include both `topup_amount_cents` and `topup_threshold_cents` |
 | `DELETE` | `/v1/accounts/auto_topup` | disable auto-topup |
-| `POST` | `/v1/checkout-sessions` | one-shot top-up or setup-mode PM capture via Stripe Checkout; does NOT configure auto-topup. Payment mode carries the gift-is-coming notice quoting that org's own figures. Nothing discounts the charge: no pre-applied coupon, no user promotion-code entry. See "Welcome-completion gift" |
+| `POST` | `/v1/checkout-sessions` | one-shot top-up or setup-mode PM capture via Stripe Checkout; does NOT configure auto-topup. Payment mode carries EITHER a pre-applied coupon worth the org's already-granted free credits (so the buyer sees them come off) OR the gift-is-coming notice quoting that org's own figures — never both, and never a user promotion-code entry. See "Checkout page" |
 | `POST` | `/v1/portal-sessions` | Stripe Customer Portal session |
 | `POST` | `/v1/customer_balance/authorize` | check if `balance_cents >= amount` ; auto-reload via PI if configured |
 | `POST` | `/v1/customer_balance/usage_apply` | proactive topup hint after a run; no-op for the ledger |

--- a/drizzle/0040_flat_thirty_free_credit_offer.sql
+++ b/drizzle/0040_flat_thirty_free_credit_offer.sql
@@ -1,0 +1,35 @@
+-- Re-price the free-credit offer to a FLAT $30, granted in full at signup.
+--
+-- The offer was a MATCH: $5 landed at signup and the remaining $395 landed only once
+-- the org's cumulative succeeded payments reached $400. The product owner has replaced
+-- it with a flat $30 that is given up front, unconditionally, with nothing to earn:
+--
+--   credit granted = $30, always, at signup (the `welcome` promo row, re-priced to
+--                    3000 at runtime by the dashboard's PATCH /v1/promo-codes/welcome)
+--   cash charged   = max($0, daily_budget - $30) at the onboarding checkout
+--
+-- So a $30/day signup pays nothing and starts with $30 of balance; a $50/day signup
+-- pays $20 and starts with $50. Both received exactly $30 — never $60, never $0.
+--
+-- ONE statement per column, and it is the SAME one-line re-price migration 0032
+-- designed for: move the column DEFAULT, touch no row. Existing accounts already hold
+-- their own frozen figures, so the $25 grandfathered cohort and the $400 cohort are
+-- untouched by construction — no cutoff date, no backfill, nothing to re-derive. There
+-- is deliberately NO `ADD COLUMN` half here: 0032 created the columns and backfilled
+-- them once; repeating that would be the only way this migration could re-price
+-- somebody, so it is absent.
+--
+-- Idempotent: SET DEFAULT is idempotent by nature, and since no row is written a
+-- re-apply changes nothing at all.
+--
+-- Reverse (restores the $400 offer for FUTURE accounts only, same as above):
+--   ALTER TABLE "billing_accounts"
+--     ALTER COLUMN "free_credit_entitlement_cents" SET DEFAULT 40000;
+--   ALTER TABLE "billing_accounts"
+--     ALTER COLUMN "free_credit_paid_trigger_cents" SET DEFAULT 40000;
+
+ALTER TABLE "billing_accounts"
+  ALTER COLUMN "free_credit_entitlement_cents" SET DEFAULT 3000;
+
+ALTER TABLE "billing_accounts"
+  ALTER COLUMN "free_credit_paid_trigger_cents" SET DEFAULT 3000;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1791540000000,
       "tag": "0039_brand_funnel_leg_budgets",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1791626400000,
+      "tag": "0040_flat_thirty_free_credit_offer",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -34,16 +34,30 @@ const FRACTIONAL_SCALE = 10;
 // off the account. (There is deliberately no bare `FREE_CREDIT_ENTITLEMENT_CENTS`
 // export any more — a global entitlement is the bug this shape exists to prevent.)
 
-/** Total free credits a NEWLY created account may ever receive, welcome gift INCLUDED. */
-export const CURRENT_FREE_CREDIT_ENTITLEMENT_CENTS = 40000;
+/**
+ * Total free credits a NEWLY created account may ever receive, welcome gift INCLUDED.
+ *
+ * $30, and the offer is no longer a MATCH: the whole amount is granted at signup by
+ * the `welcome` promo row, unconditionally, with nothing left to earn. So for a new
+ * account this figure is also exactly what signup already gave, which is why the
+ * completion remainder is zero and `settleWelcomeCompletion` no-ops for that cohort.
+ * The two earlier cohorts ($25 grandfathered, $400) keep their own frozen figures and
+ * their own two-stage behaviour — see the column comment below.
+ */
+export const CURRENT_FREE_CREDIT_ENTITLEMENT_CENTS = 3000;
 
 /**
  * Cumulative SUCCEEDED payments that earn the completion for a NEWLY created
  * account. The trigger is money actually received — NOT usage consumed: the
  * account model is threshold-postpaid, so an org can consume on credit before
  * paying anything, and we must not gift credits to someone whose card may fail.
+ *
+ * Equal to the entitlement, as it has been for every cohort. At $30 that equality
+ * has a second consequence worth stating: signup already grants the full $30, so the
+ * remainder is zero before the trigger is ever consulted and no new account can reach
+ * a second grant whatever it pays. The trigger still governs the two older cohorts.
  */
-export const CURRENT_FREE_CREDIT_PAID_TRIGGER_CENTS = 40000;
+export const CURRENT_FREE_CREDIT_PAID_TRIGGER_CENTS = 3000;
 
 /**
  * What every account that existed before migration 0032 carries, permanently.
@@ -77,8 +91,9 @@ export const billingAccounts = pgTable(
     // Written from the DB column DEFAULT on INSERT and never updated: re-pricing the
     // offer moves the default for FUTURE accounts only, so every existing org keeps
     // the offer it signed up under with no cutoff rule and no backfill. Accounts that
-    // predate 0032 carry GRANDFATHERED_* (2500/2500); accounts created after it carry
-    // CURRENT_* (40000/40000). Read these — never a module-level constant.
+    // predate 0032 carry GRANDFATHERED_* (2500/2500); accounts created between 0032
+    // and 0040 carry 40000/40000; accounts created after 0040 carry CURRENT_*
+    // (3000/3000). Read these — never a module-level constant.
     freeCreditEntitlementCents: integer("free_credit_entitlement_cents")
       .notNull()
       .default(CURRENT_FREE_CREDIT_ENTITLEMENT_CENTS),

--- a/src/lib/free-credit-promises.ts
+++ b/src/lib/free-credit-promises.ts
@@ -12,8 +12,8 @@
  *
  * An org may carry any number of promises at once. Today two kinds exist:
  *
- *   - `welcome`  — the signup offer ("$400 in free credits", $25 for the
- *                  grandfathered cohort). One per org, amount and bar copied from
+ *   - `welcome`  — the signup offer ($30 flat today; $400 and $25 for the two older
+ *                  cohorts). One per org, amount and bar copied from
  *                  the figures already frozen on its billing account. It is granted
  *                  by lib/welcome-completion.ts, whose arithmetic is unchanged; this
  *                  module only materialises the row so the welcome offer is ONE of

--- a/src/lib/stripe-service-client.ts
+++ b/src/lib/stripe-service-client.ts
@@ -420,13 +420,24 @@ export interface CheckoutSessionBody {
    */
   invoice_creation?: { enabled: boolean };
   /**
+   * Payment-mode only: pre-applied discounts, rendered on the Checkout page as a
+   * discount line so the buyer SEES the free credits come off rather than merely
+   * being charged less. Stripe accepts at most one entry.
+   *
+   * Used for exactly one thing: the flat welcome offer, on an org that has already
+   * been gifted its full entitlement and has never paid (see lib/welcome-completion
+   * for why that makes it safe, and why it was NOT safe under the old match offer).
+   *
+   * Mutually exclusive with user-entered promotion codes — billing deliberately does
+   * NOT set `allow_promotion_codes` anywhere (removed with the journalist comp it was
+   * added for), so there is no conflict to resolve.
+   */
+  discounts?: Array<{ coupon: string }>;
+  /**
    * Payment-mode only: copy rendered on the Checkout page alongside the pay button
    * (Stripe caps `message` at 1200 chars). Used to tell a buyer the free credits are
-   * coming.
-   *
-   * Note there is deliberately no `discounts` field: billing applies no pre-applied
-   * coupon to a checkout, and sets `allow_promotion_codes` nowhere either (removed
-   * with the journalist comp it was added for). Nothing here discounts a charge.
+   * still coming, on a cohort whose entitlement is not yet fully gifted. Never set
+   * alongside `discounts` — the two describe mutually exclusive states.
    */
   custom_text?: { submit: { message: string } };
 }

--- a/src/lib/welcome-completion.ts
+++ b/src/lib/welcome-completion.ts
@@ -4,11 +4,19 @@
  * ## The rule
  *
  * An org receives ITS OWN `free_credit_entitlement_cents` in free credits IN TOTAL,
- * welcome gift included. Signup grants only the `welcome` row ($5 today, for every
- * cohort), so the completion is worth the remainder. The remainder is DERIVED from
+ * welcome gift included, so the completion is worth the remainder. The remainder is
+ * DERIVED from
  * what the org has actually been gifted (SUM(local_promos)), never from a hardcoded
  * difference — so it stays correct across cohorts, if the welcome amount is
  * re-priced, or if the org never got a welcome row at all.
+ *
+ * That derivation is what makes this whole file a clean NO-OP for the current cohort.
+ * The offer is no longer a match: signup grants the FULL $30 (the `welcome` row is
+ * priced at 3000), so the remainder is already zero and `settleWelcomeCompletion`
+ * returns `entitlement_already_full` without inserting anything, at any payment
+ * amount. Nothing was special-cased to achieve that. The two older cohorts ($5 of
+ * $25, $5 of $400) still earn their remainder at their own trigger exactly as
+ * before, which is the only reason this machinery is still here.
  *
  * The completion is EARNED once the org's cumulative SUCCEEDED payments reach ITS
  * OWN `free_credit_paid_trigger_cents`. The trigger is money actually received,
@@ -69,8 +77,9 @@
  * A missing `welcome_completion` promo-code seed THROWS. Swallowing it would leave
  * a buyer short of the credit they were promised — the exact failure this feature
  * exists to remove. Note prod HAS lost promo-code seeds before (see CLAUDE.md
- * "Migrations are hand-journaled"), which is why the checkout discount is gated on
- * this seed existing: the discount can never be granted without the credit.
+ * "Migrations are hand-journaled"). The checkout discount cannot be affected by a
+ * lost seed: it applies only to an org whose entitlement is ALREADY fully gifted,
+ * so the credit it mirrors is a row that exists, not one still to be written.
  */
 
 import { and, eq, notExists, sql as rawSql } from "drizzle-orm";
@@ -112,9 +121,12 @@ function dollars(cents: number): string {
  * Copy shown on the checkout page when NO up-front discount applies, so the buyer
  * knows the gift is coming before deciding to pay. The SENTENCE is approved verbatim
  * by the product owner — do not reword it. The two figures are substituted from the
- * org's OWN offer, because they now differ per cohort and quoting the wrong one would
+ * org's OWN offer, because they differ per cohort and quoting the wrong one would
  * promise money we will not grant (or hide money we will). The "$5" is a literal on
- * purpose: the up-front welcome gift is $5 for every cohort.
+ * purpose: this notice is only ever shown to an org that still has a remainder
+ * coming, i.e. one of the two MATCH cohorts ($25 and $400), whose up-front welcome
+ * gift is $5. The current flat $30 offer grants everything at signup, has no
+ * remainder, and therefore never reaches this sentence.
  * (No em-dash: customer-facing copy.)
  */
 export function welcomeCompletionCheckoutNotice(offer: FreeCreditOffer): string {
@@ -276,27 +288,95 @@ export async function settleWelcomeCompletion(
   return NOT_GRANTED("already_granted");
 }
 
+/** What the payment-mode checkout page should apply and say for this org. */
+export interface CheckoutWelcomeOffer {
+  /**
+   * Stripe coupon to pre-apply, so the buyer SEES the free credits come off the
+   * price rather than merely being charged less. null when none applies.
+   */
+  couponId: string | null;
+  /**
+   * "Gift is coming" copy, quoting THIS org's own offer; null when nothing is
+   * still coming. Built here rather than in the route so the figures can never
+   * drift from the account the decision was made against.
+   */
+  noticeMessage: string | null;
+}
+
+const NO_OFFER: CheckoutWelcomeOffer = { couponId: null, noticeMessage: null };
+
 /**
- * The "gift is coming" copy for this org's payment-mode checkout page, quoting
- * THIS org's own offer — or null when no notice should be shown. Built here
- * rather than in the route so the figures can never drift from the account the
- * decision was made against.
+ * The coupon this deployment may pre-apply, and the amount it is worth, declared
+ * together so they cannot drift.
  *
- * Shown only to an org that genuinely still has free credit coming. Telling an
- * org with its full entitlement already gifted (or one that is not eligible at
- * all) that "the rest" is on its way would be a lie.
+ * The amount is declared rather than read back from Stripe because billing has no
+ * coupon read (stripe-service exposes none) — and it must be known, because a coupon
+ * worth the wrong amount is money. Declaring it makes a re-price FAIL SAFE: move the
+ * offer without minting a matching coupon and the discount simply stops applying
+ * (the buyer is charged in full and still receives the credit), instead of taking
+ * the old figure off the new price.
  *
- * There is deliberately NO up-front discount path. Advancing the entitlement as
- * a pre-applied Stripe coupon was removed: it required a floor of
- * (entitlement + trigger) to keep the post-discount charge above the trigger
- * that EARNS the gift, and at the current $400 offer that floor is $800 — far
- * above any real first checkout, so the branch had been unreachable for new
- * signups long before it was deleted. The gift is granted after the fact by
- * `settleWelcomeCompletion`, which is the path onboarding actually uses. Do NOT
- * reintroduce a checkout-time discount: it is the one place a buyer can be
- * handed credit before the payment that earns it has cleared.
+ * Absent or unparseable → no discount anywhere. That is a coherent state, not a
+ * degraded one: the credit is granted at signup either way.
  */
-export async function decideCheckoutWelcomeNotice(orgId: string): Promise<string | null> {
+function configuredWelcomeCoupon(): { id: string; amountCents: number } | null {
+  const id = process.env.WELCOME_DISCOUNT_COUPON_ID?.trim();
+  if (!id) return null;
+  const raw = process.env.WELCOME_DISCOUNT_COUPON_AMOUNT_CENTS?.trim();
+  if (!raw) return null;
+  const amountCents = Number(raw);
+  if (!Number.isInteger(amountCents) || amountCents <= 0) return null;
+  return { id, amountCents };
+}
+
+/**
+ * Decide what the checkout page applies and says for this org's payment-mode
+ * checkout. Exactly one of the two fields is ever set, by construction: the
+ * discount requires the entitlement to be fully gifted already, the notice
+ * requires some of it to still be coming.
+ *
+ * ## The discount, and why it is safe NOW
+ *
+ * This used to be forbidden, and the comment that forbade it is worth keeping
+ * rather than deleting, because its reasoning is exactly what changed. Under the
+ * MATCH offer the discount ADVANCED the entitlement: the credit had not been
+ * granted yet, and it was earned by the payment being discounted. That needed a
+ * floor of (entitlement + trigger) so the post-discount charge still reached the
+ * trigger, and the note read "it is the one place a buyer can be handed credit
+ * before the payment that earns it has cleared".
+ *
+ * The offer is now FLAT: the whole $30 is granted at signup, unconditionally, and
+ * no payment earns anything. So nothing is advanced, nothing can be earned by
+ * paying, and the hazard the floor existed to prevent has no way to occur. The
+ * discount is now the CASH side of a gift the ledger has already recorded — the
+ * buyer is charged (budget - entitlement) and holds (budget) of balance, having
+ * received the entitlement exactly once.
+ *
+ * That is precisely what the gate below encodes, and it is stricter than the old
+ * floor rather than looser:
+ *
+ *   - the org has already been gifted its FULL entitlement (remaining <= 0), so the
+ *     discount can only ever mirror credit that is already in `local_promos`;
+ *   - the org has NEVER paid, so it lands on the onboarding checkout once and can
+ *     never repeat on a later top-up;
+ *   - a coupon is configured whose declared amount EQUALS this org's own frozen
+ *     entitlement, so a grandfathered $25 org and a $400 org can never be handed a
+ *     $30 coupon (nor the reverse).
+ *
+ * A re-price therefore cannot silently mis-discount anybody: the amounts must match
+ * to the cent or nothing is applied.
+ *
+ * ## The notice
+ *
+ * Shown only to an org that genuinely still has free credit coming — the two older
+ * cohorts, whose remainder is still earned at their own trigger. Telling an org with
+ * its entitlement already gifted that "the rest" is on its way would be a lie, and
+ * that is the same org the discount serves.
+ */
+export async function decideCheckoutWelcomeOffer(
+  orgId: string,
+  paidTopupsCents: string
+): Promise<CheckoutWelcomeOffer> {
   const [account] = await db
     .select({
       eligible: billingAccounts.welcomeCompletionEligible,
@@ -306,20 +386,33 @@ export async function decideCheckoutWelcomeNotice(orgId: string): Promise<string
     .from(billingAccounts)
     .where(eq(billingAccounts.orgId, orgId))
     .limit(1);
-  if (!account || !account.eligible) return null;
+  if (!account) return NO_OFFER;
 
   const offer: FreeCreditOffer = {
     entitlementCents: account.entitlementCents,
     paidTriggerCents: account.paidTriggerCents,
   };
 
-  // Same exclusion as settleWelcomeCompletion — the notice describes the WELCOME
+  // Same exclusion as settleWelcomeCompletion — both surfaces describe the WELCOME
   // entitlement, so referral rewards must not count against what is left of it.
   const giftedCents = await sumEntitlementGrantsForOrg(orgId);
   const remainingCents = subCents(toCents(offer.entitlementCents), giftedCents);
-  if (cmpCents(remainingCents, ZERO) <= 0) return null;
 
-  return welcomeCompletionCheckoutNotice(offer);
+  if (cmpCents(remainingCents, ZERO) <= 0) {
+    // Fully gifted: nothing is coming, so no notice. The gift may instead be made
+    // visible on the price, once — see the doc above for why that is safe here and
+    // was not under the match offer.
+    const coupon = configuredWelcomeCoupon();
+    if (!coupon) return NO_OFFER;
+    if (coupon.amountCents !== offer.entitlementCents) return NO_OFFER;
+    if (cmpCents(paidTopupsCents, ZERO) > 0) return NO_OFFER;
+    return { couponId: coupon.id, noticeMessage: null };
+  }
+
+  // Still owed part of the entitlement. An org excluded from the completion will
+  // never receive that remainder, so promising it would be a lie.
+  if (!account.eligible) return NO_OFFER;
+  return { couponId: null, noticeMessage: welcomeCompletionCheckoutNotice(offer) };
 }
 
 /**

--- a/src/routes/checkout.ts
+++ b/src/routes/checkout.ts
@@ -8,7 +8,7 @@ import {
 } from "../lib/stripe-service-client.js";
 import type { CheckoutSessionBody } from "../lib/stripe-service-client.js";
 import { findOrCreateAccount } from "../lib/account.js";
-import { decideCheckoutWelcomeNotice } from "../lib/welcome-completion.js";
+import { decideCheckoutWelcomeOffer } from "../lib/welcome-completion.js";
 import { settleFreeCreditPromises } from "../lib/free-credit-settlement.js";
 import { traceEvent } from "../lib/trace-event.js";
 
@@ -72,18 +72,18 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
         };
       } else {
         // Free-credit offer for THIS checkout. Needs the org's cumulative paid
-        // topups: the $25 discount may only ever land on an org that has NEVER
-        // paid, otherwise every later top-up would silently get $25 off forever.
-        // Settling first also covers an org whose earlier payment already crossed
-        // the $25 trigger but was not yet settled, so the notice/discount decision
-        // reads a fresh ledger — including the grandfather resolution, which is what
-        // stops the "the rest is coming" notice being shown to an org that had
-        // already crossed the trigger before launch and is owed nothing. Both fail
-        // loud (the catch below → 502): a buyer must never get a discount without
-        // the matching credit grant.
+        // topups: the discount may only ever land on an org that has NEVER paid,
+        // otherwise every later top-up would silently get the free credits off
+        // forever. Settling first also covers an org whose earlier payment already
+        // crossed its trigger but was not yet settled, so the notice/discount
+        // decision reads a fresh ledger — including the grandfather resolution,
+        // which is what stops the "the rest is coming" notice being shown to an org
+        // that had already crossed the trigger before launch and is owed nothing.
+        // Both fail loud (the catch below → 502): the price a buyer is shown must
+        // be decided against the real ledger, never against a stale read of it.
         const paidTopupsCents = await sumSucceededTopupsForOrg(orgId);
         await settleFreeCreditPromises(orgId, paidTopupsCents);
-        const welcomeNotice = await decideCheckoutWelcomeNotice(orgId);
+        const welcome = await decideCheckoutWelcomeOffer(orgId, paidTopupsCents);
 
         // payment mode (hosted or embedded) — topup_amount_cents is guaranteed present
         // by the 400 guard above (non-setup + undefined already returned). The `!`
@@ -112,10 +112,18 @@ router.post("/v1/checkout-sessions", requireOrgHeaders, async (req, res) => {
           // PaymentIntents and are NOT invoiced by this — separate future work.
           invoice_creation: { enabled: true },
         };
-        if (welcomeNotice) {
-          // Tell the buyer the gift is still coming, so the promise is visible at
-          // the moment of payment. The figures quoted are this org's own offer.
-          body.custom_text = { submit: { message: welcomeNotice } };
+        if (welcome.couponId) {
+          // Show the free credits coming OFF the price. The org has already been
+          // gifted its full entitlement (that is the gate), so this discounts the
+          // cash side of a gift the ledger has already recorded — the buyer pays
+          // (budget - entitlement) and holds (budget) of balance. It is not an
+          // advance: nothing here is earned by paying. See lib/welcome-completion.
+          body.discounts = [{ coupon: welcome.couponId }];
+        } else if (welcome.noticeMessage) {
+          // Nothing to take off the price, but part of the gift is still coming:
+          // tell the buyer so, at the moment of payment. The figures quoted are
+          // this org's own offer.
+          body.custom_text = { submit: { message: welcome.noticeMessage } };
         }
         if (isEmbedded) {
           // Embedded Checkout: mounted in an in-app modal iframe. No redirect URLs —

--- a/tests/integration/checkout.test.ts
+++ b/tests/integration/checkout.test.ts
@@ -73,7 +73,7 @@ describe("POST /v1/checkout-sessions", () => {
         custom_text: {
           submit: {
             message:
-              "You get $400 in free credits. $5 now, the rest once your payments reach $400.",
+              "You get $30 in free credits. $5 now, the rest once your payments reach $30.",
           },
         },
       }
@@ -335,7 +335,7 @@ describe("POST /v1/checkout-sessions", () => {
         custom_text: {
           submit: {
             message:
-              "You get $400 in free credits. $5 now, the rest once your payments reach $400.",
+              "You get $30 in free credits. $5 now, the rest once your payments reach $30.",
           },
         },
       }

--- a/tests/integration/flat-welcome-offer.test.ts
+++ b/tests/integration/flat-welcome-offer.test.ts
@@ -1,0 +1,378 @@
+/**
+ * The flat $30 welcome offer (migration 0040).
+ *
+ * The offer stopped being a MATCH. A new signup receives $30 of free credit the
+ * moment its account exists, unconditionally, with no payment threshold and no
+ * second instalment. The gift is delivered through TWO sides of one $30:
+ *
+ *   credit granted = $30, always, at signup
+ *   cash charged   = max($0, daily_budget - $30) at the onboarding checkout
+ *
+ * So a $30/day signup pays nothing and starts with $30 of balance; a $50/day signup
+ * pays $20 and starts with $50. Both received exactly $30. The invariant these cases
+ * exist to pin is that it is never $60 and never $0.
+ *
+ * Own file, not a `describe` appended to an existing suite: those close the shared
+ * postgres.js connection in `afterAll`, which would take this block down with
+ * `write CONNECTION_ENDED` (see CLAUDE.md).
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import {
+  cleanTestData,
+  closeDb,
+  insertTestAccount,
+  insertTestPromoGrant,
+} from "../helpers/test-db.js";
+import { setupStripeMocks } from "../helpers/mock-stripe.js";
+import * as runsClient from "../../src/lib/runs-client.js";
+import { db } from "../../src/db/index.js";
+import {
+  billingAccounts,
+  freeCreditPromises,
+  localPromoCodes,
+  localPromos,
+  CURRENT_FREE_CREDIT_ENTITLEMENT_CENTS,
+  CURRENT_FREE_CREDIT_PAID_TRIGGER_CENTS,
+  CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+  WELCOME_COMPLETION_CODE,
+  WELCOME_PROMO_CODE,
+} from "../../src/db/schema.js";
+import {
+  decideCheckoutWelcomeOffer,
+  settleWelcomeCompletion,
+} from "../../src/lib/welcome-completion.js";
+import { claimReferral } from "../../src/lib/free-credit-promises.js";
+import { settleFreeCreditPromises } from "../../src/lib/free-credit-settlement.js";
+
+const FLAT_GIFT_CENTS = 3000;
+const COUPON_ID = "coupon_welcome_30";
+
+const orgId = "00000000-0000-0000-0000-0000000005a1";
+const otherOrgId = "00000000-0000-0000-0000-0000000005a2";
+const userId = "00000000-0000-0000-0000-0000000005a3";
+
+const NEVER_PRE_LAUNCH = () => Promise.resolve("0.0000000000");
+const cents = (n: number) => `${n}.0000000000`;
+
+/** A real signup: findOrCreateAccount inserts org_id only, so the DEFAULT decides. */
+async function insertSignupAccount(id: string) {
+  await db.insert(billingAccounts).values({ orgId: id });
+  await db
+    .update(billingAccounts)
+    .set({ welcomeCompletionEligible: true })
+    .where(eq(billingAccounts.orgId, id));
+}
+
+/** What the dashboard's boot-time re-price makes the signup grant worth. */
+async function repriceWelcomeCodeToFlatGift() {
+  await db
+    .update(localPromoCodes)
+    .set({ amountCents: FLAT_GIFT_CENTS })
+    .where(eq(localPromoCodes.code, WELCOME_PROMO_CODE));
+}
+
+/** Signup as it really happens: account created, then the $30 welcome row granted. */
+async function signupWithFlatGift(id: string) {
+  await insertSignupAccount(id);
+  await repriceWelcomeCodeToFlatGift();
+  await insertTestPromoGrant({
+    orgId: id,
+    userId,
+    amountCents: FLAT_GIFT_CENTS,
+    promoCode: WELCOME_PROMO_CODE,
+  });
+}
+
+async function giftedTotalCents(id: string): Promise<number> {
+  const rows = await db
+    .select({ amountCents: localPromos.amountCents })
+    .from(localPromos)
+    .where(eq(localPromos.orgId, id));
+  return rows.reduce((sum, r) => sum + Number(r.amountCents), 0);
+}
+
+async function completionRowCount(id: string): Promise<number> {
+  const rows = await db
+    .select({ id: localPromos.id })
+    .from(localPromos)
+    .innerJoin(localPromoCodes, eq(localPromos.promoCodeId, localPromoCodes.id))
+    .where(eq(localPromoCodes.code, WELCOME_COMPLETION_CODE));
+  return rows.filter(Boolean).length;
+}
+
+describe("flat $30 welcome offer, granted in full at signup", () => {
+  const app = createTestApp();
+  let ssMocks: ReturnType<typeof setupStripeMocks>;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    ssMocks = setupStripeMocks();
+    await cleanTestData();
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockResolvedValue({
+      spent_cents: "0.0000000000",
+    } as never);
+    vi.spyOn(runsClient, "fetchRunsOrgActualUsageTotal").mockResolvedValue({
+      spent_cents: "0.0000000000",
+    } as never);
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await cleanTestData();
+    await closeDb();
+  });
+
+  // --- AC: a newly created account carries a $30 entitlement and a $30 trigger ---
+
+  it("a newly created account carries $30 / $30, from the column DEFAULT", async () => {
+    await db.insert(billingAccounts).values({ orgId });
+
+    const [row] = await db
+      .select({
+        entitlementCents: billingAccounts.freeCreditEntitlementCents,
+        paidTriggerCents: billingAccounts.freeCreditPaidTriggerCents,
+      })
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId));
+
+    expect(row).toEqual({ entitlementCents: 3000, paidTriggerCents: 3000 });
+    expect(CURRENT_FREE_CREDIT_ENTITLEMENT_CENTS).toBe(3000);
+    expect(CURRENT_FREE_CREDIT_PAID_TRIGGER_CENTS).toBe(3000);
+  });
+
+  // --- AC: welcome + completion totals EXACTLY $30, never more ---
+
+  it("the completion is a clean no-op at a zero remainder, and inserts nothing", async () => {
+    await signupWithFlatGift(orgId);
+
+    const outcome = await settleWelcomeCompletion(
+      orgId,
+      cents(FLAT_GIFT_CENTS),
+      NEVER_PRE_LAUNCH
+    );
+
+    expect(outcome.granted).toBe(false);
+    expect(outcome.reason).toBe("entitlement_already_full");
+    expect(outcome.amountCents).toBe("0.0000000000");
+    // The whole point: no $0 row, no throw, nothing written.
+    expect(await completionRowCount(orgId)).toBe(0);
+    expect(await giftedTotalCents(orgId)).toBe(FLAT_GIFT_CENTS);
+  });
+
+  it("stays exactly $30 whatever the org pays, and at any number of settles", async () => {
+    await signupWithFlatGift(orgId);
+
+    for (const paid of [0, 3000, 5000, 100000]) {
+      const outcome = await settleWelcomeCompletion(
+        orgId,
+        cents(paid),
+        NEVER_PRE_LAUNCH
+      );
+      expect(outcome.granted).toBe(false);
+      expect(await giftedTotalCents(orgId)).toBe(FLAT_GIFT_CENTS);
+    }
+    expect(await completionRowCount(orgId)).toBe(0);
+  });
+
+  it("is never $0 either: an account whose welcome row is missing still earns its $30", async () => {
+    // Belt and braces on the OTHER side of the invariant. If the signup grant never
+    // landed, the completion machinery still owes the org its full entitlement — so
+    // the flat offer cannot silently become nothing.
+    await insertSignupAccount(orgId);
+
+    const outcome = await settleWelcomeCompletion(
+      orgId,
+      cents(FLAT_GIFT_CENTS),
+      NEVER_PRE_LAUNCH
+    );
+
+    expect(outcome.granted).toBe(true);
+    expect(outcome.amountCents).toBe(cents(FLAT_GIFT_CENTS));
+    expect(await giftedTotalCents(orgId)).toBe(FLAT_GIFT_CENTS);
+  });
+
+  // --- AC: an existing $400 or $25 account is untouched ---
+
+  it("an existing $400 account keeps its own offer and its own two-stage behaviour", async () => {
+    await insertTestAccount({
+      orgId: otherOrgId,
+      welcomeCompletionEligible: true,
+      freeCreditEntitlementCents: 40000,
+      freeCreditPaidTriggerCents: 40000,
+    });
+    await insertTestPromoGrant({
+      orgId: otherOrgId,
+      userId,
+      amountCents: 500,
+      promoCode: WELCOME_PROMO_CODE,
+    });
+
+    // The new $30 trigger must not reach it: $30 of payments earns nothing here.
+    const below = await settleWelcomeCompletion(
+      otherOrgId,
+      cents(3000),
+      NEVER_PRE_LAUNCH
+    );
+    expect(below.granted).toBe(false);
+    expect(below.reason).toBe("payments_below_trigger");
+
+    const earned = await settleWelcomeCompletion(
+      otherOrgId,
+      cents(40000),
+      NEVER_PRE_LAUNCH
+    );
+    expect(earned.granted).toBe(true);
+    expect(earned.amountCents).toBe(cents(39500));
+    expect(await giftedTotalCents(otherOrgId)).toBe(40000);
+  });
+
+  it("an existing $25 account keeps its own offer and is not re-priced to $30", async () => {
+    await insertTestAccount({ orgId: otherOrgId, welcomeCompletionEligible: true });
+    await insertTestPromoGrant({
+      orgId: otherOrgId,
+      userId,
+      amountCents: 500,
+      promoCode: WELCOME_PROMO_CODE,
+    });
+
+    const [row] = await db
+      .select({
+        entitlementCents: billingAccounts.freeCreditEntitlementCents,
+        paidTriggerCents: billingAccounts.freeCreditPaidTriggerCents,
+      })
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, otherOrgId));
+    expect(row).toEqual({ entitlementCents: 2500, paidTriggerCents: 2500 });
+
+    const earned = await settleWelcomeCompletion(
+      otherOrgId,
+      cents(2500),
+      NEVER_PRE_LAUNCH
+    );
+    expect(earned.granted).toBe(true);
+    // $20, i.e. its OWN $25 entitlement minus its $5 welcome — not $25, not $30.
+    expect(earned.amountCents).toBe(cents(2000));
+    expect(await giftedTotalCents(otherOrgId)).toBe(2500);
+  });
+
+  // --- AC: the buyer SEES the $30 come off a payment-mode checkout ---
+
+  it("shows the discount on the checkout page for an org that still has its $30", async () => {
+    await signupWithFlatGift(orgId);
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    vi.stubEnv("WELCOME_DISCOUNT_COUPON_ID", COUPON_ID);
+    vi.stubEnv("WELCOME_DISCOUNT_COUPON_AMOUNT_CENTS", String(FLAT_GIFT_CENTS));
+
+    // A $50/day signup: the dashboard charges the full budget and the $30 comes off
+    // in front of the buyer, so they pay $20 and hold $50.
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        success_url: "https://example.com/s",
+        cancel_url: "https://example.com/c",
+        topup_amount_cents: 5000,
+      });
+    expect(res.status).toBe(200);
+
+    const body = ssMocks.createCheckoutSession.mock.calls[0][1];
+    expect(body.discounts).toEqual([{ coupon: COUPON_ID }]);
+    // Mutually exclusive with the notice: nothing is "still coming".
+    expect(body).not.toHaveProperty("custom_text");
+    // The charge is the full budget; Stripe applies the coupon to it.
+    expect(body.line_items[0].price_data.unit_amount).toBe(5000);
+  });
+
+  it("does not discount a later top-up: the gift lands once, on the first checkout", async () => {
+    await signupWithFlatGift(orgId);
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue(cents(5000));
+    vi.stubEnv("WELCOME_DISCOUNT_COUPON_ID", COUPON_ID);
+    vi.stubEnv("WELCOME_DISCOUNT_COUPON_AMOUNT_CENTS", String(FLAT_GIFT_CENTS));
+
+    const offer = await decideCheckoutWelcomeOffer(orgId, cents(5000));
+    expect(offer).toEqual({ couponId: null, noticeMessage: null });
+  });
+
+  it("does not hand a $30 coupon to a grandfathered $25 org", async () => {
+    await insertTestAccount({ orgId: otherOrgId, welcomeCompletionEligible: true });
+    await insertTestPromoGrant({
+      orgId: otherOrgId,
+      userId,
+      amountCents: 2500,
+      promoCode: WELCOME_PROMO_CODE,
+    });
+    vi.stubEnv("WELCOME_DISCOUNT_COUPON_ID", COUPON_ID);
+    vi.stubEnv("WELCOME_DISCOUNT_COUPON_AMOUNT_CENTS", String(FLAT_GIFT_CENTS));
+
+    // Fully gifted and never paid, so only the amount check stands between this org
+    // and a coupon worth $5 more than its entitlement.
+    const offer = await decideCheckoutWelcomeOffer(otherOrgId, "0.0000000000");
+    expect(offer).toEqual({ couponId: null, noticeMessage: null });
+  });
+
+  it("applies no discount when no coupon is configured, and still grants the credit", async () => {
+    await signupWithFlatGift(orgId);
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+
+    const res = await request(app)
+      .post("/v1/checkout-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({
+        success_url: "https://example.com/s",
+        cancel_url: "https://example.com/c",
+        topup_amount_cents: 5000,
+      });
+    expect(res.status).toBe(200);
+
+    const body = ssMocks.createCheckoutSession.mock.calls[0][1];
+    expect(body).not.toHaveProperty("discounts");
+    expect(body).not.toHaveProperty("custom_text");
+    // The credit is in the ledger either way — the discount is only its cash side.
+    expect(await giftedTotalCents(orgId)).toBe(FLAT_GIFT_CENTS);
+  });
+
+  it("applies no discount when the declared coupon amount is unparseable", async () => {
+    await signupWithFlatGift(orgId);
+    vi.stubEnv("WELCOME_DISCOUNT_COUPON_ID", COUPON_ID);
+    vi.stubEnv("WELCOME_DISCOUNT_COUPON_AMOUNT_CENTS", "thirty dollars");
+
+    expect(await decideCheckoutWelcomeOffer(orgId, "0.0000000000")).toEqual({
+      couponId: null,
+      noticeMessage: null,
+    });
+  });
+
+  // --- The referral ladder stacks on the new bar with no special-casing ---
+
+  it("a referred signup's $500 promise sits at $30 + $500, straight from the ladder", async () => {
+    await insertSignupAccount(otherOrgId); // the inviter
+    await insertSignupAccount(orgId); // the invitee
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+
+    // Materialise the invitee's welcome promise at its own $30 bar.
+    await settleFreeCreditPromises(orgId, "0.0000000000");
+    await claimReferral(orgId, otherOrgId);
+
+    const rows = await db
+      .select({
+        amountCents: freeCreditPromises.amountCents,
+        paidTriggerCents: freeCreditPromises.paidTriggerCents,
+      })
+      .from(freeCreditPromises)
+      .where(eq(freeCreditPromises.orgId, orgId));
+
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        { amountCents: 3000, paidTriggerCents: 3000 },
+        {
+          amountCents: CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+          paidTriggerCents: 3000 + CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+        },
+      ])
+    );
+  });
+});

--- a/tests/integration/free-credit-offer-cohorts.test.ts
+++ b/tests/integration/free-credit-offer-cohorts.test.ts
@@ -1,12 +1,15 @@
 /**
- * The free-credit offer is a PER-ACCOUNT property (migration 0032).
+ * The free-credit offer is a PER-ACCOUNT property (migration 0032, re-priced by 0040).
  *
- * distribute re-priced the offer from "$25 in free credits" to "$400 in free
- * credits", for NEW customers only: every org that already exists keeps the $25
- * offer it signed up under, permanently. These cases pin both cohorts side by side,
- * plus the two properties that make a THIRD re-price free: the amount is written
- * from the column DEFAULT at account creation, and the completion remainder stays
- * derived from what the org was actually gifted.
+ * distribute has re-priced it twice: $25 -> $400 -> a flat $30. Each re-price is for
+ * NEW customers only, so THREE cohorts now coexist and every org keeps the offer it
+ * signed up under, permanently. These cases pin all three side by side, plus the two
+ * properties that make the NEXT re-price free: the amount is written from the column
+ * DEFAULT at account creation, and the completion remainder stays derived from what
+ * the org was actually gifted.
+ *
+ * The flat $30 cohort's own behaviour (grant in full at signup, completion a clean
+ * no-op, discount on the checkout price) lives in flat-welcome-offer.test.ts.
  *
  * Own file, not a `describe` appended to welcome-completion.test.ts: that suite
  * closes the shared postgres.js connection in `afterAll`, which would take this
@@ -71,16 +74,24 @@ async function completionRows(orgId: string) {
     .where(eq(localPromoCodes.code, WELCOME_COMPLETION_CODE));
 }
 
-/** A NEW signup: inserted exactly the way findOrCreateAccount does it — org_id only. */
-async function insertSignupAccount(orgId: string) {
-  await db.insert(billingAccounts).values({ orgId });
+/**
+ * An account created between 0032 and 0040, i.e. the $400 MATCH cohort. Its figures
+ * are stated explicitly because they are no longer the column DEFAULT — which is the
+ * point: the re-price reached the default and left this row alone.
+ */
+async function insertLegacyMatchAccount(orgId: string) {
+  await db.insert(billingAccounts).values({
+    orgId,
+    freeCreditEntitlementCents: 40000,
+    freeCreditPaidTriggerCents: 40000,
+  });
   await db
     .update(billingAccounts)
     .set({ welcomeCompletionEligible: true })
     .where(eq(billingAccounts.orgId, orgId));
 }
 
-describe("per-account free-credit offer ($400 new cohort vs $25 grandfathered)", () => {
+describe("per-account free-credit offer (flat $30 current, $400 and $25 grandfathered)", () => {
   const app = createTestApp();
   let ssMocks: ReturnType<typeof setupStripeMocks>;
 
@@ -103,17 +114,17 @@ describe("per-account free-credit offer ($400 new cohort vs $25 grandfathered)",
 
   // --- AC: the amount is decided once, when the account comes into existence ---
 
-  it("a billing account created after this ships resolves to $400 / $400", async () => {
+  it("a billing account created after this ships resolves to $30 / $30", async () => {
     // Inserted with org_id only — exactly what findOrCreateAccount writes — so the
     // figures come from the column DEFAULT and nothing in code picks them.
     await db.insert(billingAccounts).values({ orgId: newOrgId });
 
     expect(await storedOffer(newOrgId)).toEqual({
-      entitlementCents: 40000,
-      paidTriggerCents: 40000,
+      entitlementCents: 3000,
+      paidTriggerCents: 3000,
     });
-    expect(CURRENT_FREE_CREDIT_ENTITLEMENT_CENTS).toBe(40000);
-    expect(CURRENT_FREE_CREDIT_PAID_TRIGGER_CENTS).toBe(40000);
+    expect(CURRENT_FREE_CREDIT_ENTITLEMENT_CENTS).toBe(3000);
+    expect(CURRENT_FREE_CREDIT_PAID_TRIGGER_CENTS).toBe(3000);
   });
 
   it("an account that existed before resolves to $25 / $25", async () => {
@@ -127,25 +138,43 @@ describe("per-account free-credit offer ($400 new cohort vs $25 grandfathered)",
     expect(GRANDFATHERED_FREE_CREDIT_PAID_TRIGGER_CENTS).toBe(2500);
   });
 
-  it("re-applying migration 0032 cannot re-price an account created under the new offer", async () => {
+  it("re-applying migration 0032 cannot re-price an account created under a later offer", async () => {
     await db.insert(billingAccounts).values({ orgId: newOrgId });
 
     // The two statements verbatim from 0032. ADD COLUMN IF NOT EXISTS is a no-op on
-    // a column that already exists, so the $400 row keeps its value — this is what
+    // a column that already exists, so the $30 row keeps its value — this is what
     // makes the migration safe to re-run.
     await sql`ALTER TABLE "billing_accounts" ADD COLUMN IF NOT EXISTS "free_credit_entitlement_cents" integer NOT NULL DEFAULT 2500`;
     await sql`ALTER TABLE "billing_accounts" ADD COLUMN IF NOT EXISTS "free_credit_paid_trigger_cents" integer NOT NULL DEFAULT 2500`;
 
     expect(await storedOffer(newOrgId)).toEqual({
+      entitlementCents: 3000,
+      paidTriggerCents: 3000,
+    });
+  });
+
+  it("re-applying migration 0040 writes no row, so no account is re-priced", async () => {
+    await insertLegacyMatchAccount(newOrgId);
+    await insertTestAccount({ orgId: oldOrgId });
+
+    // 0040 verbatim: it moves the DEFAULT and touches nothing.
+    await sql`ALTER TABLE "billing_accounts" ALTER COLUMN "free_credit_entitlement_cents" SET DEFAULT 3000`;
+    await sql`ALTER TABLE "billing_accounts" ALTER COLUMN "free_credit_paid_trigger_cents" SET DEFAULT 3000`;
+
+    expect(await storedOffer(newOrgId)).toEqual({
       entitlementCents: 40000,
       paidTriggerCents: 40000,
+    });
+    expect(await storedOffer(oldOrgId)).toEqual({
+      entitlementCents: 2500,
+      paidTriggerCents: 2500,
     });
   });
 
   // --- AC: each cohort earns its own remainder at its own trigger ---
 
-  it("new cohort: $399 of payments earns nothing; $400 grants the $395 remainder", async () => {
-    await insertSignupAccount(newOrgId);
+  it("$400 cohort: $399 of payments earns nothing; $400 grants the $395 remainder", async () => {
+    await insertLegacyMatchAccount(newOrgId);
     await insertTestPromoGrant({
       orgId: newOrgId,
       userId,
@@ -236,10 +265,10 @@ describe("per-account free-credit offer ($400 new cohort vs $25 grandfathered)",
     expect(await completionRows(oldOrgId)).toHaveLength(1);
   });
 
-  // --- REMOVED SURFACE: the up-front checkout discount ---
+  // --- The checkout page, for a cohort that still has a remainder coming ---
 
-  it("new cohort: a $500 first checkout gets the notice, NOT a discount", async () => {
-    await insertSignupAccount(newOrgId);
+  it("$400 cohort: a $500 first checkout gets the notice, NOT a discount", async () => {
+    await insertLegacyMatchAccount(newOrgId);
     ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
 
     await request(app)
@@ -252,8 +281,9 @@ describe("per-account free-credit offer ($400 new cohort vs $25 grandfathered)",
       });
 
     const body = ssMocks.createCheckoutSession.mock.calls[0][1];
-    // Below the floor: discounting here would hand over $400 of credit for a $100
-    // payment, i.e. the gift without the payment that earns it.
+    // This org has NOT been gifted its entitlement yet — the $395 remainder is still
+    // earned by paying. Discounting here would hand over credit the ledger does not
+    // hold, which is exactly what the discount gate forbids.
     expect(body).not.toHaveProperty("discounts");
     expect(body.custom_text).toEqual({
       submit: {
@@ -263,12 +293,16 @@ describe("per-account free-credit offer ($400 new cohort vs $25 grandfathered)",
     });
   });
 
-  // An $800 first checkout — the old floor for this cohort — used to be the ONE
-  // amount that carried a discount. No amount does any more, and the coupon env
-  // var being set must not bring it back.
-  it("removed: an $800 first checkout carries no discount either", async () => {
-    await insertSignupAccount(newOrgId);
+  // An $800 first checkout — the old (entitlement + trigger) floor for this cohort —
+  // used to be the ONE amount that carried a discount. The floor is gone and the
+  // discount is now gated on the entitlement being ALREADY gifted, which this org's
+  // is not: no checkout amount brings it back, and a configured coupon must not
+  // either.
+  it("$400 cohort: an $800 first checkout carries no discount, at any coupon config", async () => {
+    await insertLegacyMatchAccount(newOrgId);
     ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    vi.stubEnv("WELCOME_DISCOUNT_COUPON_ID", COUPON_ID);
+    vi.stubEnv("WELCOME_DISCOUNT_COUPON_AMOUNT_CENTS", "40000");
 
     await request(app)
       .post("/v1/checkout-sessions")
@@ -295,8 +329,8 @@ describe("per-account free-credit offer ($400 new cohort vs $25 grandfathered)",
     );
     expect(
       welcomeCompletionCheckoutNotice({
-        entitlementCents: CURRENT_FREE_CREDIT_ENTITLEMENT_CENTS,
-        paidTriggerCents: CURRENT_FREE_CREDIT_PAID_TRIGGER_CENTS,
+        entitlementCents: 40000,
+        paidTriggerCents: 40000,
       })
     ).toBe(
       "You get $400 in free credits. $5 now, the rest once your payments reach $400."
@@ -305,8 +339,8 @@ describe("per-account free-credit offer ($400 new cohort vs $25 grandfathered)",
 
   // --- AC: the grant is still exactly-once and still fails loud ---
 
-  it("stays exactly-once per org under concurrent settles at the new figure", async () => {
-    await insertSignupAccount(newOrgId);
+  it("stays exactly-once per org under concurrent settles at the $400 figure", async () => {
+    await insertLegacyMatchAccount(newOrgId);
 
     const outcomes = await Promise.all([
       settleWelcomeCompletion(newOrgId, cents(40000), NEVER_PRE_LAUNCH),

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -47,14 +47,15 @@ beforeAll(async () => {
   // Welcome-completion eligibility (migration 0029). DEFAULT true = a brand-new org
   // is eligible; 0029 flipped pre-existing prod accounts to false (no backfill).
   await sql`ALTER TABLE "billing_accounts" ADD COLUMN IF NOT EXISTS "welcome_completion_eligible" boolean NOT NULL DEFAULT true`;
-  // Per-account free-credit offer (migration 0032). Existing rows were backfilled to
-  // the grandfathered $25/$25; the DEFAULT is the current $400/$400 offer, so any
-  // account inserted WITHOUT these columns resolves to the new offer — which is
-  // exactly how a real signup gets it (findOrCreateAccount inserts org_id only).
+  // Per-account free-credit offer (migration 0032, re-priced by 0040). Existing rows
+  // were backfilled to the grandfathered $25/$25; the DEFAULT is the current flat
+  // $30/$30 offer, so any account inserted WITHOUT these columns resolves to the new
+  // offer — which is exactly how a real signup gets it (findOrCreateAccount inserts
+  // org_id only).
   await sql`ALTER TABLE "billing_accounts" ADD COLUMN IF NOT EXISTS "free_credit_entitlement_cents" integer NOT NULL DEFAULT 2500`;
   await sql`ALTER TABLE "billing_accounts" ADD COLUMN IF NOT EXISTS "free_credit_paid_trigger_cents" integer NOT NULL DEFAULT 2500`;
-  await sql`ALTER TABLE "billing_accounts" ALTER COLUMN "free_credit_entitlement_cents" SET DEFAULT 40000`;
-  await sql`ALTER TABLE "billing_accounts" ALTER COLUMN "free_credit_paid_trigger_cents" SET DEFAULT 40000`;
+  await sql`ALTER TABLE "billing_accounts" ALTER COLUMN "free_credit_entitlement_cents" SET DEFAULT 3000`;
+  await sql`ALTER TABLE "billing_accounts" ALTER COLUMN "free_credit_paid_trigger_cents" SET DEFAULT 3000`;
 
   // Drop legacy columns if a stale local DB still has them.
   await sql`ALTER TABLE "billing_accounts" DROP COLUMN IF EXISTS "balance_cents"`;


### PR DESCRIPTION
## What

The welcome offer becomes a **flat $30, granted in full at signup**, unconditionally. No payment threshold, no second instalment, nothing to earn.

Exactly ONE $30 per org, delivered through two sides of the same gift:

```
credit granted = $30, always, at signup
cash charged   = max($0, daily_budget - $30) at the onboarding checkout
```

A $30/day signup pays nothing and starts with $30 of balance. A $50/day signup pays $20 and starts with $50. Both received exactly $30. **It is never $60 and never $0** — pinned by tests, not left as a property of the arithmetic.

## Migration 0040 — one line, no row written, no backfill

`ALTER COLUMN free_credit_{entitlement,paid_trigger}_cents SET DEFAULT 3000`. That is the whole migration: the offer has been a per-account property frozen at creation since 0032, so moving the DEFAULT reaches future signups only.

**No backfill is needed and none is performed, and this is confirmed against production, not assumed.** Read directly from `billing_service` before writing the migration:

| entitlement / trigger | accounts |
|---|---|
| 2500 / 2500 (grandfathered) | 93 |
| 40000 / 40000 ($400 cohort) | 10 |

All 103 hold their own frozen figures and are untouched by construction. There are **three** cohorts now, not two. Deliberately no `ADD COLUMN` half: repeating 0032's backfill is the only way this could reach an existing account, so it is absent. Idempotent (SET DEFAULT is idempotent and no row is written); reverse SQL is in the migration header.

`tests/integration/free-credit-offer-cohorts.test.ts` replays 0040 verbatim, twice, and asserts both older cohorts keep their exact figures.

## `settleWelcomeCompletion` needed no special case

Its remainder has always been `entitlement − SUM(what was already gifted)`. Signup now grants the full $30, so the two sides are equal, the remainder is zero, and it returns `entitlement_already_full` and **inserts nothing** — at any payment amount, at any number of settles. A test proves no row is written and no `$0` promo appears.

The machinery stays for the two match cohorts, which still earn their remainder at their own trigger. Tests cover both.

## The checkout discount comes back — and this is not a revert

The comment that forbade it said a discount "is the one place a buyer can be handed credit before the payment that earns it has cleared", and it required a floor of `entitlement + trigger` so the post-discount charge still reached the trigger. **Both statements were about the MATCH**: the credit had not been granted yet, and paying is what earned it. With the gift granted at signup and no trigger, nothing is advanced and the hazard has no way to occur. The comment is **updated to say why it is now safe**, not deleted — the reasoning is exactly what changed.

The new gate is **stricter than the old floor**. All must hold:

- the org already holds its **FULL** entitlement in `local_promos`, so the discount can only mirror credit already in the ledger;
- the org has **never paid**, so it lands once on the onboarding checkout and can never repeat on a later top-up;
- the configured coupon's **declared amount equals that org's own frozen entitlement**.

`decideCheckoutWelcomeNotice` → `decideCheckoutWelcomeOffer(orgId, paidTopupsCents)`, returning `{couponId, noticeMessage}` where **exactly one is ever set by construction** (discount requires remaining ≤ 0, notice requires remaining > 0).

## ⚠️ Two env vars + a Stripe coupon are needed before the discount appears

```
WELCOME_DISCOUNT_COUPON_ID            = <a Stripe coupon, amount_off 3000, USD, once>
WELCOME_DISCOUNT_COUPON_AMOUNT_CENTS  = 3000
```

Declared together so they cannot drift. The amount is declared rather than read back from Stripe because billing has **no coupon read** (stripe-service exposes none) and it must be known — a coupon worth the wrong amount is money. This makes a re-price **fail safe**: move the offer without minting a matching coupon and the discount simply stops applying (buyer charged in full, credit still granted) instead of taking the old figure off the new price. It is also what stops a grandfathered $25 org being handed a $30 coupon.

**Until both are set, this PR changes nothing about any checkout page** — the discount is simply absent and the credit is granted exactly as it will be afterwards. So the deploy is safe in any order, and the coupon can be minted after the promote.

## Referral ladder — falls out, no special-casing

A new promise's bar is `(highest bar this org already carries) + (its own amount)`, and `highestBarCents` reads the account's frozen trigger. With the welcome bar at $30, a referred signup's $500 promise sits at **$30 + $500 = $530**. (The brief said "$500 not $900"; the exact figure is $530 — the ladder always stacks above the welcome bar, as it does for the $25 cohort at $525.) Covered by a test; zero code change.

## Not touched

- The `$5` → `$30` signup grant amount: it lives on the `welcome` `local_promo_codes` row and is re-priced at runtime by the dashboard's boot `PATCH /v1/promo-codes/welcome`. Nothing here hardcodes it (`WELCOME_PROMO_AMOUNT_CENTS` is only a fresh-database seed default). Until that lands, a new $30 account gets $5 at signup and the completion grants the remaining $25 at $30 of payments — a coherent interim, not a break.
- The referral offer's own amount.
- Balance composition, idempotency (promo `idempotency_key`, both partial unique indexes), `allow_promotion_codes` (still off).
- `openapi.json` — no route shape moved.

## Verification

- Full suite: **728 passed / 65 files**, `tsc --noEmit` clean, `pnpm build` clean.
- New `tests/integration/flat-welcome-offer.test.ts` (12 cases): the $30/$30 default; the zero-remainder no-op inserting nothing; total stays exactly $30 across four payment amounts; the never-$0 direction; $400 and $25 accounts untouched and still two-stage; the discount visible on a payment-mode checkout; no discount on a later top-up; no $30 coupon for a $25 org; no discount without config or with an unparseable amount; the $530 referral bar.
- Production cohort counts read directly from `billing_service` (above). A prod-dump replay of 0040 was attempted on a scratch database and abandoned when `docker exec ... psql` on the box stopped responding; the statements write zero rows and are replayed twice against the real schema in CI instead.

## Triage

Feature → `staging`, then promote to `main`. The dashboard change is gated on this being live in prod.
