### PR TITLE
feat(debt): settle before a card change, and never skip an uncollectable debt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,51 @@ Nothing about the balance, the checkout or the top-up flows changed, and no org 
 
 The same CSV convention applies to the `x-brand-id` header forwarded by workflow-service for multi-brand campaigns.
 
+## Settle the debt before the card may change (`src/lib/card-change-settlement.ts`)
+
+A customer who owes us money on the postpaid credit line must never be able to leave us holding the debt with no card to collect it. Google Ads, Meta and AWS all settle the outstanding balance before the payment method may be changed, and billing is the only service that knows what is owed — stripe-service separately makes the acquirer's card page replace-only, but the collection has to happen here.
+
+`settleOutstandingBeforeCardChange(orgId)` runs at the top of **both** `POST /v1/portal-sessions` and `POST /v1/accounts/card_setup`. They serve ONE descriptor, so they must gate identically or the gate is one URL away from being bypassed.
+
+| situation | what happens |
+|---|---|
+| balance ≥ 0 | session opens exactly as before, nothing charged |
+| negative, chargeable card | charge EXACTLY the outstanding amount; success opens the session |
+| charge declines / backoff / stripe-service errors | **402**, no session, body states what is owed |
+| negative, NO card | session OPENS — adding a card is the only way out of the debt |
+| negative, off_session-blocked card (India) | session OPENS — no off_session settle is possible on that card at all |
+| negative, under $0.50 | session OPENS — Stripe rejects the charge; rolls into the month-end sweep |
+
+- **The amount is `computeSettleCharge`, imported from the month-end sweep, never restated.** Two surfaces computing "settle to zero" separately is how they start disagreeing. Do NOT charge a tier multiple here for the same reason the sweep does not: there is no credit line to restore, only a balance to zero.
+- **The refusal is 402 with a stable `code: "outstanding_balance_unsettled"`**, plus `owed_cents` / `balance_cents` / `reason` (`charge_failed` | `charge_backoff`). It has to be distinguishable from a 400 (bad body), a 404 (no account) and a 502 (stripe-service down), because it is the ONE failure of these routes the customer can act on. Body shape lives in `src/lib/outstanding-balance-response.ts`.
+- **Idempotency keys on (org, UTC DAY, amount).** The amount is in the key for the reason the sweep documents at length (an acquirer replays a key whose parameters changed); the DAY is in it so a double-click collapses onto one charge while a legitimate settle of the same amount next week still goes through.
+- Goes through `coalesceReload`, so a card that just declined is refused by the existing backoff instead of being hammered — that refusal reaches the customer as `reason: "charge_backoff"`.
+- **Fail-loud**: nothing here falls back to opening the session anyway.
+
+## An unpaid debt we cannot collect is VISIBLE, never silently skipped (`src/lib/unpaid-debt.ts`, migration 0041)
+
+An org whose balance is negative and whose last chargeable card is gone owes us money we have no way to take. The month-end sweep used to count it `skipped`, and the debt then disappeared from every surface: no email, no staff signal, campaigns still running and the debt still growing.
+
+**Two things are deliberately REUSED rather than rebuilt, and that is most of the design:**
+
+- **Campaigns stop on their own.** `resolvePostpaidTier` grants a NEGATIVE credit-line floor only to an org that can actually be reloaded (config + chargeable card + non-blocked country), so losing the card drops the floor to `"0"` and both the authorize gate and the read-only affordability pre-flight read the org as depleted at any balance ≤ 0. Nothing in this feature stops anything.
+- **The state is the existing depletion EPISODE.** No new table and no second lifecycle: recovery stays keyed on `credited` rising (a real recharge), and adding a card back restores the credit line, which re-arms auto-reload and the month-end sweep. That is the whole of "adding a card resumes things through the existing dunning recovery path".
+
+**What is new is the telling.** Two sends, claimed at most once per episode by `card_required_notified_at`:
+
+- `credit-debt-card-required` → the customer, with the amount owed. Deliberately NOT one of the six `credit-depleted*` templates: those nudge "turn on auto-topup" and the `-blocked` variants nudge a manual recharge, and neither is reachable without a card on file.
+- `unpaid_debt_uncollectable` → staff, routed by transactional-email-service to the staff list it already owns (same shape as `brand_daily_budget_changed`; no recipient list lives here).
+
+Both are registered by THIS service in `src/instrument.ts` (a template belongs to whoever SENDS it), and both hang off a REAL platform run — `createPlatformRun` first, and a run we cannot open DEFERS the notification WITHOUT claiming the marker, so the next tick retries rather than burning the only send.
+
+**Three entry points, one function** (`flagUncollectableDebt`): the month-end sweep (which now counts `unpaidDebt`, never `skipped`), `POST /internal/payment-methods/lost` (stripe-service's immediate signal), and the hourly `runUnpaidDebtScan` on the existing dunning scheduler — the backstop that catches an org which went into debt while already card-less, refreshes the amount as the debt grows, and CLEARS the flag when a card returns (so the org leaves the staff surface and a LATER loss notifies afresh). The scan is bounded by the number of billing accounts (~100 in prod), one balance composition each, isolated per org.
+
+**`uncollectable_debt_cents` is frozen on the episode at flag time and refreshed on every tick while the debt persists**, so `GET /internal/unpaid-debts` is one query rather than a per-org fan-out.
+
+**A debt on an off_session-BLOCKED card (India) is counted (`blockedCountryDebt`) and logged, not flagged and not emailed** — the existing `-blocked` dunning copy already tells those customers to recharge manually, and a second mechanism must not mail them twice. It is still never `skipped`.
+
+**Fail-soft on the telling, fail-loud on the state**: a notification failure can never touch the money it describes, but a database failure propagates.
+
 ## Off_session auto-reload — country eligibility (India / RBI e-mandates)
 
 **Off_session auto-reload is IMPOSSIBLE for cards issued in some countries, and Stripe cannot fix it through the path billing uses. India is the confirmed, prod-observed case (GH #220).** Hard Stripe facts (verified against docs 2026-06-27 — re-verify before changing this):
@@ -514,7 +559,7 @@ Growth rows expose `credited_cents` and `revenue_cents` only, both NET (they rea
 | `PATCH` | `/v1/accounts/auto_topup` | configure auto-topup; body must include both `topup_amount_cents` and `topup_threshold_cents` |
 | `DELETE` | `/v1/accounts/auto_topup` | disable auto-topup |
 | `POST` | `/v1/checkout-sessions` | one-shot top-up or setup-mode PM capture via Stripe Checkout; does NOT configure auto-topup. Payment mode carries the gift-is-coming notice quoting that org's own figures. Nothing discounts the charge: onboarding already subtracted the gift from the amount it sends. See "Checkout page" |
-| `POST` | `/v1/portal-sessions` | Stripe Customer Portal session |
+| `POST` | `/v1/portal-sessions` | How this org's customer adds a card (historical name). **Settles any outstanding balance FIRST** — 402 `outstanding_balance_unsettled` when it cannot. See "Settle the debt before the card may change". |
 | `POST` | `/v1/customer_balance/authorize` | check if `balance_cents >= amount` ; auto-reload via PI if configured |
 | `POST` | `/v1/customer_balance/usage_apply` | proactive topup hint after a run; no-op for the ledger |
 | `POST` | `/v1/promotion_codes/redeem` | redeem promo code → insert `local_promos` row |
@@ -524,6 +569,8 @@ Growth rows expose `credited_cents` and `revenue_cents` only, both NET (they rea
 | `POST` | `/internal/referrals/claim` | client-service records that an org signed up through another org's invite link — body `{orgId, referrerOrgId}` → `{ok, alreadyClaimed, promise}`. Opens the INVITEE's outstanding referral promise (bar stacks above every bar it already carries) and remembers the referrer; grants NOTHING. Service-auth only. Idempotent on a re-claim; **409** when the org was already referred by a DIFFERENT org; 400 on self-referral; 500 when the `referral_reward` seed is missing. See "Free-credit promises". |
 | `GET` | `/v1/free-credit-promises` | every promise this org is still waiting on, for the customer dashboard (via the api-service gateway; org headers). → `{org_id, paid_topups_cents, outstanding_total_cents, promises[]}` cheapest bar first, each with `amount_cents` (what would actually land), `paid_trigger_cents`, `paid_so_far_cents`, `remaining_to_unlock_cents`, `progress_pct`, `referred_org_id` (the referred org that caused it) + `referred_org_name` / `referred_org_domain` (that org's display identity, resolved here — see "Naming the referral"), `referrer_org_id`. Settles first, so an earned grant lands sooner; it can never conjure one. 502 when stripe-service is down. |
 | `POST` | `/internal/dunning/tick` | run one out-of-credit dunning pass (ops/manual). Same pass runs on the in-process hourly scheduler. → `{processed, recovered, followup3dSent, followup10dSent}`. |
+| `POST` | `/internal/payment-methods/lost` | stripe-service reports that an org's last chargeable payment method is gone; billing decides what it means. Body `{orgId}` → `{orgId, state, owed_cents}`. An org with a NEGATIVE balance and no card now carries a debt we cannot collect → flagged, customer emailed ("add a card", with the amount), staff emailed, campaigns already stopped by the credit-line floor. Owes nothing / still has a card → no-op, so a false alarm is free. Idempotent per depletion episode. See "An unpaid debt we cannot collect". |
+| `GET` | `/internal/unpaid-debts` | Staff read: every org currently owing money we cannot collect → `{unpaid_debts:[{org_id, owed_cents, flagged_at, episode_started_at}]}`. A plain DB read (the amount is frozen on the episode at flag time and refreshed hourly), not a balance composition per org. A row leaves the list when a card comes back or the balance is restored. |
 | `GET` | `/internal/campaigns/:campaignId/affordability` | READ-ONLY pre-flight gate (campaign-service). → `{affordable, balanceCents, lastRequiredCents, hasHistory}`. ZERO side effects. See "Campaign affordability gate" below. |
 | `GET` | `/internal/brands/:brandId/daily-budget` | READ this org's current daily budget for a brand (service auth + `x-org-id`). → `{brandId, dailyBudgetCents, updatedAt}`; unset for that org → `dailyBudgetCents:null, updatedAt:null`. See "Per-brand daily budget" below. |
 | `GET` | `/internal/brands/:brandId/daily-budget/history` | READ this org's ordered daily-budget CHANGE history for a brand (service auth + `x-org-id`, same auth as the current-value read). → `{brandId, history:[{dailyBudgetCents, changedAt}]}` oldest-first; no writes since the feature shipped → `history:[]`. Forward-only (no fabricated backfill). Consumer = features-service customer-health board. See "Per-brand daily budget". |

--- a/drizzle/0041_unpaid_debt_notification.sql
+++ b/drizzle/0041_unpaid_debt_notification.sql
@@ -1,0 +1,35 @@
+-- 0041 — an unpaid debt we cannot collect is VISIBLE, never silently skipped.
+--
+-- An org with a negative balance and no chargeable card owes us money we have no
+-- way to take. Before this, the month-end sweep counted it as `skipped` and the
+-- debt disappeared from every surface: no email, no staff signal, campaigns
+-- still running and the debt still growing.
+--
+-- Two ADDITIVE columns on the existing depletion episode — the dunning state we
+-- already open for an out-of-credit org — rather than a new table, so the
+-- existing recovery path (credited rising closes the episode) keeps owning the
+-- lifecycle and nothing new has to be reconciled:
+--
+--   card_required_notified_at  claims the ONE "a card is required" notification
+--                              (customer + staff) per episode. "Did we grant"
+--                              and "did we tell them" are different questions,
+--                              and the hourly sweep re-examines every open
+--                              episode, so without a marker a customer would be
+--                              mailed about the same debt forever.
+--   uncollectable_debt_cents   the amount owed at flag time, refreshed on each
+--                              tick while still uncollectable, so the staff read
+--                              is a plain DB read with no per-org fan-out.
+--
+-- Both NULL on every existing row: an episode that has never been flagged reads
+-- exactly as it did. NULL is a permanent first-class value ("this debt is
+-- collectable / was never uncollectable"), not a placeholder.
+--
+-- Reverse:
+--   ALTER TABLE "credit_depletion_episodes" DROP COLUMN "card_required_notified_at";
+--   ALTER TABLE "credit_depletion_episodes" DROP COLUMN "uncollectable_debt_cents";
+
+ALTER TABLE "credit_depletion_episodes"
+  ADD COLUMN IF NOT EXISTS "card_required_notified_at" timestamp with time zone;
+
+ALTER TABLE "credit_depletion_episodes"
+  ADD COLUMN IF NOT EXISTS "uncollectable_debt_cents" numeric(16,10);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1791626400000,
       "tag": "0040_flat_thirty_free_credit_offer",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1791712800000,
+      "tag": "0041_unpaid_debt_notification",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -265,6 +265,40 @@
           "mode"
         ]
       },
+      "OutstandingBalanceResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string",
+            "enum": [
+              "outstanding_balance_unsettled"
+            ]
+          },
+          "owed_cents": {
+            "type": "string"
+          },
+          "balance_cents": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "charge_failed",
+              "charge_backoff"
+            ]
+          }
+        },
+        "required": [
+          "error",
+          "code",
+          "owed_cents",
+          "balance_cents",
+          "reason"
+        ]
+      },
       "CreatePortalSessionRequest": {
         "type": "object",
         "properties": {
@@ -797,6 +831,80 @@
           "recovered",
           "followup3dSent",
           "followup10dSent"
+        ]
+      },
+      "PaymentMethodLostResponse": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "no_debt",
+              "collectable",
+              "flagged",
+              "already_flagged",
+              "deferred"
+            ]
+          },
+          "owed_cents": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "orgId",
+          "state",
+          "owed_cents"
+        ]
+      },
+      "PaymentMethodLostRequest": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "orgId"
+        ]
+      },
+      "UnpaidDebtsResponse": {
+        "type": "object",
+        "properties": {
+          "unpaid_debts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "org_id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "owed_cents": {
+                  "type": "string"
+                },
+                "flagged_at": {
+                  "type": "string"
+                },
+                "episode_started_at": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "org_id",
+                "owed_cents",
+                "flagged_at",
+                "episode_started_at"
+              ]
+            }
+          }
+        },
+        "required": [
+          "unpaid_debts"
         ]
       },
       "CampaignAffordability": {
@@ -2207,6 +2315,16 @@
               }
             }
           },
+          "402": {
+            "description": "The org owes an outstanding balance that could not be settled on its saved card. No session is opened; the body states what is owed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutstandingBalanceResponse"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Billing account not found",
             "content": {
@@ -2343,6 +2461,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The org owes an outstanding balance that could not be settled on its saved card. No session is opened; the body states what is owed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutstandingBalanceResponse"
                 }
               }
             }
@@ -3574,6 +3702,101 @@
           },
           "502": {
             "description": "Tick failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/payment-methods/lost": {
+      "post": {
+        "summary": "An org's last chargeable payment method is gone",
+        "description": "stripe-service reports the event; billing decides what it means. An org with a negative balance and no chargeable card now carries a debt we cannot collect: it is flagged on its depletion episode, the customer is emailed that a card is required (with the amount owed), staff are notified, and campaigns stop through the existing credit-line floor. An org that owes nothing, or still has a card, is a no-op — so a false alarm is free. Idempotent: the notification is claimed once per episode, so a redelivered event sends nothing.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentMethodLostRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "What the org's debt state is now",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodLostResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "orgId missing or not a UUID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Could not evaluate the org's balance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/internal/unpaid-debts": {
+      "get": {
+        "summary": "Every org currently owing money we cannot collect",
+        "description": "The staff view of unpaid debt. One row per org whose balance is negative and whose last chargeable card is gone, with the amount owed (frozen when the debt was flagged and refreshed hourly while it persists). A row leaves this list when a card comes back or the balance is restored.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "x-api-key",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unpaid debts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnpaidDebtsResponse"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Read failed",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -403,6 +403,21 @@ export const creditDepletionEpisodes = pgTable(
     t0SentAt: timestamp("t0_sent_at", { withTimezone: true }),
     followup3dSentAt: timestamp("followup_3d_sent_at", { withTimezone: true }),
     followup10dSentAt: timestamp("followup_10d_sent_at", { withTimezone: true }),
+    // Claims the ONE "your card is gone, we cannot collect what you owe"
+    // notification (customer + staff) for this episode — migration 0041. The
+    // hourly sweep re-examines every open episode, so without this marker the
+    // same debt would be mailed about forever. Cleared when the org regains a
+    // chargeable card, so a LATER loss notifies again.
+    cardRequiredNotifiedAt: timestamp("card_required_notified_at", {
+      withTimezone: true,
+    }),
+    // Amount owed while the debt is uncollectable, refreshed on each dunning
+    // tick — lets the staff read be a plain DB read with no per-org fan-out.
+    // NULL = this debt is not (or is no longer) uncollectable.
+    uncollectableDebtCents: numeric("uncollectable_debt_cents", {
+      precision: FRACTIONAL_PRECISION,
+      scale: FRACTIONAL_SCALE,
+    }),
     recoveredAt: timestamp("recovered_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -19,6 +19,8 @@
  *   - `brand_daily_budget_changed` → src/lib/brand-budget-notification.ts
  *   - `referral-reward-opened`     → src/lib/referral-notifications.ts
  *   - `referral-credits-granted`   → src/lib/referral-notifications.ts
+ *   - `credit-debt-card-required`  → src/lib/unpaid-debt.ts
+ *   - `unpaid_debt_uncollectable`  → src/lib/unpaid-debt.ts (staff)
  * The six dunning templates (`credit-depleted*`) are registered by the dashboard
  * (distribute.you#1420, which owns their copy) and are present in prod.
  */
@@ -28,6 +30,10 @@ import {
   REFERRAL_REWARD_OPENED_EVENT,
   REFERRAL_CREDITS_GRANTED_EVENT,
 } from "./lib/referral-notifications.js";
+import {
+  UNPAID_DEBT_CARD_REQUIRED_EVENT,
+  UNPAID_DEBT_STAFF_EVENT,
+} from "./lib/unpaid-debt.js";
 
 /**
  * The sibling can be cold (Neon scale-to-zero), suspended, or down at our boot.
@@ -101,6 +107,36 @@ const TEMPLATES = [
 <p>The credits come off what you spend from here, so there is nothing to claim.</p>`,
     textBody:
       "{{amount}} in referral credits is now in your account. {{reason}} The credits come off what you spend from here, so there is nothing to claim.",
+  },
+  {
+    // The org owes money and the card we would have taken it from is gone.
+    //
+    // Deliberately NOT one of the six `credit-depleted*` templates: those nudge
+    // "turn on auto-topup" and the `-blocked` variants nudge a manual recharge,
+    // and neither is reachable without a card on file. Adding a card is the one
+    // action that unblocks this customer, so that is what this says.
+    name: UNPAID_DEBT_CARD_REQUIRED_EVENT,
+    subject: "Add a payment method to resume your campaigns",
+    htmlBody: `<p>Your campaigns have stopped. You have an unpaid balance of {{amountOwed}} and we no longer have a card on file to charge.</p>
+<p>Add a payment method in your billing settings and we will settle the {{amountOwed}} and start your campaigns again.</p>`,
+    textBody:
+      "Your campaigns have stopped. You have an unpaid balance of {{amountOwed}} and we no longer have a card on file to charge. Add a payment method in your billing settings and we will settle the {{amountOwed}} and start your campaigns again.",
+  },
+  {
+    // Staff notification, not a customer email: transactional-email-service
+    // routes this event type to its own staff recipient list, so no recipient
+    // list lives here. Same shape as brand_daily_budget_changed, and the name is
+    // imported from the sender rather than retyped so the two cannot drift.
+    name: UNPAID_DEBT_STAFF_EVENT,
+    subject: "Unpaid debt {{amountOwed}}, no card on file",
+    htmlBody: `<p>An org owes {{amountOwed}} and has no chargeable card, so we cannot collect it.</p>
+<ul>
+<li>Org: {{orgId}}</li>
+<li>Billing email: {{billingEmail}}</li>
+</ul>
+<p>Their campaigns are stopped and they have been asked to add a card.</p>`,
+    textBody:
+      "An org owes {{amountOwed}} and has no chargeable card, so we cannot collect it. Org: {{orgId}}. Billing email: {{billingEmail}}. Their campaigns are stopped and they have been asked to add a card.",
   },
 ] as const;
 

--- a/src/lib/card-change-settlement.ts
+++ b/src/lib/card-change-settlement.ts
@@ -1,0 +1,231 @@
+/**
+ * Settle what the customer owes BEFORE handing them a card-management session.
+ *
+ * A customer who owes us money on the postpaid credit line must never be able to
+ * leave us with the debt and no card to collect it. That is what Google Ads,
+ * Meta and AWS all do: the outstanding balance is settled first, and only then
+ * may the payment method be changed. stripe-service separately makes the
+ * acquirer's card page replace-only, but the collection has to happen here —
+ * this service is the one that knows what is owed.
+ *
+ * The rule, in full:
+ *
+ *   balance >= 0            → open the session, exactly as before.
+ *   negative, has a card    → charge EXACTLY the outstanding amount first.
+ *                             Success opens the session; failure REFUSES it and
+ *                             states what is owed.
+ *   negative, NO card       → open the session. There is nothing to charge, and
+ *                             adding a card IS the recovery — refusing here
+ *                             would trap the org in a debt it can never pay.
+ *                             That org is separately flagged as an uncollectable
+ *                             debt (see lib/unpaid-debt).
+ *   negative, blocked card  → open the session. An issuing country that cannot
+ *                             be charged off_session (India / RBI) cannot be
+ *                             settled by this path at all, so blocking the one
+ *                             screen where they could act is pure harm.
+ *   negative, below $0.50   → open the session. Stripe rejects a smaller charge
+ *                             outright; the remainder rolls into the month-end
+ *                             sweep like any other sub-minimum deficit.
+ *
+ * The amount is `computeSettleCharge` — the SAME arithmetic the month-end sweep
+ * bills, deliberately imported rather than restated, so the two surfaces can
+ * never disagree about what settling to zero means.
+ *
+ * Fail-loud: a charge-path error refuses the session. Nothing here falls back to
+ * opening it anyway.
+ */
+
+import crypto from "crypto";
+import { computeBalance, type BalanceSnapshot } from "./balance.js";
+import { cmpCents } from "./cents.js";
+import { computeSettleCharge, STRIPE_MIN_CHARGE_CENTS } from "./month-end-sweep.js";
+import { coalesceReload } from "./reload-coalescer.js";
+import { reloadOffSession } from "./reload.js";
+
+/** A hung stripe-service call must not hold the customer's browser forever. */
+const SETTLE_TIMEOUT_MS = 30_000;
+
+/** Why a card-change session was refused — distinguishable on the wire. */
+export type SettlementFailureReason =
+  /** The card declined, or stripe-service could not take the money. */
+  | "charge_failed"
+  /** A recent decline put this org in the reload backoff — no charge attempted. */
+  | "charge_backoff";
+
+/**
+ * Thrown when an outstanding balance could NOT be settled, so the card-change
+ * session must not be handed over. Carries what the customer owes so the caller
+ * can say it — the dashboard distinguishes this from every other failure.
+ */
+export class OutstandingBalanceError extends Error {
+  readonly owedCents: string;
+  readonly balanceCents: string;
+  readonly reason: SettlementFailureReason;
+
+  constructor(params: {
+    owedCents: string;
+    balanceCents: string;
+    reason: SettlementFailureReason;
+    message: string;
+  }) {
+    super(params.message);
+    this.name = "OutstandingBalanceError";
+    this.owedCents = params.owedCents;
+    this.balanceCents = params.balanceCents;
+    this.reason = params.reason;
+  }
+}
+
+/** "YYYY-MM-DD" (UTC) — the idempotency scope for one day's settle attempts. */
+export function dayBucket(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Idempotency key scoped to (org, UTC day, charge amount).
+ *
+ * The AMOUNT is in the key for the reason the month-end sweep documents at
+ * length: stripe-service derives its acquirer keys from this one, and an
+ * acquirer rejects a replayed key whose parameters changed — so an
+ * amount-independent key makes a second, DIFFERENT settle impossible and
+ * replays a stale charge. The DAY is in it so a retry of the same settle within
+ * the day collapses onto one charge (the customer clicking twice, a browser
+ * retry) while a genuine settle of the same amount next week still goes through.
+ */
+export function cardChangeSettleIdempotencyKey(
+  orgId: string,
+  bucket: string,
+  chargeAmountCents: number
+): string {
+  return crypto
+    .createHash("sha256")
+    .update(`card-change-settle:${orgId}:${bucket}:${chargeAmountCents}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+function withTimeout<T>(ms: number, p: Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`card-change settle timeout after ${ms}ms`)),
+      ms
+    );
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
+export interface SettlementOutcome {
+  /** Cents actually charged (0 when nothing was owed or nothing could be taken). */
+  chargedCents: number;
+  /** The balance read before the settle. */
+  balanceCents: string;
+  /** The snapshot the decision was made on — saves the caller a second read. */
+  snapshot: BalanceSnapshot;
+}
+
+/**
+ * Collect any outstanding balance before a card-management session is opened.
+ *
+ * Resolves when the session may be handed over (nothing owed, settled, or
+ * nothing collectable). Throws `OutstandingBalanceError` when the org owes money
+ * we could have taken and the charge did not land — the session must NOT be
+ * opened in that case.
+ */
+export async function settleOutstandingBeforeCardChange(
+  orgId: string,
+  now: Date = new Date()
+): Promise<SettlementOutcome> {
+  const snapshot = await computeBalance(orgId);
+  const balanceCents = snapshot.balanceCents;
+  const nothingToDo: SettlementOutcome = { chargedCents: 0, balanceCents, snapshot };
+
+  if (cmpCents(balanceCents, "0") >= 0) return nothingToDo;
+
+  if (!snapshot.hasCardPm) {
+    // Nothing to charge. Adding a card is this org's only way out of the debt,
+    // and it is separately flagged as uncollectable, so the session opens.
+    console.warn(
+      `[billing-service] card change: org ${orgId} owes ${balanceCents} cents with ` +
+        `no chargeable card — opening the session so a card can be added`
+    );
+    return nothingToDo;
+  }
+
+  if (!snapshot.autoReloadSupported) {
+    // The saved card's issuing country cannot be charged off_session at all, so
+    // there is no settle to perform here — blocking would be pure harm.
+    console.warn(
+      `[billing-service] card change: org ${orgId} owes ${balanceCents} cents on a ` +
+        `card that cannot be charged off_session (country=${snapshot.cardCountry ?? "unknown"}) — ` +
+        `opening the session`
+    );
+    return nothingToDo;
+  }
+
+  const chargeAmount = computeSettleCharge(balanceCents);
+  if (chargeAmount <= 0) {
+    // Below Stripe's minimum charge — uncollectable this instant, rolls into the
+    // month-end sweep like any other sub-minimum deficit.
+    console.log(
+      `[billing-service] card change: org ${orgId} owes ${balanceCents} cents, below ` +
+        `the ${STRIPE_MIN_CHARGE_CENTS}-cent minimum — opening the session`
+    );
+    return nothingToDo;
+  }
+
+  const owedCents = String(chargeAmount);
+  let outcome;
+  try {
+    outcome = await coalesceReload(orgId, () =>
+      withTimeout(
+        SETTLE_TIMEOUT_MS,
+        reloadOffSession(
+          orgId,
+          chargeAmount,
+          cardChangeSettleIdempotencyKey(orgId, dayBucket(now), chargeAmount),
+          { reason: "card_change_settlement" }
+        )
+      )
+    );
+  } catch (err) {
+    // A declined off_session charge arrives as a THROW (stripe-service answers
+    // non-2xx), which is the ordinary case here, not an exotic one.
+    console.warn(
+      `[billing-service] card change: settle of ${chargeAmount} cents failed for org ` +
+        `${orgId}:`,
+      err instanceof Error ? err.message : String(err)
+    );
+    throw new OutstandingBalanceError({
+      owedCents,
+      balanceCents,
+      reason: "charge_failed",
+      message: `Outstanding balance of ${owedCents} cents could not be settled`,
+    });
+  }
+
+  if (outcome.status !== "succeeded") {
+    throw new OutstandingBalanceError({
+      owedCents,
+      balanceCents,
+      reason: outcome.backoffSkipped ? "charge_backoff" : "charge_failed",
+      message:
+        `Outstanding balance of ${owedCents} cents could not be settled: ` +
+        `${outcome.failure_reason ?? outcome.status}`,
+    });
+  }
+
+  console.log(
+    `[billing-service] card change: settled ${chargeAmount} cents for org ${orgId} ` +
+      `before opening a card session`
+  );
+  return { chargedCents: chargeAmount, balanceCents, snapshot };
+}

--- a/src/lib/dunning-scheduler.ts
+++ b/src/lib/dunning-scheduler.ts
@@ -12,6 +12,7 @@
 import { runDunningTick } from "./dunning.js";
 import { runMonthEndSweep } from "./month-end-sweep.js";
 import { runWelcomeCompletionSweep } from "./welcome-completion-sweep.js";
+import { runUnpaidDebtScan } from "./unpaid-debt.js";
 
 // Hourly heartbeat. The follow-up windows (+3d / +10d) are far coarser, so this
 // is plenty frequent for both follow-ups and recharge detection.
@@ -49,6 +50,25 @@ export function startDunningScheduler(): void {
         }
       } catch (err) {
         console.error("[billing-service] month-end sweep failed:", err);
+      }
+
+      // Unpaid-debt scan — every org that owes money with no chargeable card
+      // gets flagged, told, and made visible to staff. This is the BACKSTOP for
+      // "the last card was lost": stripe-service calls
+      // POST /internal/payment-methods/lost the moment it happens, and this
+      // catches the org that went into debt while already card-less, refreshes
+      // the amount owed, and clears the flag when a card comes back. Isolated so
+      // a failure here never blocks the other sweeps, and vice-versa.
+      try {
+        const d = await runUnpaidDebtScan();
+        if (d.flagged > 0 || d.failed > 0) {
+          console.log(
+            `[billing-service] unpaid-debt scan: scanned=${d.scanned} ` +
+              `flagged=${d.flagged} alreadyFlagged=${d.alreadyFlagged} failed=${d.failed}`
+          );
+        }
+      } catch (err) {
+        console.error("[billing-service] unpaid-debt scan failed:", err);
       }
 
       // Welcome-completion sweep — the unconditional server-side driver for the

--- a/src/lib/month-end-sweep.ts
+++ b/src/lib/month-end-sweep.ts
@@ -38,6 +38,7 @@ import { computeBalance } from "./balance.js";
 import { cmpCents } from "./cents.js";
 import { coalesceReload } from "./reload-coalescer.js";
 import { reloadOffSession } from "./reload.js";
+import { flagUncollectableDebt } from "./unpaid-debt.js";
 
 
 // A hung stripe-service call must not stall the whole sweep loop.
@@ -198,8 +199,22 @@ export interface MonthEndSweepResult {
   eligible: number;
   /** Orgs charged one settling reload. */
   charged: number;
-  /** Orgs skipped (non-negative balance, no card, blocked country, zero charge). */
+  /** Orgs skipped because they owe nothing this cycle, or owe under the Stripe minimum. */
   skipped: number;
+  /**
+   * Orgs that OWE money with no chargeable card. NEVER counted as `skipped`:
+   * the debt is flagged on the org's depletion episode, the customer is told a
+   * card is required (with the amount), staff are told, and campaigns stop
+   * through the existing credit-line floor. See lib/unpaid-debt.
+   */
+  unpaidDebt: number;
+  /**
+   * Orgs that owe money on a card whose issuing country cannot be charged
+   * off_session (India / RBI). Also not `skipped` — the existing `-blocked`
+   * dunning copy already nudges these customers to recharge manually, so they
+   * are counted and logged rather than re-notified by a second mechanism.
+   */
+  blockedCountryDebt: number;
   /** Orgs whose reload errored / declined (logged + isolated). */
   failed: number;
 }
@@ -217,6 +232,8 @@ export async function runMonthEndSweep(
     eligible: 0,
     charged: 0,
     skipped: 0,
+    unpaidDebt: 0,
+    blockedCountryDebt: 0,
     failed: 0,
   };
 
@@ -245,8 +262,28 @@ export async function runMonthEndSweep(
 
       // Reload-capable guards — mirror usage_apply: chargeable card AND an
       // issuing country that supports off_session charges (India/RBI excluded).
+      //
+      // An org that owes money here cannot be charged, and that debt must NOT
+      // disappear into `skipped`: it is real money, it keeps growing while
+      // campaigns run, and nobody is told. It is flagged instead — see
+      // lib/unpaid-debt for what that means and why nothing new stops the
+      // campaigns (losing the card already drops the credit-line floor to 0).
       if (!snapshot.hasCardPm || !snapshot.autoReloadSupported) {
-        result.skipped += 1;
+        const owes = cmpCents(snapshot.balanceCents, "0") < 0;
+        if (!owes) {
+          result.skipped += 1;
+        } else if (!snapshot.hasCardPm) {
+          await flagUncollectableDebt({ orgId: account.orgId, snapshot });
+          result.unpaidDebt += 1;
+        } else {
+          result.blockedCountryDebt += 1;
+          console.warn(
+            `[billing-service] month-end sweep: org ${account.orgId} owes ` +
+              `${snapshot.balanceCents} cents on a card that cannot be charged ` +
+              `off_session (country=${snapshot.cardCountry ?? "unknown"}) — ` +
+              `uncollected (${bucket})`
+          );
+        }
         continue;
       }
 

--- a/src/lib/outstanding-balance-response.ts
+++ b/src/lib/outstanding-balance-response.ts
@@ -1,0 +1,37 @@
+/**
+ * The wire shape of "you owe us money, so we will not hand you a card session".
+ *
+ * 402 Payment Required, with a stable `code` the dashboard keys on — this must
+ * be distinguishable from every other failure of these routes (400 bad body,
+ * 404 no account, 502 stripe-service down), because it is the ONE case where the
+ * customer can act: pay what is owed.
+ *
+ * `owed_cents` is what a successful settle would have taken (whole cents, the
+ * same figure the month-end sweep bills). `balance_cents` is the raw negative
+ * balance it came from, so nothing has to be re-derived to display either.
+ */
+
+import type { OutstandingBalanceError } from "./card-change-settlement.js";
+
+export const OUTSTANDING_BALANCE_CODE = "outstanding_balance_unsettled";
+
+export interface OutstandingBalanceBody {
+  error: string;
+  code: typeof OUTSTANDING_BALANCE_CODE;
+  owed_cents: string;
+  balance_cents: string;
+  reason: string;
+}
+
+export function outstandingBalanceBody(
+  err: OutstandingBalanceError
+): OutstandingBalanceBody {
+  return {
+    error:
+      "Settle your outstanding balance before changing your payment method.",
+    code: OUTSTANDING_BALANCE_CODE,
+    owed_cents: err.owedCents,
+    balance_cents: err.balanceCents,
+    reason: err.reason,
+  };
+}

--- a/src/lib/unpaid-debt.ts
+++ b/src/lib/unpaid-debt.ts
@@ -1,0 +1,367 @@
+/**
+ * An unpaid debt we cannot collect is VISIBLE, never silently skipped.
+ *
+ * An org whose balance is negative and whose last chargeable card is gone owes
+ * us money we have no way to take. Before this, that org was counted `skipped`
+ * by the month-end sweep and vanished from every surface: no customer email, no
+ * staff signal, campaigns still running and the debt still growing.
+ *
+ * What happens instead, and what is deliberately REUSED rather than rebuilt:
+ *
+ *   - CAMPAIGNS STOP on their own, through the machinery that already exists.
+ *     `resolvePostpaidTier` grants a NEGATIVE credit-line floor only to an org
+ *     that can actually be reloaded (config + chargeable card + non-blocked
+ *     issuing country). Losing the card drops the floor to "0", so the
+ *     authorize gate and the read-only affordability pre-flight both read the
+ *     org as depleted at any balance at or below zero and campaign-service
+ *     stops dispatching. Nothing here has to stop anything.
+ *   - THE STATE is the existing depletion EPISODE — the same row the dunning
+ *     engine opens for an out-of-credit org — so recovery is the existing
+ *     recovery: the episode closes when `credited` rises (a real recharge), and
+ *     adding a card back restores the credit line, which re-arms auto-reload and
+ *     the month-end sweep. No new lifecycle, nothing new to reconcile.
+ *
+ * What IS new is the telling: two emails (customer "a card is required to
+ * resume, here is what you owe", staff "this org owes money we cannot collect")
+ * claimed at most once per episode by `card_required_notified_at`, plus the
+ * owed amount frozen on the row so a staff read costs one query.
+ *
+ * Fail-soft, the same posture as every other notification in this repo: nothing
+ * here can fail, delay or roll back anything about the money it describes. The
+ * money decisions (the floor, the sweep, the settle) are made elsewhere and have
+ * already been made by the time any of this runs.
+ */
+
+import { and, eq, isNull, isNotNull } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { billingAccounts, creditDepletionEpisodes } from "../db/schema.js";
+import type { CreditDepletionEpisode } from "../db/schema.js";
+import { computeBalance, type BalanceSnapshot } from "./balance.js";
+import { cmpCents } from "./cents.js";
+import { sendEmail } from "./email-client.js";
+import { createPlatformRun, completePlatformRun } from "./runs-client.js";
+
+/**
+ * Customer email: "we could not collect what you owe, and we no longer have a
+ * card — add one to resume". Registered by THIS service (see src/instrument.ts):
+ * the fleet convention is that a template belongs to whoever SENDS it.
+ *
+ * NOT one of the six `credit-depleted*` dunning templates, and not the
+ * `-blocked` variant either: those nudge "turn on auto-topup" and "recharge
+ * manually", and neither is reachable for an org with no card on file. The one
+ * action that unblocks this org is adding a card.
+ */
+export const UNPAID_DEBT_CARD_REQUIRED_EVENT = "credit-debt-card-required";
+
+/**
+ * Staff notification: this org owes money we cannot collect. Routed to the staff
+ * list transactional-email-service already owns (its ADMIN_NOTIFICATION_EVENTS),
+ * exactly like `brand_daily_budget_changed` — no recipient list lives here.
+ */
+export const UNPAID_DEBT_STAFF_EVENT = "unpaid_debt_uncollectable";
+
+/**
+ * The platform is the actor. There is no end user behind a sweep or a scheduler
+ * tick, and none is invented for a READ — this is the all-zeros sentinel this
+ * service already uses for a write it performs itself, stored on a row of its
+ * OWN table. The recipient is resolved from the org's Stripe billing email, so
+ * nothing downstream resolves a user from it.
+ */
+const PLATFORM_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+export type UnpaidDebtState =
+  /** Balance is non-negative — nothing is owed. */
+  | "no_debt"
+  /** Owed, but a chargeable card exists — the normal collection paths own it. */
+  | "collectable"
+  /** Uncollectable, and this call is what flagged it (emails sent). */
+  | "flagged"
+  /** Uncollectable, already flagged on this episode — amount refreshed, no email. */
+  | "already_flagged"
+  /** Uncollectable, but the notification could not be claimed this tick (retried). */
+  | "deferred";
+
+export interface UnpaidDebtOutcome {
+  state: UnpaidDebtState;
+  /** Cents owed (positive) when the org is in debt; "0" otherwise. */
+  owedCents: string;
+}
+
+function owedFrom(snapshot: BalanceSnapshot): string {
+  return cmpCents(snapshot.balanceCents, "0") < 0
+    ? snapshot.balanceCents.replace(/^-/, "")
+    : "0";
+}
+
+/**
+ * Format cents (a decimal string) as a dollar amount for customer-facing copy.
+ * Whole cents, two decimals — a customer is told what they owe, not a
+ * ten-decimal internal figure.
+ */
+export function formatOwed(cents: string): string {
+  const n = Number(cents);
+  return `$${(Math.round(n) / 100).toFixed(2)}`;
+}
+
+/**
+ * Open (or reuse) the depletion episode for an org whose debt we cannot collect,
+ * and tell the customer and staff about it exactly once.
+ *
+ * Pass a `snapshot` when the caller already holds one (the sweep does) so this
+ * costs no extra reads. Per-org failure is the caller's to isolate — every
+ * NOTIFICATION failure is swallowed here, but a database failure propagates
+ * (fail-loud on state, fail-soft on telling).
+ */
+export async function flagUncollectableDebt(params: {
+  orgId: string;
+  snapshot?: BalanceSnapshot;
+}): Promise<UnpaidDebtOutcome> {
+  const snapshot = params.snapshot ?? (await computeBalance(params.orgId));
+  const owedCents = owedFrom(snapshot);
+
+  if (cmpCents(snapshot.balanceCents, "0") >= 0) {
+    // Nothing owed. If a previous tick flagged this org, the flag is stale —
+    // clear it so the staff surface does not show a debt that no longer exists.
+    await clearUncollectableFlag(params.orgId);
+    return { state: "no_debt", owedCents: "0" };
+  }
+
+  if (snapshot.hasCardPm) {
+    // Owed, but collectable: the floor-crossing reload, the settle-before-card-
+    // change and the month-end sweep all own this org. Clear any stale flag so
+    // a card that came back is visible as such, and so a LATER loss re-notifies.
+    await clearUncollectableFlag(params.orgId);
+    return { state: "collectable", owedCents };
+  }
+
+  const episode = await ensureOpenEpisode(params.orgId, snapshot);
+
+  if (episode.cardRequiredNotifiedAt != null) {
+    // Already told. Refresh the amount so the staff surface tracks a growing
+    // debt, and send nothing — a second tick must not re-email.
+    await db
+      .update(creditDepletionEpisodes)
+      .set({ uncollectableDebtCents: owedCents, updatedAt: new Date() })
+      .where(eq(creditDepletionEpisodes.id, episode.id));
+    return { state: "already_flagged", owedCents };
+  }
+
+  // Resolve everything the sends need BEFORE claiming the marker: a claim taken
+  // against a run we cannot open would burn the only notification. Same ordering
+  // rule as the referral notifications.
+  const runId = await createPlatformRun("unpaid-debt-notification");
+  if (!runId) {
+    console.error(
+      `[billing-service] unpaid debt: no platform run for org ${params.orgId}, ` +
+        `notification deferred to the next tick`
+    );
+    return { state: "deferred", owedCents };
+  }
+
+  const [claimed] = await db
+    .update(creditDepletionEpisodes)
+    .set({
+      cardRequiredNotifiedAt: new Date(),
+      uncollectableDebtCents: owedCents,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(creditDepletionEpisodes.id, episode.id),
+        isNull(creditDepletionEpisodes.cardRequiredNotifiedAt)
+      )
+    )
+    .returning();
+
+  if (!claimed) {
+    // A concurrent tick / replica won the claim and is sending.
+    await completePlatformRun(runId);
+    return { state: "already_flagged", owedCents };
+  }
+
+  console.warn(
+    `[billing-service] unpaid debt: org ${params.orgId} owes ${owedCents} cents ` +
+      `with no chargeable card — customer + staff notified, campaigns stopped`
+  );
+
+  const amountOwed = formatOwed(owedCents);
+  sendEmail({
+    eventType: UNPAID_DEBT_CARD_REQUIRED_EVENT,
+    orgId: params.orgId,
+    userId: episode.userId,
+    runId,
+    recipientEmail: snapshot.customer.email ?? undefined,
+    metadata: { amountOwed, orgId: params.orgId },
+  });
+  sendEmail({
+    eventType: UNPAID_DEBT_STAFF_EVENT,
+    orgId: params.orgId,
+    userId: episode.userId,
+    runId,
+    metadata: {
+      amountOwed,
+      orgId: params.orgId,
+      billingEmail: snapshot.customer.email ?? "unknown",
+    },
+  });
+  await completePlatformRun(runId);
+
+  return { state: "flagged", owedCents };
+}
+
+/**
+ * The org's OPEN depletion episode, opening one if there is none.
+ *
+ * Unlike `openDepletionEpisodeIfDepleted` this does NOT require campaign
+ * activity and sends no T0: the debt already exists whether or not a campaign
+ * happens to be authorizing right now, and the message this path sends is a
+ * different one. The partial unique index `(org_id) WHERE recovered_at IS NULL`
+ * is the race guard — a 23505 means someone else just opened it, so we re-read.
+ */
+async function ensureOpenEpisode(
+  orgId: string,
+  snapshot: BalanceSnapshot
+): Promise<CreditDepletionEpisode> {
+  const existing = await selectOpenEpisode(orgId);
+  if (existing) return existing;
+
+  try {
+    const [row] = await db
+      .insert(creditDepletionEpisodes)
+      .values({
+        orgId,
+        userId: PLATFORM_USER_ID,
+        creditedCentsAtOpen: snapshot.creditedCents,
+      })
+      .returning();
+    return row;
+  } catch (err) {
+    if ((err as { code?: string }).code !== "23505") throw err;
+    const raced = await selectOpenEpisode(orgId);
+    if (!raced) throw err;
+    return raced;
+  }
+}
+
+async function selectOpenEpisode(
+  orgId: string
+): Promise<CreditDepletionEpisode | undefined> {
+  const [row] = await db
+    .select()
+    .from(creditDepletionEpisodes)
+    .where(
+      and(
+        eq(creditDepletionEpisodes.orgId, orgId),
+        isNull(creditDepletionEpisodes.recoveredAt)
+      )
+    )
+    .limit(1);
+  return row;
+}
+
+/**
+ * Drop the uncollectable flag from this org's open episode, if it carries one.
+ *
+ * The EPISODE is not closed — that stays keyed on `credited` rising, the
+ * existing recovery. Only the "we cannot collect this" marker goes, so the staff
+ * surface stops listing a debt that is collectable again and a LATER card loss
+ * notifies the customer afresh.
+ */
+async function clearUncollectableFlag(orgId: string): Promise<void> {
+  await db
+    .update(creditDepletionEpisodes)
+    .set({
+      cardRequiredNotifiedAt: null,
+      uncollectableDebtCents: null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(creditDepletionEpisodes.orgId, orgId),
+        isNull(creditDepletionEpisodes.recoveredAt),
+        isNotNull(creditDepletionEpisodes.cardRequiredNotifiedAt)
+      )
+    );
+}
+
+export interface UnpaidDebtScanResult {
+  scanned: number;
+  flagged: number;
+  alreadyFlagged: number;
+  cleared: number;
+  failed: number;
+}
+
+/**
+ * Hourly backstop: find every org that now owes money with no chargeable card.
+ *
+ * The immediate signal is `POST /internal/payment-methods/lost`, which
+ * stripe-service calls the moment an org's last chargeable method is detached.
+ * This scan is what makes the state correct WITHOUT that call — it also catches
+ * the org that went into debt while already card-less, and it refreshes or
+ * clears a flag when the situation changes. Bounded by the number of billing
+ * accounts (~100 in prod), one balance composition each, isolated per org.
+ */
+export async function runUnpaidDebtScan(): Promise<UnpaidDebtScanResult> {
+  const result: UnpaidDebtScanResult = {
+    scanned: 0,
+    flagged: 0,
+    alreadyFlagged: 0,
+    cleared: 0,
+    failed: 0,
+  };
+
+  const accounts = await db
+    .select({ orgId: billingAccounts.orgId })
+    .from(billingAccounts);
+
+  for (const account of accounts) {
+    result.scanned += 1;
+    try {
+      const outcome = await flagUncollectableDebt({ orgId: account.orgId });
+      if (outcome.state === "flagged") result.flagged += 1;
+      else if (outcome.state === "already_flagged") result.alreadyFlagged += 1;
+    } catch (err) {
+      result.failed += 1;
+      console.error(
+        `[billing-service] unpaid-debt scan failed for org ${account.orgId}, skipping:`,
+        err
+      );
+    }
+  }
+
+  return result;
+}
+
+export interface UnpaidDebtRow {
+  orgId: string;
+  owedCents: string;
+  flaggedAt: string;
+  episodeStartedAt: string;
+}
+
+/**
+ * Every org currently carrying an uncollectable debt — the staff read.
+ *
+ * A plain DB read: the amount was frozen on the episode at flag time and is
+ * refreshed on every tick while the debt persists, so this costs one query
+ * rather than a balance composition per org.
+ */
+export async function listUnpaidDebts(): Promise<UnpaidDebtRow[]> {
+  const rows = await db
+    .select()
+    .from(creditDepletionEpisodes)
+    .where(
+      and(
+        isNull(creditDepletionEpisodes.recoveredAt),
+        isNotNull(creditDepletionEpisodes.cardRequiredNotifiedAt)
+      )
+    );
+
+  return rows.map((row) => ({
+    orgId: row.orgId,
+    owedCents: row.uncollectableDebtCents ?? "0",
+    flaggedAt: (row.cardRequiredNotifiedAt as Date).toISOString(),
+    episodeStartedAt: row.startedAt.toISOString(),
+  }));
+}

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -12,6 +12,11 @@ import { sumLocalPromoCreditsForOrg } from "../lib/promos.js";
 import { settleFreeCreditPromises } from "../lib/free-credit-settlement.js";
 import { getUsageDiscountPct } from "../lib/usage-discount.js";
 import {
+  settleOutstandingBeforeCardChange,
+  OutstandingBalanceError,
+} from "../lib/card-change-settlement.js";
+import { outstandingBalanceBody } from "../lib/outstanding-balance-response.js";
+import {
   getCustomerByOrg,
   sumSucceededTopupsForOrg,
   hasAttachedCardPm,
@@ -286,9 +291,19 @@ router.post("/v1/accounts/card_setup", requireOrgHeaders, async (req, res) => {
       return;
     }
 
+    // Same rule as POST /v1/portal-sessions: an outstanding balance is
+    // collected before the customer may touch the card that owes it. The two
+    // routes serve one descriptor, so they must gate identically or the gate is
+    // one URL away from being bypassed.
+    await settleOutstandingBeforeCardChange(orgId);
+
     const setup = await getCardSetup(orgId, return_url, undefined, currency);
     res.json(setup);
   } catch (err) {
+    if (err instanceof OutstandingBalanceError) {
+      res.status(402).json(outstandingBalanceBody(err));
+      return;
+    }
     const message = err instanceof Error ? err.message : String(err);
     console.error("[billing-service] card setup failed:", message);
     res.status(502).json({ error: "Failed to start card setup" });

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -26,6 +26,7 @@ import { resolvePostpaidTier } from "../lib/topup-tier.js";
 import { fetchRunsOrgActualUsageTotal } from "../lib/runs-client.js";
 import { getUsageDiscountPct } from "../lib/usage-discount.js";
 import { gte as gteCents, isDepleted, subCents } from "../lib/cents.js";
+import { flagUncollectableDebt, listUnpaidDebts } from "../lib/unpaid-debt.js";
 
 const router = Router();
 
@@ -477,6 +478,57 @@ router.post("/internal/dunning/tick", async (_req, res) => {
   } catch (err) {
     console.error("[billing-service] dunning tick (manual) failed:", err);
     res.status(502).json({ error: "Dunning tick failed" });
+  }
+});
+
+// POST /internal/payment-methods/lost — stripe-service tells us an org's last
+// chargeable payment method is gone.
+//
+// It is the only service that can observe `payment_method.detached` and decide
+// whether anything chargeable is left; it is NOT the service that knows whether
+// the org owes us money. So it reports the EVENT and this route decides: an org
+// with a negative balance and no card now carries a debt we cannot collect, and
+// is flagged, told, and surfaced to staff immediately rather than an hour later
+// on the scan.
+//
+// Idempotent by construction — the notification is claimed once per depletion
+// episode, so a redelivered webhook re-reads the state and sends nothing. An org
+// that owes nothing (or still has a card) is a no-op, so a false alarm is free.
+router.post("/internal/payment-methods/lost", async (req, res) => {
+  try {
+    const orgId = (req.body ?? {}).orgId;
+    if (typeof orgId !== "string" || !UUID_RE.test(orgId)) {
+      res.status(400).json({ error: "orgId must be a valid UUID" });
+      return;
+    }
+    const outcome = await flagUncollectableDebt({ orgId });
+    res.json({ orgId, state: outcome.state, owed_cents: outcome.owedCents });
+  } catch (err) {
+    console.error("[billing-service] payment-method-lost handling failed:", err);
+    res.status(502).json({ error: "Failed to evaluate unpaid debt" });
+  }
+});
+
+// GET /internal/unpaid-debts — every org currently owing money we cannot
+// collect, for the staff surface that already reads dunning state.
+//
+// A plain DB read: the amount was frozen on the depletion episode when the debt
+// was flagged and is refreshed on every hourly tick while it persists, so this
+// costs one query rather than a balance composition per org.
+router.get("/internal/unpaid-debts", async (_req, res) => {
+  try {
+    const debts = await listUnpaidDebts();
+    res.json({
+      unpaid_debts: debts.map((d) => ({
+        org_id: d.orgId,
+        owed_cents: d.owedCents,
+        flagged_at: d.flaggedAt,
+        episode_started_at: d.episodeStartedAt,
+      })),
+    });
+  } catch (err) {
+    console.error("[billing-service] unpaid-debts read failed:", err);
+    res.status(502).json({ error: "Failed to read unpaid debts" });
   }
 });
 

--- a/src/routes/portal.ts
+++ b/src/routes/portal.ts
@@ -5,6 +5,11 @@ import { billingAccounts } from "../db/schema.js";
 import { requireOrgHeaders, getWorkflowHeaders, forwardWorkflowHeaders } from "../middleware/auth.js";
 import { CreatePortalSessionRequestSchema } from "../schemas.js";
 import { getCardSetup } from "../lib/stripe-service-client.js";
+import {
+  settleOutstandingBeforeCardChange,
+  OutstandingBalanceError,
+} from "../lib/card-change-settlement.js";
+import { outstandingBalanceBody } from "../lib/outstanding-balance-response.js";
 
 const router = Router();
 
@@ -41,9 +46,19 @@ router.post("/v1/portal-sessions", requireOrgHeaders, async (req, res) => {
       return;
     }
 
+    // An outstanding balance is collected BEFORE the customer may touch the
+    // card that owes it — see lib/card-change-settlement for the full rule (a
+    // card-less or off_session-blocked debtor still gets the session, because
+    // adding a card is their only way out).
+    await settleOutstandingBeforeCardChange(orgId);
+
     const setup = await getCardSetup(orgId, return_url, amount, currency);
     res.json(setup);
   } catch (err) {
+    if (err instanceof OutstandingBalanceError) {
+      res.status(402).json(outstandingBalanceBody(err));
+      return;
+    }
     const message = err instanceof Error ? err.message : String(err);
     console.error("[billing-service] card setup failed:", message);
     res.status(502).json({ error: "Failed to start card setup" });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -564,6 +564,54 @@ export const DunningTickResponseSchema = z
   })
   .openapi("DunningTickResponse");
 
+// --- Unpaid debt: an org owes money we cannot collect ---
+
+// 402 body for a card-management session refused because the org's outstanding
+// balance could not be settled. `code` is stable and the dashboard keys on it —
+// this is the ONE failure of those routes the customer can act on.
+export const OutstandingBalanceResponseSchema = z
+  .object({
+    error: z.string(),
+    code: z.literal("outstanding_balance_unsettled"),
+    owed_cents: z.string(),
+    balance_cents: z.string(),
+    reason: z.enum(["charge_failed", "charge_backoff"]),
+  })
+  .openapi("OutstandingBalanceResponse");
+
+export const PaymentMethodLostRequestSchema = z
+  .object({
+    orgId: z.string().uuid(),
+  })
+  .openapi("PaymentMethodLostRequest");
+
+export const PaymentMethodLostResponseSchema = z
+  .object({
+    orgId: z.string().uuid(),
+    state: z.enum([
+      "no_debt",
+      "collectable",
+      "flagged",
+      "already_flagged",
+      "deferred",
+    ]),
+    owed_cents: z.string(),
+  })
+  .openapi("PaymentMethodLostResponse");
+
+export const UnpaidDebtsResponseSchema = z
+  .object({
+    unpaid_debts: z.array(
+      z.object({
+        org_id: z.string().uuid(),
+        owed_cents: z.string(),
+        flagged_at: z.string(),
+        episode_started_at: z.string(),
+      })
+    ),
+  })
+  .openapi("UnpaidDebtsResponse");
+
 // --- Campaign affordability (read-only pre-flight gate) ---
 
 export const CampaignAffordabilitySchema = z
@@ -1090,6 +1138,14 @@ registry.registerPath({
       description: "Invalid request",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
+    402: {
+      description:
+        "The org owes an outstanding balance that could not be settled on its saved card. " +
+        "No session is opened; the body states what is owed.",
+      content: {
+        "application/json": { schema: OutstandingBalanceResponseSchema },
+      },
+    },
     404: {
       description: "Billing account not found",
       content: { "application/json": { schema: ErrorResponseSchema } },
@@ -1127,6 +1183,14 @@ registry.registerPath({
     400: {
       description: "Invalid request",
       content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    402: {
+      description:
+        "The org owes an outstanding balance that could not be settled on its saved card. " +
+        "No session is opened; the body states what is owed.",
+      content: {
+        "application/json": { schema: OutstandingBalanceResponseSchema },
+      },
     },
     404: {
       description: "Billing account not found",
@@ -1594,6 +1658,67 @@ registry.registerPath({
     },
     502: {
       description: "Tick failed",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/internal/payment-methods/lost",
+  summary: "An org's last chargeable payment method is gone",
+  description:
+    "stripe-service reports the event; billing decides what it means. An org with a negative " +
+    "balance and no chargeable card now carries a debt we cannot collect: it is flagged on its " +
+    "depletion episode, the customer is emailed that a card is required (with the amount owed), " +
+    "staff are notified, and campaigns stop through the existing credit-line floor. An org that " +
+    "owes nothing, or still has a card, is a no-op — so a false alarm is free. Idempotent: the " +
+    "notification is claimed once per episode, so a redelivered event sends nothing.",
+  request: {
+    headers: internalHeaders,
+    body: {
+      content: {
+        "application/json": { schema: PaymentMethodLostRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "What the org's debt state is now",
+      content: {
+        "application/json": { schema: PaymentMethodLostResponseSchema },
+      },
+    },
+    400: {
+      description: "orgId missing or not a UUID",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+    502: {
+      description: "Could not evaluate the org's balance",
+      content: { "application/json": { schema: ErrorResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/internal/unpaid-debts",
+  summary: "Every org currently owing money we cannot collect",
+  description:
+    "The staff view of unpaid debt. One row per org whose balance is negative and whose last " +
+    "chargeable card is gone, with the amount owed (frozen when the debt was flagged and " +
+    "refreshed hourly while it persists). A row leaves this list when a card comes back or the " +
+    "balance is restored.",
+  request: {
+    headers: internalHeaders,
+  },
+  responses: {
+    200: {
+      description: "Unpaid debts",
+      content: { "application/json": { schema: UnpaidDebtsResponseSchema } },
+    },
+    502: {
+      description: "Read failed",
       content: { "application/json": { schema: ErrorResponseSchema } },
     },
   },

--- a/tests/integration/card-change-settlement.test.ts
+++ b/tests/integration/card-change-settlement.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Settle the debt before the customer may change the card that owes it.
+ *
+ * The rule these pin: an org that owes money on a chargeable card pays it before
+ * a card-management session is handed over, and a refusal says what is owed in a
+ * shape the dashboard can tell apart from every other failure. The two carve-outs
+ * (no card, off_session-blocked card) matter as much as the rule — refusing there
+ * would trap an org in a debt it can never pay.
+ *
+ * Own file rather than a describe appended to portal.test.ts: that one closes the
+ * shared postgres.js connection in afterAll (see CLAUDE.md).
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
+import { setupStripeMocks } from "../helpers/mock-stripe.js";
+import * as runsClient from "../../src/lib/runs-client.js";
+import {
+  cardChangeSettleIdempotencyKey,
+  dayBucket,
+} from "../../src/lib/card-change-settlement.js";
+
+const app = createTestApp();
+const orgId = "00000000-0000-0000-0000-0000000000d1";
+
+describe("outstanding balance is settled before a card-management session", () => {
+  let ssMocks: ReturnType<typeof setupStripeMocks>;
+  let usageCents: string;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    ssMocks = setupStripeMocks();
+    await cleanTestData();
+
+    // balance = credited − usage. credited comes from sumSucceededTopupsForOrg
+    // (no promos in these fixtures); usage is driven per-test.
+    usageCents = "0.0000000000";
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(
+      async (org: string) => ({
+        org_id: org,
+        spent_cents: usageCents,
+        as_of: "2026-01-31T00:00:00.000Z",
+      })
+    );
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  /** Put the org at exactly −$50: paid $10, used $60. */
+  function owingFifty() {
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("1000.0000000000");
+    usageCents = "6000.0000000000";
+  }
+
+  it("AC1: charges the outstanding $50 on the saved card, then opens the session", async () => {
+    await insertTestAccount({ orgId });
+    owingFifty();
+
+    const res = await request(app)
+      .post("/v1/portal-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ return_url: "https://example.com/return" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.url).toBe("https://billing.stripe.com/p/session/abc");
+    expect(ssMocks.reloadOffSession).toHaveBeenCalledTimes(1);
+    const [chargedOrg, chargedCents, key] = ssMocks.reloadOffSession.mock.calls[0];
+    expect(chargedOrg).toBe(orgId);
+    // EXACTLY the outstanding amount — the same arithmetic the month-end sweep
+    // bills, never a tier multiple.
+    expect(chargedCents).toBe(5000);
+    expect(key).toBe(
+      cardChangeSettleIdempotencyKey(orgId, dayBucket(new Date()), 5000)
+    );
+  });
+
+  it("AC1b: a retry carries the SAME idempotency key, so it cannot double charge", async () => {
+    await insertTestAccount({ orgId });
+    owingFifty();
+    const headers = getAuthHeaders(orgId);
+    const body = { return_url: "https://example.com/return" };
+
+    await request(app).post("/v1/portal-sessions").set(headers).send(body);
+    // The mirror has not caught up within the retry window, so the balance still
+    // reads −$50 and the second attempt computes the same amount.
+    await request(app).post("/v1/portal-sessions").set(headers).send(body);
+
+    expect(ssMocks.reloadOffSession).toHaveBeenCalledTimes(2);
+    const keys = ssMocks.reloadOffSession.mock.calls.map((c) => c[2]);
+    expect(keys[0]).toBe(keys[1]);
+  });
+
+  it("AC2: a declining card gets NO session and a 402 stating what is owed", async () => {
+    await insertTestAccount({ orgId });
+    owingFifty();
+    // A declined off_session charge reaches billing as a throw (stripe-service
+    // answers non-2xx) — the ordinary case, not an exotic one.
+    ssMocks.reloadOffSession.mockRejectedValue(new Error("card_declined"));
+
+    const res = await request(app)
+      .post("/v1/portal-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ return_url: "https://example.com/return" });
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("outstanding_balance_unsettled");
+    expect(res.body.owed_cents).toBe("5000");
+    expect(res.body.balance_cents).toBe("-5000.0000000000");
+    expect(res.body.reason).toBe("charge_failed");
+    expect(ssMocks.getCardSetup).not.toHaveBeenCalled();
+  });
+
+  it("AC2b: a settled non-succeeded outcome also refuses, and never opens a session", async () => {
+    await insertTestAccount({ orgId });
+    owingFifty();
+    ssMocks.reloadOffSession.mockResolvedValue({
+      status: "failed",
+      failure_reason: "insufficient_funds",
+    });
+
+    const res = await request(app)
+      .post("/v1/portal-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ return_url: "https://example.com/return" });
+
+    expect(res.status).toBe(402);
+    expect(res.body.reason).toBe("charge_failed");
+    expect(ssMocks.getCardSetup).not.toHaveBeenCalled();
+  });
+
+  it("AC3: a positive balance opens the session exactly as before, with no charge", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("1000.0000000000");
+    usageCents = "0.0000000000";
+
+    const res = await request(app)
+      .post("/v1/portal-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ return_url: "https://example.com/return" });
+
+    expect(res.status).toBe(200);
+    expect(ssMocks.reloadOffSession).not.toHaveBeenCalled();
+  });
+
+  it("a debtor with NO card still gets the session — adding one is the only way out", async () => {
+    await insertTestAccount({ orgId });
+    owingFifty();
+    ssMocks.hasChargeablePmForOrg.mockResolvedValue(false);
+
+    const res = await request(app)
+      .post("/v1/portal-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ return_url: "https://example.com/return" });
+
+    expect(res.status).toBe(200);
+    expect(ssMocks.reloadOffSession).not.toHaveBeenCalled();
+  });
+
+  it("a debtor whose card cannot be charged off_session still gets the session", async () => {
+    await insertTestAccount({ orgId });
+    owingFifty();
+    // India / RBI: no off_session settle is possible on this card at all, so
+    // blocking the one screen where the customer could act is pure harm.
+    ssMocks.getOrgCardCountryByOrg.mockResolvedValue("IN");
+
+    const res = await request(app)
+      .post("/v1/portal-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ return_url: "https://example.com/return" });
+
+    expect(res.status).toBe(200);
+    expect(ssMocks.reloadOffSession).not.toHaveBeenCalled();
+  });
+
+  it("a deficit below Stripe's minimum charge opens the session and rolls into the sweep", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("1000.0000000000");
+    usageCents = "1000.2000000000"; // −0.20 cents owed, under the 50-cent minimum
+
+    const res = await request(app)
+      .post("/v1/portal-sessions")
+      .set(getAuthHeaders(orgId))
+      .send({ return_url: "https://example.com/return" });
+
+    expect(res.status).toBe(200);
+    expect(ssMocks.reloadOffSession).not.toHaveBeenCalled();
+  });
+
+  it("POST /v1/accounts/card_setup gates identically — the rule is not one URL away from bypass", async () => {
+    await insertTestAccount({ orgId });
+    owingFifty();
+    ssMocks.reloadOffSession.mockRejectedValue(new Error("card_declined"));
+
+    const res = await request(app)
+      .post("/v1/accounts/card_setup")
+      .set(getAuthHeaders(orgId))
+      .send({ return_url: "https://example.com/return" });
+
+    expect(res.status).toBe(402);
+    expect(res.body.code).toBe("outstanding_balance_unsettled");
+    expect(res.body.owed_cents).toBe("5000");
+    expect(ssMocks.getCardSetup).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/month-end-sweep.test.ts
+++ b/tests/integration/month-end-sweep.test.ts
@@ -176,7 +176,12 @@ describe("Month-end forced top-up sweep", () => {
     const res = await runMonthEndSweep(LAST_DAY);
 
     expect(res.charged).toBe(0);
-    expect(res.skipped).toBe(1);
+    // NOT `skipped`: this org OWES money we cannot collect, so it is flagged,
+    // its customer and staff are told, and it shows on the staff unpaid-debt
+    // surface. A silent skip is what made this debt invisible. See
+    // lib/unpaid-debt and unpaid-debt.test.ts.
+    expect(res.skipped).toBe(0);
+    expect(res.unpaidDebt).toBe(1);
     expect(ssMocks.reloadOffSession).not.toHaveBeenCalled();
   });
 
@@ -193,7 +198,11 @@ describe("Month-end forced top-up sweep", () => {
     const res = await runMonthEndSweep(LAST_DAY);
 
     expect(res.charged).toBe(0);
-    expect(res.skipped).toBe(1);
+    // Counted and logged rather than skipped — the existing `-blocked` dunning
+    // copy already nudges these customers to recharge manually, so this path
+    // must not mail them a second time.
+    expect(res.skipped).toBe(0);
+    expect(res.blockedCountryDebt).toBe(1);
     expect(ssMocks.reloadOffSession).not.toHaveBeenCalled();
   });
 

--- a/tests/integration/portal.test.ts
+++ b/tests/integration/portal.test.ts
@@ -3,6 +3,7 @@ import request from "supertest";
 import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
 import { cleanTestData, insertTestAccount, closeDb } from "../helpers/test-db.js";
 import { setupStripeMocks } from "../helpers/mock-stripe.js";
+import * as runsClient from "../../src/lib/runs-client.js";
 
 describe("POST /v1/portal-sessions", () => {
   const app = createTestApp();
@@ -12,6 +13,16 @@ describe("POST /v1/portal-sessions", () => {
   beforeEach(async () => {
     vi.restoreAllMocks();
     ssMocks = setupStripeMocks();
+    // The route now settles any outstanding balance before opening a session, so
+    // it composes a balance — these cases sit at 0 (paid 0, used 0) and take the
+    // "nothing owed" branch, which is the pre-settlement behaviour verbatim.
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(
+      async (org: string) => ({
+        org_id: org,
+        spent_cents: "0.0000000000",
+        as_of: "2026-01-31T00:00:00.000Z",
+      })
+    );
     await cleanTestData();
   });
 

--- a/tests/integration/unpaid-debt.test.ts
+++ b/tests/integration/unpaid-debt.test.ts
@@ -1,0 +1,283 @@
+/**
+ * An unpaid debt we cannot collect is VISIBLE, never silently skipped.
+ *
+ * Before this, an org with a negative balance and no chargeable card was counted
+ * `skipped` by the month-end sweep and disappeared: no email, no staff signal,
+ * campaigns still running and the debt still growing. These cases pin the three
+ * guarantees that are cheap to break — it is never `skipped`, the customer and
+ * staff are told exactly ONCE per episode, and the flag clears when a card comes
+ * back so the org leaves the staff surface (and a LATER loss notifies afresh).
+ *
+ * Own file rather than a describe appended to month-end-sweep.test.ts: that one
+ * closes the shared postgres.js connection in afterAll (see CLAUDE.md).
+ */
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import { createTestApp, getAuthHeaders } from "../helpers/test-app.js";
+import {
+  cleanTestData,
+  closeDb,
+  insertTestAccount,
+  listEpisodes,
+} from "../helpers/test-db.js";
+import { setupStripeMocks, customerWithEmail } from "../helpers/mock-stripe.js";
+import * as runsClient from "../../src/lib/runs-client.js";
+import * as emailClient from "../../src/lib/email-client.js";
+import { runMonthEndSweep, SWEEP_HOUR_UTC } from "../../src/lib/month-end-sweep.js";
+import {
+  flagUncollectableDebt,
+  runUnpaidDebtScan,
+  UNPAID_DEBT_CARD_REQUIRED_EVENT,
+  UNPAID_DEBT_STAFF_EVENT,
+} from "../../src/lib/unpaid-debt.js";
+
+const app = createTestApp();
+const orgId = "00000000-0000-0000-0000-0000000000e1";
+const billingEmail = "founder@acme.test";
+const LAST_DAY = new Date(Date.UTC(2026, 0, 31, SWEEP_HOUR_UTC, 0, 0));
+
+function eventsSent(mock: ReturnType<typeof vi.fn>): string[] {
+  return mock.mock.calls.map((c) => (c[0] as { eventType: string }).eventType);
+}
+
+describe("unpaid debt (negative balance, no chargeable card)", () => {
+  let ssMocks: ReturnType<typeof setupStripeMocks>;
+  let sendEmail: ReturnType<typeof vi.fn>;
+  let usageCents: string;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    ssMocks = setupStripeMocks();
+    ssMocks.fetchOrgCustomer.mockResolvedValue(customerWithEmail(billingEmail));
+    await cleanTestData();
+
+    usageCents = "0.0000000000";
+    vi.spyOn(runsClient, "fetchRunsOrgUsageTotal").mockImplementation(
+      async (org: string) => ({
+        org_id: org,
+        spent_cents: usageCents,
+        as_of: "2026-01-31T00:00:00.000Z",
+      })
+    );
+    // Every send hangs off a REAL platform run — a minted uuid is silently
+    // dropped by transactional-email-service (see CLAUDE.md).
+    vi.spyOn(runsClient, "createPlatformRun").mockResolvedValue(
+      "99999999-9999-4999-8999-999999999999"
+    );
+    vi.spyOn(runsClient, "completePlatformRun").mockResolvedValue(undefined);
+    sendEmail = vi.fn();
+    vi.spyOn(emailClient, "sendEmail").mockImplementation(sendEmail);
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  /** −$50 with no card the acquirer will charge. */
+  function owingFiftyWithNoCard() {
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("1000.0000000000");
+    usageCents = "6000.0000000000";
+    ssMocks.hasChargeablePmForOrg.mockResolvedValue(false);
+  }
+
+  it("AC4: the month-end sweep flags the debt instead of counting it `skipped`", async () => {
+    await insertTestAccount({
+      orgId,
+      topupAmountCents: 5000,
+      topupThresholdCents: 5000,
+    });
+    owingFiftyWithNoCard();
+
+    const result = await runMonthEndSweep(LAST_DAY);
+
+    expect(result.eligible).toBe(1);
+    expect(result.unpaidDebt).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.charged).toBe(0);
+
+    const [episode] = await listEpisodes(orgId);
+    expect(episode).toBeDefined();
+    expect(episode.cardRequiredNotifiedAt).not.toBeNull();
+    expect(episode.uncollectableDebtCents).toBe("5000.0000000000");
+
+    // The customer is told a card is required, with the amount; staff are told
+    // there is money we cannot collect.
+    expect(eventsSent(sendEmail).sort()).toEqual(
+      [UNPAID_DEBT_CARD_REQUIRED_EVENT, UNPAID_DEBT_STAFF_EVENT].sort()
+    );
+    const customerSend = sendEmail.mock.calls.find(
+      (c) => (c[0] as { eventType: string }).eventType === UNPAID_DEBT_CARD_REQUIRED_EVENT
+    )![0] as { recipientEmail?: string; metadata: Record<string, string> };
+    expect(customerSend.recipientEmail).toBe(billingEmail);
+    expect(customerSend.metadata.amountOwed).toBe("$50.00");
+  });
+
+  it("AC4b: a second tick refreshes the amount and re-emails NOBODY", async () => {
+    await insertTestAccount({
+      orgId,
+      topupAmountCents: 5000,
+      topupThresholdCents: 5000,
+    });
+    owingFiftyWithNoCard();
+
+    await runMonthEndSweep(LAST_DAY);
+    sendEmail.mockClear();
+
+    // The debt grew between ticks: the amount tracks it, the notification does not repeat.
+    usageCents = "7000.0000000000";
+    const second = await runMonthEndSweep(LAST_DAY);
+
+    expect(second.unpaidDebt).toBe(1);
+    expect(second.skipped).toBe(0);
+    expect(sendEmail).not.toHaveBeenCalled();
+    const [episode] = await listEpisodes(orgId);
+    expect(episode.uncollectableDebtCents).toBe("6000.0000000000");
+  });
+
+  it("an org that owes NOTHING and has no card is still an ordinary skip", async () => {
+    await insertTestAccount({
+      orgId,
+      topupAmountCents: 5000,
+      topupThresholdCents: 5000,
+    });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("1000.0000000000");
+    ssMocks.hasChargeablePmForOrg.mockResolvedValue(false);
+
+    const result = await runMonthEndSweep(LAST_DAY);
+
+    expect(result.skipped).toBe(1);
+    expect(result.unpaidDebt).toBe(0);
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(await listEpisodes(orgId)).toHaveLength(0);
+  });
+
+  it("a debt on an off_session-blocked card is counted, not skipped, and not re-notified here", async () => {
+    // The existing `-blocked` dunning copy already nudges these customers to
+    // recharge manually — a second mechanism must not mail them again.
+    await insertTestAccount({
+      orgId,
+      topupAmountCents: 5000,
+      topupThresholdCents: 5000,
+    });
+    ssMocks.sumSucceededTopupsForOrg.mockResolvedValue("1000.0000000000");
+    usageCents = "6000.0000000000";
+    ssMocks.getOrgCardCountryByOrg.mockResolvedValue("IN");
+
+    const result = await runMonthEndSweep(LAST_DAY);
+
+    expect(result.blockedCountryDebt).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.unpaidDebt).toBe(0);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("POST /internal/payment-methods/lost flags the debt the moment the card goes", async () => {
+    await insertTestAccount({ orgId });
+    owingFiftyWithNoCard();
+
+    const res = await request(app)
+      .post("/internal/payment-methods/lost")
+      .set(getAuthHeaders(orgId))
+      .send({ orgId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.state).toBe("flagged");
+    expect(res.body.owed_cents).toBe("5000.0000000000");
+    expect(eventsSent(sendEmail)).toHaveLength(2);
+
+    // Redelivered webhook: same state re-read, nothing sent.
+    sendEmail.mockClear();
+    const again = await request(app)
+      .post("/internal/payment-methods/lost")
+      .set(getAuthHeaders(orgId))
+      .send({ orgId });
+    expect(again.body.state).toBe("already_flagged");
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("POST /internal/payment-methods/lost is a no-op for an org that owes nothing", async () => {
+    await insertTestAccount({ orgId });
+    ssMocks.hasChargeablePmForOrg.mockResolvedValue(false);
+
+    const res = await request(app)
+      .post("/internal/payment-methods/lost")
+      .set(getAuthHeaders(orgId))
+      .send({ orgId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.state).toBe("no_debt");
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(await listEpisodes(orgId)).toHaveLength(0);
+  });
+
+  it("rejects a non-UUID orgId rather than guessing", async () => {
+    const res = await request(app)
+      .post("/internal/payment-methods/lost")
+      .set(getAuthHeaders(orgId))
+      .send({ orgId: "not-a-uuid" });
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /internal/unpaid-debts is the staff surface, and an org leaves it when a card returns", async () => {
+    await insertTestAccount({ orgId });
+    owingFiftyWithNoCard();
+    await flagUncollectableDebt({ orgId });
+
+    const listed = await request(app)
+      .get("/internal/unpaid-debts")
+      .set(getAuthHeaders(orgId));
+    expect(listed.status).toBe(200);
+    expect(listed.body.unpaid_debts).toHaveLength(1);
+    expect(listed.body.unpaid_debts[0].org_id).toBe(orgId);
+    expect(listed.body.unpaid_debts[0].owed_cents).toBe("5000.0000000000");
+
+    // AC: adding a card back makes the debt collectable again. The EPISODE stays
+    // open (recovery is still keyed on credited rising, the existing path) but
+    // the uncollectable flag goes, so staff stop seeing it and a LATER card loss
+    // notifies afresh.
+    ssMocks.hasChargeablePmForOrg.mockResolvedValue(true);
+    const outcome = await flagUncollectableDebt({ orgId });
+    expect(outcome.state).toBe("collectable");
+
+    const after = await request(app)
+      .get("/internal/unpaid-debts")
+      .set(getAuthHeaders(orgId));
+    expect(after.body.unpaid_debts).toHaveLength(0);
+    const [episode] = await listEpisodes(orgId);
+    expect(episode.recoveredAt).toBeNull();
+    expect(episode.cardRequiredNotifiedAt).toBeNull();
+
+    // Losing the card again tells the customer again — one notification per loss.
+    sendEmail.mockClear();
+    ssMocks.hasChargeablePmForOrg.mockResolvedValue(false);
+    const relost = await flagUncollectableDebt({ orgId });
+    expect(relost.state).toBe("flagged");
+    expect(eventsSent(sendEmail)).toHaveLength(2);
+  });
+
+  it("the hourly scan catches an org that lost its card with nobody calling us", async () => {
+    await insertTestAccount({ orgId });
+    owingFiftyWithNoCard();
+
+    const result = await runUnpaidDebtScan();
+
+    expect(result.scanned).toBe(1);
+    expect(result.flagged).toBe(1);
+    const [episode] = await listEpisodes(orgId);
+    expect(episode.cardRequiredNotifiedAt).not.toBeNull();
+  });
+
+  it("a platform run we cannot open DEFERS the notification rather than burning it", async () => {
+    await insertTestAccount({ orgId });
+    owingFiftyWithNoCard();
+    vi.spyOn(runsClient, "createPlatformRun").mockResolvedValue(null);
+
+    const outcome = await flagUncollectableDebt({ orgId });
+
+    expect(outcome.state).toBe("deferred");
+    expect(sendEmail).not.toHaveBeenCalled();
+    const [episode] = await listEpisodes(orgId);
+    expect(episode.cardRequiredNotifiedAt).toBeNull();
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -123,6 +123,9 @@ beforeAll(async () => {
   `;
   // Stale-DB path: add the migration-0020 column if an older local DB predates it.
   await sql`ALTER TABLE "credit_depletion_episodes" ADD COLUMN IF NOT EXISTS "credited_cents_at_open" numeric(16,10)`;
+  // Migration 0041 — unpaid-debt (no chargeable card) notification claim + amount.
+  await sql`ALTER TABLE "credit_depletion_episodes" ADD COLUMN IF NOT EXISTS "card_required_notified_at" timestamp with time zone`;
+  await sql`ALTER TABLE "credit_depletion_episodes" ADD COLUMN IF NOT EXISTS "uncollectable_debt_cents" numeric(16,10)`;
   await sql`CREATE UNIQUE INDEX IF NOT EXISTS "idx_one_open_episode_per_org" ON "credit_depletion_episodes" ("org_id") WHERE "recovered_at" IS NULL`;
   await sql`CREATE INDEX IF NOT EXISTS "idx_credit_depletion_open" ON "credit_depletion_episodes" ("recovered_at")`;
 

--- a/tests/unit/card-change-settlement.test.ts
+++ b/tests/unit/card-change-settlement.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  cardChangeSettleIdempotencyKey,
+  dayBucket,
+} from "../../src/lib/card-change-settlement.js";
+import { formatOwed } from "../../src/lib/unpaid-debt.js";
+
+describe("card-change settle idempotency key", () => {
+  const orgId = "00000000-0000-0000-0000-0000000000d1";
+
+  it("is stable for the same org, day and amount, so a retry collapses", () => {
+    const a = cardChangeSettleIdempotencyKey(orgId, "2026-01-31", 5000);
+    const b = cardChangeSettleIdempotencyKey(orgId, "2026-01-31", 5000);
+    expect(a).toBe(b);
+  });
+
+  it("carries the AMOUNT, so a different settle is never blocked by an old key", () => {
+    // The acquirer rejects a replayed key whose parameters changed. An
+    // amount-independent key makes a second, corrected charge impossible and
+    // replays the first attempt's charge — the prod failure the month-end sweep
+    // documents at length.
+    expect(cardChangeSettleIdempotencyKey(orgId, "2026-01-31", 5000)).not.toBe(
+      cardChangeSettleIdempotencyKey(orgId, "2026-01-31", 7000)
+    );
+  });
+
+  it("carries the DAY, so the same amount can legitimately be settled again later", () => {
+    expect(cardChangeSettleIdempotencyKey(orgId, "2026-01-31", 5000)).not.toBe(
+      cardChangeSettleIdempotencyKey(orgId, "2026-02-07", 5000)
+    );
+  });
+
+  it("scopes to the org", () => {
+    expect(cardChangeSettleIdempotencyKey(orgId, "2026-01-31", 5000)).not.toBe(
+      cardChangeSettleIdempotencyKey(
+        "00000000-0000-0000-0000-0000000000d2",
+        "2026-01-31",
+        5000
+      )
+    );
+  });
+
+  it("buckets by UTC day", () => {
+    expect(dayBucket(new Date(Date.UTC(2026, 0, 31, 23, 59, 59)))).toBe("2026-01-31");
+    expect(dayBucket(new Date(Date.UTC(2026, 1, 1, 0, 0, 0)))).toBe("2026-02-01");
+  });
+});
+
+describe("formatOwed", () => {
+  it("states whole cents in dollars, never a ten-decimal internal figure", () => {
+    expect(formatOwed("5000.0000000000")).toBe("$50.00");
+    expect(formatOwed("1.0000000000")).toBe("$0.01");
+    expect(formatOwed("0")).toBe("$0.00");
+  });
+});

--- a/tests/unit/instrument-templates.test.ts
+++ b/tests/unit/instrument-templates.test.ts
@@ -11,6 +11,10 @@ import {
   REFERRAL_REWARD_OPENED_EVENT,
   REFERRAL_CREDITS_GRANTED_EVENT,
 } from "../../src/lib/referral-notifications.js";
+import {
+  UNPAID_DEBT_CARD_REQUIRED_EVENT,
+  UNPAID_DEBT_STAFF_EVENT,
+} from "../../src/lib/unpaid-debt.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -83,6 +87,8 @@ describe("boot-time email template registration", () => {
       BRAND_DAILY_BUDGET_CHANGED_EVENT,
       REFERRAL_REWARD_OPENED_EVENT,
       REFERRAL_CREDITS_GRANTED_EVENT,
+      UNPAID_DEBT_CARD_REQUIRED_EVENT,
+      UNPAID_DEBT_STAFF_EVENT,
     ]);
     expect(names).toEqual(REGISTERED_TEMPLATE_NAMES);
   });


### PR DESCRIPTION
## Why

A customer who owes us money on the postpaid credit line could leave us in a state where the debt exists and we have no card to collect it. Industry practice (Google Ads, Meta, AWS): an outstanding balance is settled **before** the payment method may change, losing the payment method suspends spend immediately, and an uncollectable debt is visible rather than silently skipped.

Two holes, one rule.

## 1. A card-management session settles the debt first

`settleOutstandingBeforeCardChange(orgId)` runs at the top of **both** `POST /v1/portal-sessions` and `POST /v1/accounts/card_setup`. They serve one descriptor, so they must gate identically or the gate is one URL away from being bypassed.

| situation | what happens |
|---|---|
| balance ≥ 0 | session opens exactly as before, nothing charged |
| negative, chargeable card | charge EXACTLY the outstanding amount; success opens the session |
| charge declines / backoff / stripe-service errors | **402**, no session, body states what is owed |
| negative, NO card | session OPENS — adding a card is the only way out of the debt |
| negative, off_session-blocked card (India) | session OPENS — no off_session settle is possible on that card at all |
| negative, under $0.50 | session OPENS — Stripe rejects it; rolls into the month-end sweep |

- The amount is `computeSettleCharge`, **imported from the month-end sweep**, never restated: two surfaces computing "settle to zero" separately is how they start disagreeing. Not a tier multiple, for the same reason the sweep does not use one.
- Idempotency keys on `(org, UTC day, amount)`. The amount is in the key because an acquirer replays a key whose parameters changed; the day is in it so a double-click collapses onto one charge while a legitimate settle of the same amount next week still goes through.
- Goes through the existing `coalesceReload`, so a card that just declined is refused by the backoff rather than hammered. That reaches the customer as `reason: "charge_backoff"`.

### What the dashboard receives on a refusal (402)

```json
{
  "error": "Settle your outstanding balance before changing your payment method.",
  "code": "outstanding_balance_unsettled",
  "owed_cents": "5000",
  "balance_cents": "-5000.0000000000",
  "reason": "charge_failed"
}
```

`code` is stable and is the thing to key on. `reason` is `charge_failed` | `charge_backoff`. It has to be distinguishable from 400 (bad body), 404 (no account) and 502 (stripe-service down), because it is the one failure of these routes the customer can act on.

## 2. An uncollectable debt is visible, never `skipped`

An org with a negative balance and no chargeable card was counted `skipped` by the month-end sweep and then disappeared: no email, no staff signal, campaigns still running and the debt still growing.

Two things are deliberately **reused rather than rebuilt**:

- **Campaigns stop on their own.** `resolvePostpaidTier` grants a negative credit-line floor only to an org that can actually be reloaded, so losing the card drops the floor to `"0"` and both the authorize gate and the read-only affordability pre-flight read the org as depleted at any balance ≤ 0. Nothing here stops anything.
- **The state is the existing depletion episode.** No new table, no second lifecycle. Recovery stays keyed on `credited` rising, and adding a card back restores the credit line, which re-arms auto-reload and the sweep — that is the whole of "adding a card resumes through the existing dunning recovery path".

What is new is the telling: `credit-debt-card-required` to the customer (with the amount owed, and "add a card" rather than the unreachable "turn on auto-topup" the `credit-depleted*` copy uses) and `unpaid_debt_uncollectable` to staff. Both claimed at most once per episode by `card_required_notified_at`; both hang off a real platform run, and a run we cannot open **defers** the notification without claiming the marker.

Three entry points, one function (`flagUncollectableDebt`): the sweep, the new `POST /internal/payment-methods/lost`, and an hourly backstop scan on the existing dunning scheduler which also refreshes the amount as the debt grows and clears the flag when a card returns.

A debt on an off_session-**blocked** card is counted (`blockedCountryDebt`) and logged rather than flagged: the existing `-blocked` dunning copy already nudges those customers to recharge manually, and a second mechanism must not mail them twice. Still never `skipped`.

## New endpoints

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/internal/payment-methods/lost` | Body `{orgId}` → `{orgId, state, owed_cents}`. No-op when the org owes nothing or still has a card, so a false alarm is free. Idempotent per episode. |
| `GET` | `/internal/unpaid-debts` | Staff read → `{unpaid_debts:[{org_id, owed_cents, flagged_at, episode_started_at}]}`. A plain DB read (the amount is frozen on the episode and refreshed hourly), not a per-org fan-out. |

## Migration 0041

Two nullable columns on `credit_depletion_episodes`: `card_required_notified_at` (the notification claim) and `uncollectable_debt_cents` (the amount owed, so the staff read costs one query). Both NULL on every existing row, and NULL is a permanent first-class value, not a placeholder. Idempotent, reverse SQL in the migration header.

## What I need from stripe-service (orchestrator: please spawn)

`POST /internal/payment-methods/lost` is the immediate signal and is **live-but-uncalled** until stripe-service calls it. Nothing breaks without it: the hourly scan already catches the same state within an hour, so this is a latency improvement, not a correctness gate.

- On `payment_method.detached`, once stripe-service has determined the org has **no chargeable method left** (card or link, the same question `hasChargeablePmForOrg` answers), `POST {BILLING_SERVICE_URL}/internal/payment-methods/lost` with `x-api-key: $BILLING_SERVICE_API_KEY` and body `{"orgId": "<internal org uuid>"}`.
- Fire it unconditionally on that condition — billing decides whether it means anything. Redelivery is safe.

Also for transactional-email-service: **`unpaid_debt_uncollectable` must be added to `ADMIN_NOTIFICATION_EVENTS`** so it routes to the staff list. Until then the staff copy of the notification is dropped; the customer email is unaffected (it carries an explicit `recipientEmail`).

## Env vars

None new. Uses `TRANSACTIONAL_EMAIL_SERVICE_*` and `RUNS_SERVICE_*`, both already configured.

## Tests

767 green (`vitest run`), `tsc --noEmit` clean, `openapi.json` regenerated.

- `tests/integration/card-change-settlement.test.ts` — the $50 settle, the stable retry key, the 402 on a declining card and on a settled failure, the untouched positive-balance path, both carve-outs, the sub-minimum case, and `card_setup` gating identically.
- `tests/integration/unpaid-debt.test.ts` — the sweep counting `unpaidDebt` instead of `skipped`, a second tick refreshing the amount and emailing nobody, the blocked-country counter, the internal endpoint flagging and no-opping, the staff read, the flag clearing when a card returns and re-firing on a later loss, the hourly scan, and the deferred notification when no platform run can be opened.
- `tests/unit/card-change-settlement.test.ts` — idempotency-key scoping and the owed-amount formatting.

Two existing `month-end-sweep.test.ts` assertions moved from `skipped: 1` to `unpaidDebt: 1` / `blockedCountryDebt: 1`. That is the behaviour change, not collateral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
