### PR TITLE
release: a granted welcome is not a rung on the referral ladder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,19 +122,24 @@ Until 0033 an org had exactly ONE outstanding promise, expressed as the two `bil
 **The rules (product-locked):**
 
 - `amount_cents` and `paid_trigger_cents` are **FROZEN at creation and never updated**. Re-pricing an offer later reaches only promises created after the re-price — no cutoff date, no backfill, every existing customer grandfathered by construction. Same discipline as 0032, and the reason `insertStackedPromise` is the ONLY writer.
-- **The bar of a NEW promise is `(highest bar this org already carries) + (its own amount)`** — whether or not that earlier promise has been earned, because cumulative payments only ever go up. `highestBarCents` reads BOTH the promises table and the account's own frozen trigger, so it is right even for an org whose welcome promise row was never materialised. The ladder:
+- **The bar of a NEW promise is `(highest bar this org already carries that a PAYMENT stands behind) + (its own amount)`.** Whether that earlier promise has been earned YET does not matter (cumulative payments only ever go up); whether it can EVER be earned does. **A promise that is GRANTED rather than EARNED contributes nothing to the ladder** — its bar is not a bar, because no payment is behind it, and stacking on it would charge the next promise for money the customer was never asked to spend. The ladder:
 
   | situation | ladder |
   |---|---|
-  | brand-new $30 account | $30 @ $30 |
-  | ...then referred | + $500 @ $530 |
-  | ...a third promise | + $500 @ $1,030, and so on, no ceiling |
+  | brand-new $30 account (GRANTED in full at signup) | $30 @ $30 — worth nothing, never listed, and NOT a rung |
+  | ...then referred | + $500 @ **$500** |
+  | ...a third promise | + $500 @ $1,000, and so on, no ceiling |
   | $400 account, referred | $400 @ $400, then $500 @ $900 |
   | grandfathered $25 account, referred | $25 @ $25, then $500 @ $525 |
 
-  The flat-$30 re-price (0040) needed NO change here and no special case: the welcome
-  bar is read off the account's own frozen trigger, so it simply became $30 and every
-  referral stacks $500 above whatever that org carries.
+  **"Granted rather than earned" is read off the org's OWN frozen figures, never off the kind** — keying on `kind='welcome'` would retroactively demote the two MATCH cohorts, whose welcome genuinely had a payments trigger. `highestBarCents` takes the up-front `welcome` gift the org RECEIVED (or, before that row exists, the amount the live `welcome` code says it is about to receive — a referral claimed in the seconds before the signup grant lands must not get a different ladder from one claimed after it) and compares it to the entitlement frozen on the account:
+
+  - gift **<** entitlement → a REMAINDER is earned at the account's trigger, so that trigger is a real bar **forever**, including after the completion has landed. The $25 and $400 cohorts are untouched in both directions.
+  - gift **==** entitlement (the flat $30 offer) → signup already gave everything, so the trigger is not a bar and the referral sits at its own $500.
+
+  It reads the account rather than the welcome promise ROW for the same reason it always did (an org excluded from the welcome completion never gets a row yet still carries the bar), and takes `MAX(paid_trigger_cents)` over the org's REFERRAL promises only — those are earned on payments by construction, which is what keeps $500 / $1,000 / $1,500 stacking with no ceiling.
+
+  **Existing rows are untouched.** This changes only what a NEW promise freezes; an org still carrying a $500-@-$530 or $500-@-$900 promise keeps it exactly, and the next promise stacks above it. Pinned by tests in `tests/integration/flat-welcome-offer.test.ts`.
 
 - **An outstanding promise is a promise, not money.** No `local_promos` row exists until it is granted, so it is absent from `credited` / `balance` / `actual_balance` / spendable everywhere. Do NOT "helpfully" surface it in a balance figure.
 - **The referral offer has NO up-front portion** — the whole amount lands when the bar is crossed. The $5 up-front gift belongs to the welcome offer only, and is unchanged for every cohort.

--- a/src/lib/free-credit-promises.ts
+++ b/src/lib/free-credit-promises.ts
@@ -24,14 +24,28 @@
  *
  * ## The ladder
  *
- * The bar of a NEW promise is (the highest bar this org already carries) + (the new
- * promise's own amount) — whether or not that earlier promise has been earned,
- * because cumulative payments only ever go up so both readings give the same ladder:
+ * The bar of a NEW promise is (the highest bar this org already carries that some
+ * PAYMENT stands behind) + (the new promise's own amount). Whether that earlier
+ * promise has been earned YET does not matter — cumulative payments only ever go up,
+ * so both readings give the same ladder — but whether it can EVER be earned does: a
+ * promise handed over at signup has no payment behind its bar, so stacking on it
+ * would charge the next promise for money the customer was never asked to spend.
  *
- *   brand-new $400 account          → $400 @ $400          (unchanged from today)
+ *   brand-new $400 account          → $400 @ $400
  *   ...then referred a $500 promise → $500 @ $900
  *   ...then a third $500 promise    → $500 @ $1,400        (and so on, no ceiling)
  *   grandfathered $25 account       → $25 @ $25, $500 @ $525
+ *   flat $30 account (GRANTED)      → $30 @ $30 (worth nothing, never listed),
+ *                                     then $500 @ $500 — the granted welcome is not
+ *                                     a rung, because no payment earns it
+ *
+ * "Granted rather than earned" is read off the org's OWN figures and nothing else:
+ * the up-front `welcome` gift it received (or, before that row exists, the gift the
+ * live code says it will receive) against the entitlement frozen on its account. Gift
+ * < entitlement means a REMAINDER is earned at the account's trigger, so that trigger
+ * is a real bar and stays one FOREVER — including after the completion has landed,
+ * which is why the two MATCH cohorts are unaffected in either direction. Gift ==
+ * entitlement means signup already gave everything and there is nothing to earn.
  *
  * ## The referral chain
  *
@@ -80,6 +94,7 @@ import {
   PROMISE_KIND_REFERRAL,
   PROMISE_KIND_WELCOME,
   REFERRAL_REWARD_CODE,
+  WELCOME_PROMO_CODE,
   type FreeCreditPromise,
 } from "../db/schema.js";
 import { addCents, gte, subCents } from "./cents.js";
@@ -158,18 +173,54 @@ export async function referralRewardCodeExists(): Promise<boolean> {
 }
 
 /**
- * The highest bar this org already carries, in whole cents.
+ * The highest bar this org already carries that a PAYMENT stands behind, in whole
+ * cents — the rung a new promise stacks on.
  *
- * Reads the promises table AND the account's own frozen trigger, so it is correct
- * even for an org whose welcome promise row has not been materialised (an account
- * excluded from the welcome completion never gets one, yet it still carries that
- * bar). 0 when the org has neither.
+ * Two sources, and the welcome offer is deliberately NOT read out of the promises
+ * table:
+ *
+ *   - every REFERRAL promise's frozen bar. Those are earned on payments by
+ *     construction (the referral offer has no up-front portion), so they always
+ *     stack, which is what keeps $500, $1,000, $1,500 … working with no ceiling.
+ *   - the account's OWN frozen welcome trigger, but only while some of the welcome
+ *     entitlement is still EARNED at it. Reading it off the account rather than off
+ *     the welcome promise row is also what makes this correct for an org whose
+ *     welcome promise was never materialised (an account excluded from the welcome
+ *     completion never gets one, yet it still carries that bar).
+ *
+ * The up-front gift is this org's own `welcome` grant; before that row exists we
+ * read the live `welcome` code, which is what the org is about to be given — a
+ * referral claimed in the seconds before the signup grant lands must not get a
+ * different ladder from one claimed after it.
+ *
+ * 0 when the org carries neither, which is also exactly what the flat $30 cohort
+ * answers: its whole entitlement was granted at signup, so its trigger is not a bar.
  */
 async function highestBarCents(runner: Tx | typeof db, orgId: string): Promise<number> {
   const rows = (await runner.execute(rawSql`
     SELECT GREATEST(
-      COALESCE((SELECT MAX(paid_trigger_cents) FROM free_credit_promises WHERE org_id = ${orgId}), 0),
-      COALESCE((SELECT free_credit_paid_trigger_cents FROM billing_accounts WHERE org_id = ${orgId}), 0)
+      COALESCE((
+        SELECT MAX(paid_trigger_cents)
+          FROM free_credit_promises
+         WHERE org_id = ${orgId}
+           AND kind <> ${PROMISE_KIND_WELCOME}
+      ), 0),
+      COALESCE((
+        SELECT CASE
+                 WHEN COALESCE(
+                        (SELECT SUM(lp.amount_cents)
+                           FROM local_promos lp
+                           JOIN local_promo_codes c ON c.id = lp.promo_code_id
+                          WHERE lp.org_id = a.org_id AND c.code = ${WELCOME_PROMO_CODE}),
+                        (SELECT amount_cents FROM local_promo_codes WHERE code = ${WELCOME_PROMO_CODE}),
+                        0
+                      ) >= a.free_credit_entitlement_cents
+                 THEN 0
+                 ELSE a.free_credit_paid_trigger_cents
+               END
+          FROM billing_accounts a
+         WHERE a.org_id = ${orgId}
+      ), 0)
     )::int AS bar
   `)) as unknown as Array<{ bar: number }>;
   return Number(rows[0]?.bar ?? 0);
@@ -302,8 +353,10 @@ export async function claimReferral(
     return { promise: existing, alreadyClaimed: true };
   }
 
-  // The invitee's own welcome promise must exist first, or the referral bar would
-  // stack on nothing and land at $500 instead of $900.
+  // Materialise the invitee's own welcome promise first, so the dashboard lists what
+  // the org actually carries. It does not decide the referral bar: highestBarCents
+  // reads the welcome offer off the account either way, and ignores it entirely when
+  // that offer was GRANTED at signup rather than earned on payments.
   await db.insert(billingAccounts).values({ orgId }).onConflictDoNothing();
   await ensureWelcomePromise(orgId);
 

--- a/tests/integration/flat-welcome-offer.test.ts
+++ b/tests/integration/flat-welcome-offer.test.ts
@@ -53,6 +53,8 @@ const COUPON_ID = "coupon_welcome_30";
 const orgId = "00000000-0000-0000-0000-0000000005a1";
 const otherOrgId = "00000000-0000-0000-0000-0000000005a2";
 const userId = "00000000-0000-0000-0000-0000000005a3";
+const invitee1 = "00000000-0000-0000-0000-0000000005a4";
+const invitee2 = "00000000-0000-0000-0000-0000000005a5";
 
 const NEVER_PRE_LAUNCH = () => Promise.resolve("0.0000000000");
 const cents = (n: number) => `${n}.0000000000`;
@@ -346,33 +348,118 @@ describe("flat $30 welcome offer, granted in full at signup", () => {
     });
   });
 
-  // --- The referral ladder stacks on the new bar with no special-casing ---
+  // --- A GRANTED welcome is not a rung: the referral ladder ignores it ---
 
-  it("a referred signup's $500 promise sits at $30 + $500, straight from the ladder", async () => {
-    await insertSignupAccount(otherOrgId); // the inviter
-    await insertSignupAccount(orgId); // the invitee
-    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
-
-    // Materialise the invitee's welcome promise at its own $30 bar.
-    await settleFreeCreditPromises(orgId, "0.0000000000");
-    await claimReferral(orgId, otherOrgId);
-
+  /** Every promise the org carries, as (amount, bar), cheapest bar first. */
+  async function promiseLadder(id: string) {
     const rows = await db
       .select({
         amountCents: freeCreditPromises.amountCents,
         paidTriggerCents: freeCreditPromises.paidTriggerCents,
       })
       .from(freeCreditPromises)
-      .where(eq(freeCreditPromises.orgId, orgId));
+      .where(eq(freeCreditPromises.orgId, id));
+    return rows
+      .map((r) => [r.amountCents, r.paidTriggerCents])
+      .sort((a, b) => a[1] - b[1] || a[0] - b[0]);
+  }
 
-    expect(rows).toEqual(
-      expect.arrayContaining([
-        { amountCents: 3000, paidTriggerCents: 3000 },
-        {
-          amountCents: CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
-          paidTriggerCents: 3000 + CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
-        },
-      ])
-    );
+  /** One referral all the way through: the invitee claims, pays, and converts. */
+  async function convertReferral(inviteeId: string, inviterOrgId: string) {
+    await signupWithFlatGift(inviteeId);
+    await claimReferral(inviteeId, inviterOrgId);
+    await settleFreeCreditPromises(inviteeId, cents(1_000_000));
+  }
+
+  it("a referred signup earns its $500 at $500, not at $30 + $500", async () => {
+    await signupWithFlatGift(otherOrgId); // the inviter
+    await signupWithFlatGift(orgId); // the invitee
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+
+    // Materialise the invitee's welcome promise, exactly as the dashboard read does.
+    await settleFreeCreditPromises(orgId, "0.0000000000");
+    await claimReferral(orgId, otherOrgId);
+
+    expect(await promiseLadder(orgId)).toEqual([
+      // The welcome promise stays frozen at its own figures, and contributes no rung:
+      // nothing earns it, so the referral sits at its own $500.
+      [FLAT_GIFT_CENTS, FLAT_GIFT_CENTS],
+      [CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS, CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS],
+    ]);
+  });
+
+  it("a second referral promise still stacks above the first", async () => {
+    await signupWithFlatGift(orgId); // the inviter
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+
+    await convertReferral(invitee1, orgId);
+    await convertReferral(invitee2, orgId);
+
+    expect(await promiseLadder(orgId)).toEqual([
+      [FLAT_GIFT_CENTS, FLAT_GIFT_CENTS],
+      [CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS, CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS],
+      [
+        CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+        CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS * 2,
+      ],
+    ]);
+  });
+
+  it("a welcome offer genuinely EARNED on payments still sets the bar", async () => {
+    // The $400 MATCH cohort: $5 at signup, the $395 remainder earned at $400. Its
+    // trigger is a real bar and stays one, so the referral stacks to $900.
+    await insertTestAccount({
+      orgId,
+      welcomeCompletionEligible: true,
+      freeCreditEntitlementCents: 40000,
+      freeCreditPaidTriggerCents: 40000,
+    });
+    await insertTestPromoGrant({
+      orgId,
+      userId,
+      amountCents: 500,
+      promoCode: WELCOME_PROMO_CODE,
+    });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    await settleFreeCreditPromises(orgId, "0.0000000000");
+
+    await claimReferral(orgId, otherOrgId);
+
+    expect(await promiseLadder(orgId)).toEqual([
+      [40000, 40000],
+      [
+        CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+        40000 + CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+      ],
+    ]);
+  });
+
+  it("an EXISTING promise row is never re-barred, and a new one stacks above it", async () => {
+    await signupWithFlatGift(orgId); // the inviter
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("0.0000000000");
+    await settleFreeCreditPromises(orgId, "0.0000000000");
+
+    // A promise frozen under the OLD ladder ($500 @ $530), as prod may hold.
+    await db.insert(freeCreditPromises).values({
+      orgId,
+      kind: "referral",
+      amountCents: CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+      paidTriggerCents: FLAT_GIFT_CENTS + CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+      referredOrgId: invitee2,
+    });
+
+    await convertReferral(invitee1, orgId);
+
+    expect(await promiseLadder(orgId)).toEqual([
+      [FLAT_GIFT_CENTS, FLAT_GIFT_CENTS],
+      [
+        CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+        FLAT_GIFT_CENTS + CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+      ],
+      [
+        CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS,
+        FLAT_GIFT_CENTS + CURRENT_REFERRAL_PROMISE_AMOUNT_CENTS * 2,
+      ],
+    ]);
   });
 });


### PR DESCRIPTION
Promote #428 to production. A referred signup earns its $500 referral credits at $500, not $530 — the flat $30 welcome is granted at signup, so no payment stands behind its bar. Existing promise rows untouched; no migration.